### PR TITLE
Makefile: find preCICE using pkg-config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,46 +1,47 @@
-# Specify the locations of: the original CCX source, SPOOLES and ARPACK
+# See our wiki for getting the CalculiX dependencies:
+# https://github.com/precice/calculix-adapter/wiki/Installation-instructions-for-CalculiX
+# Set the following variables before building:
+# Path to original CalculiX source (e.g. $(HOME)/ccx_2.15/src )
 CCX             = $(HOME)/PathTo/CalculiX/ccx_2.15/src
+# Path to SPOOLES main directory (e.g. $(HOME)/SPOOLES.2.2 )
 SPOOLES         = $(HOME)/PathTo/SPOOLES
+# Path to ARPACK main directory (e.g. $(HOME)/ARPACK )
 ARPACK          = $(HOME)/PathTo/ARPACK
-PRECICE_ROOT    = $(HOME)/PathTo/preCICE
+# Path to yaml-cpp prefix (e.g. $(HOME)/yaml-cpp, should contain "include" and "build")
 YAML            = $(HOME)/PathTo/yaml-cpp
 
+# Get the CFLAGS and LIBS from pkg-config (preCICE version >= 1.4.0).
+# If pkg-config cannot find the libprecice.pc meta-file, you may need to set the
+# path where this is stored into PKG_CONFIG_PATH when building the adapter.
+PKGCONF_CFLAGS  = $(shell pkg-config --cflags libprecice)
+PKGCONF_LIBS    = $(shell pkg-config --libs libprecice)
+
 # Specify where to store the generated .o files
-OBJDIR 		= bin
+OBJDIR = bin
 
 # Includes and libs
 INCLUDES = \
-	-I./ \
-	-I./adapter \
-	-I$(CCX) \
-	-I$(SPOOLES) \
-	-I$(PRECICE_ROOT)/src \
-    	-I$(ARPACK) \
-	-I$(YAML)/include
+    -I./ \
+    -I./adapter \
+    -I$(CCX) \
+    -I$(SPOOLES) \
+    $(PKGCONF_CFLAGS) \
+    -I$(ARPACK) \
+    -I$(YAML)/include
 
 LIBS = \
-	$(SPOOLES)/spooles.a \
-    	-L$(PRECICE_ROOT)/build/last -lprecice \
-    	-lboost_log \
-    	-lboost_log_setup \
-    	-lboost_thread \
-    	-lboost_system \
-    	-lboost_filesystem \
-	-lboost_program_options \
-    	-lpython2.7 \
-    	-lstdc++ \
-	-L$(PETSC_DIR)/$(PETSC_ARCH)/lib -lpetsc \
-    	-lmpi_cxx \
-    	-L$(YAML)/build -lyaml-cpp \
-        -lxml2
+    $(SPOOLES)/spooles.a \
+    $(PKGCONF_LIBS) \
+    -lstdc++ \
+    -L$(YAML)/build -lyaml-cpp \
 
 # OS-specific options
 UNAME_S := $(shell uname -s)
 ifeq ($(UNAME_S),Darwin)
-	LIBS += $(ARPACK)/libarpack_MAC.a
+    LIBS += $(ARPACK)/libarpack_MAC.a
 else
-	LIBS += $(ARPACK)/libarpack_INTEL.a
-    	LIBS += -lpthread -lm -lc
+    LIBS += $(ARPACK)/libarpack_INTEL.a
+    LIBS += -lpthread -lm -lc
 endif
 
 # Compilers and flags
@@ -73,20 +74,20 @@ SCCXF += getflux.f getkdeltatemp.f
 
 # Source files in this folder and in the adapter directory
 $(OBJDIR)/%.o : %.c
-	$(CC) $(CFLAGS) -c $< -o $@
+    $(CC) $(CFLAGS) -c $< -o $@
 $(OBJDIR)/%.o : %.f
-	$(FC) $(FFLAGS) -c $< -o $@
+    $(FC) $(FFLAGS) -c $< -o $@
 $(OBJDIR)/%.o : adapter/%.c
-	$(CC) $(CFLAGS) -c $< -o $@
+    $(CC) $(CFLAGS) -c $< -o $@
 $(OBJDIR)/%.o : adapter/%.cpp
-	g++ -std=c++11 -I$(YAML)/include -c $< -o $@ $(LIBS)
-    	#$(CC) $(CFLAGS) $(INCLUDES) -c $< -o $@ $(LIBS)
+    g++ -std=c++11 -I$(YAML)/include -c $< -o $@ $(LIBS)
+        #$(CC) $(CFLAGS) $(INCLUDES) -c $< -o $@ $(LIBS)
 
 # Source files in the $(CCX) folder
 $(OBJDIR)/%.o : $(CCX)/%.c
-	$(CC) $(CFLAGS) -c $< -o $@
+    $(CC) $(CFLAGS) -c $< -o $@
 $(OBJDIR)/%.o : $(CCX)/%.f
-	$(FC) $(FFLAGS) -c $< -o $@
+    $(FC) $(FFLAGS) -c $< -o $@
 
 # Generate list of object files from the source files, prepend $(OBJDIR)
 OCCXF = $(SCCXF:%.f=$(OBJDIR)/%.o)
@@ -97,13 +98,13 @@ OCCXC += $(OBJDIR)/ConfigReader.o
 
 
 $(OBJDIR)/ccx_preCICE: $(OBJDIR) $(OCCXMAIN) $(OBJDIR)/ccx_2.15.a
-	$(FC) -fopenmp -Wall -O3 -o $@ $(OCCXMAIN) $(OBJDIR)/ccx_2.15.a $(LIBS)
+    $(FC) -fopenmp -Wall -O3 -o $@ $(OCCXMAIN) $(OBJDIR)/ccx_2.15.a $(LIBS)
 
 $(OBJDIR)/ccx_2.15.a: $(OCCXF) $(OCCXC)
-	ar vr $@ $?
+    ar vr $@ $?
 
 $(OBJDIR):
-	mkdir -p $(OBJDIR)
+    mkdir -p $(OBJDIR)
 
 clean:
-	rm -f $(OBJDIR)/*.o $(OBJDIR)/ccx_2.15.a $(OBJDIR)/ccx_preCICE
+    rm -f $(OBJDIR)/*.o $(OBJDIR)/ccx_2.15.a $(OBJDIR)/ccx_preCICE

--- a/Makefile
+++ b/Makefile
@@ -21,27 +21,27 @@ OBJDIR = bin
 
 # Includes and libs
 INCLUDES = \
-    -I./ \
-    -I./adapter \
-    -I$(CCX) \
-    -I$(SPOOLES) \
-    $(PKGCONF_CFLAGS) \
-    -I$(ARPACK) \
-    -I$(YAML)/include
+	-I./ \
+	-I./adapter \
+	-I$(CCX) \
+	-I$(SPOOLES) \
+	$(PKGCONF_CFLAGS) \
+	-I$(ARPACK) \
+	-I$(YAML)/include
 
 LIBS = \
-    $(SPOOLES)/spooles.a \
-    $(PKGCONF_LIBS) \
-    -lstdc++ \
-    -L$(YAML)/build -lyaml-cpp \
+	$(SPOOLES)/spooles.a \
+	$(PKGCONF_LIBS) \
+	-lstdc++ \
+	-L$(YAML)/build -lyaml-cpp \
 
 # OS-specific options
 UNAME_S := $(shell uname -s)
 ifeq ($(UNAME_S),Darwin)
-    LIBS += $(ARPACK)/libarpack_MAC.a
+	LIBS += $(ARPACK)/libarpack_MAC.a
 else
-    LIBS += $(ARPACK)/libarpack_INTEL.a
-    LIBS += -lpthread -lm -lc
+	LIBS += $(ARPACK)/libarpack_INTEL.a
+	LIBS += -lpthread -lm -lc
 endif
 
 # Compilers and flags
@@ -52,9 +52,9 @@ CFLAGS = -Wall -O3 -fopenmp $(INCLUDES) -DARCH="Linux" -DSPOOLES -DARPACK -DMATR
 
 # OS-specific options
 ifeq ($(UNAME_S),Darwin)
-        CC = /usr/local/bin/gcc
+	CC = /usr/local/bin/gcc
 else
-        CC = mpicc
+	CC = mpicc
 endif
 
 FFLAGS = -Wall -O3 -fopenmp $(INCLUDES)
@@ -74,20 +74,20 @@ SCCXF += getflux.f getkdeltatemp.f
 
 # Source files in this folder and in the adapter directory
 $(OBJDIR)/%.o : %.c
-    $(CC) $(CFLAGS) -c $< -o $@
+	$(CC) $(CFLAGS) -c $< -o $@
 $(OBJDIR)/%.o : %.f
-    $(FC) $(FFLAGS) -c $< -o $@
+	$(FC) $(FFLAGS) -c $< -o $@
 $(OBJDIR)/%.o : adapter/%.c
-    $(CC) $(CFLAGS) -c $< -o $@
+	$(CC) $(CFLAGS) -c $< -o $@
 $(OBJDIR)/%.o : adapter/%.cpp
-    g++ -std=c++11 -I$(YAML)/include -c $< -o $@ $(LIBS)
-        #$(CC) $(CFLAGS) $(INCLUDES) -c $< -o $@ $(LIBS)
+	g++ -std=c++11 -I$(YAML)/include -c $< -o $@ $(LIBS)
+	#$(CC) $(CFLAGS) $(INCLUDES) -c $< -o $@ $(LIBS)
 
 # Source files in the $(CCX) folder
 $(OBJDIR)/%.o : $(CCX)/%.c
-    $(CC) $(CFLAGS) -c $< -o $@
+	$(CC) $(CFLAGS) -c $< -o $@
 $(OBJDIR)/%.o : $(CCX)/%.f
-    $(FC) $(FFLAGS) -c $< -o $@
+	$(FC) $(FFLAGS) -c $< -o $@
 
 # Generate list of object files from the source files, prepend $(OBJDIR)
 OCCXF = $(SCCXF:%.f=$(OBJDIR)/%.o)
@@ -98,13 +98,13 @@ OCCXC += $(OBJDIR)/ConfigReader.o
 
 
 $(OBJDIR)/ccx_preCICE: $(OBJDIR) $(OCCXMAIN) $(OBJDIR)/ccx_2.15.a
-    $(FC) -fopenmp -Wall -O3 -o $@ $(OCCXMAIN) $(OBJDIR)/ccx_2.15.a $(LIBS)
+	$(FC) -fopenmp -Wall -O3 -o $@ $(OCCXMAIN) $(OBJDIR)/ccx_2.15.a $(LIBS)
 
 $(OBJDIR)/ccx_2.15.a: $(OCCXF) $(OCCXC)
-    ar vr $@ $?
+	ar vr $@ $?
 
 $(OBJDIR):
-    mkdir -p $(OBJDIR)
+	mkdir -p $(OBJDIR)
 
 clean:
-    rm -f $(OBJDIR)/*.o $(OBJDIR)/ccx_2.15.a $(OBJDIR)/ccx_preCICE
+	rm -f $(OBJDIR)/*.o $(OBJDIR)/ccx_2.15.a $(OBJDIR)/ccx_preCICE

--- a/README.md
+++ b/README.md
@@ -30,7 +30,16 @@ This adapter was developed for CalculiX version 2.15. Other versions may be comp
 Before installing the adapter, CalculiX itself must be downloaded from http://www.dhondt.de. CalculiX consists of the solver, called "CCX" and a pre- and postprocessing software with graphical user interface "CGX". The installation procedure of CalculiX is described in the *README* files of the respective packages. Moreover, SPOOLES and ARPACK need to be installed for CalculiX. The procedure is also explained in the *README* files of CalculiX. You can also find detailed instructions for installing SPOOLES and ARPACK and coupled CalculiX on the [wiki page](https://github.com/precice/calculix-adapter/wiki/Installation-instructions-for-CalculiX)
 
 ### preCICE
-It is assumed that preCICE has been installed successfully beforehand. Concerning installation instructions for preCICE, have a look at the preCICE-wiki pages on GitHub: https://github.com/precice/precice/wiki/Building.
+It is assumed that preCICE has been installed successfully beforehand. Concerning installation instructions for preCICE, have a look at the preCICE-wiki pages on GitHub: https://github.com/precice/precice/wiki/Get-preCICE.
+
+#### Notes on preCICE versions
+
+1. This adapter expects the preCICE C bindings in `[prefix]/include/precice/SolverInterfaceC.h` and gets this path from pkg-config. In other words, this assumes that preCICE (at least v1.4.0) has been built & installed with CMake (e.g. using a Debian package). In case you want to keep using preCICE built with SCons, see the changes invoked by [Pull Request #14](https://github.com/precice/calculix-adapter/pull/14).
+2. Starting from preCICE v1.2.0, the name (and the respective paths) of the language "adapters" have changed to language "bindings". This affects the line `#include "precice/bindings/c/SolverInterfaceC.h"` in `calculix-adapter/adapter/PreciceInterface.c`. To compile with older preCICE versions, change `bindings` to `adapters`.
+
+## Running Simulations
+### Layout of the YAML Configuration File
+The layout of the YAML configuration file, which should be named *config.yml* (default name), is explained by means of an example for an FSI simulation:
 
 ### Adapter
 The adapter makes use of an additional input configuration file in YAML format. Therefore, the YAML parser "yaml-cpp" needs to be installed. It can either be [built from the source code](https://github.com/jbeder/yaml-cpp) (see the included README file), or installed from the OS repositories. **Note:** If you use Boost 1.67 or newer, then you also need to install yaml-cpp 0.6 or newer.
@@ -48,12 +57,6 @@ Type "make" for building and "make clean" before a rebuild from the top-level di
 You may want to add this to your `$PATH`, or move it to a searchable `bin` directory.
 
 By default, the Makefile uses the `mpifort` compiler wrapper. You may need to change this to `mpif90` or to whatever your system uses.
-
-**Note:** Starting from preCICE v1.2, the name (and the respective paths) of the language "adapters" have changed to language "bindings". This affects the line `#include "precice/bindings/c/SolverInterfaceC.h"` in `calculix-adapter/adapter/PreciceInterface.c`. To compile with older preCICE versions, change `bindings` to `adapters`.
-
-## Running Simulations
-### Layout of the YAML Configuration File
-The layout of the YAML configuration file, which should be named *config.yml* (default name), is explained by means of an example for an FSI simulation:
 
 ```
 participants:

--- a/README.md
+++ b/README.md
@@ -36,11 +36,6 @@ It is assumed that preCICE has been installed successfully beforehand. Concernin
 
 1. This adapter expects the preCICE C bindings in `[prefix]/include/precice/SolverInterfaceC.h` and gets this path from pkg-config. In other words, this assumes that preCICE (at least v1.4.0) has been built & installed with CMake (e.g. using a Debian package). In case you want to keep using preCICE built with SCons, see the changes invoked by [Pull Request #14](https://github.com/precice/calculix-adapter/pull/14).
 2. Starting from preCICE v1.2.0, the name (and the respective paths) of the language "adapters" have changed to language "bindings". This affects the line `#include "precice/bindings/c/SolverInterfaceC.h"` in `calculix-adapter/adapter/PreciceInterface.c`. To compile with older preCICE versions, change `bindings` to `adapters`.
-
-## Running Simulations
-### Layout of the YAML Configuration File
-The layout of the YAML configuration file, which should be named *config.yml* (default name), is explained by means of an example for an FSI simulation:
-
 ### Adapter
 The adapter makes use of an additional input configuration file in YAML format. Therefore, the YAML parser "yaml-cpp" needs to be installed. It can either be [built from the source code](https://github.com/jbeder/yaml-cpp) (see the included README file), or installed from the OS repositories. **Note:** If you use Boost 1.67 or newer, then you also need to install yaml-cpp 0.6 or newer.
 
@@ -57,6 +52,10 @@ Type "make" for building and "make clean" before a rebuild from the top-level di
 You may want to add this to your `$PATH`, or move it to a searchable `bin` directory.
 
 By default, the Makefile uses the `mpifort` compiler wrapper. You may need to change this to `mpif90` or to whatever your system uses.
+
+## Running Simulations
+### Layout of the YAML Configuration File
+The layout of the YAML configuration file, which should be named *config.yml* (default name), is explained by means of an example for an FSI simulation:
 
 ```
 participants:

--- a/adapter/PreciceInterface.c
+++ b/adapter/PreciceInterface.c
@@ -10,7 +10,7 @@
 #include <stdlib.h>
 #include "PreciceInterface.h"
 #include "ConfigReader.h"
-#include "precice/bindings/c/SolverInterfaceC.h"
+#include "precice/SolverInterfaceC.h"
 
 void Precice_Setup( char * configFilename, char * participantName, SimulationData * sim )
 {


### PR DESCRIPTION
This is necessary for moving preCICE from SCons to CMake. Since the C bindings are expected in a different location than before, we decided to only support the new location, for simplicity.

This breaks the out-of-the-box compatibility with SCons and the user is referred to this commit in case she
wants to keep using preCICE build with SCons.

This PR also fixes indentation and mixed tabs/spaces issues.