### PR TITLE
Make velocity and position accessible

### DIFF
--- a/adapter/CCXHelpers.c
+++ b/adapter/CCXHelpers.c
@@ -136,6 +136,20 @@ void getNodeDisplacementDeltas( ITG * nodes, ITG numNodes, int dim, double * v, 
 	}
 }
 
+void getNodeVelocities( ITG * nodes, ITG numNodes, int dim, double * ve, int mt, double * velocities )
+{
+
+	// CalculiX variable mt = 4 : temperature rate + 3 velocities (depends on the type of analysis)
+	// where 0 index corresponds to temp rate; 1, 2, 3 indices correspond to the velocities, respectively
+	ITG i, j;
+
+	for( i = 0 ; i < numNodes ; i++ )
+	{
+		int nodeIdx = nodes[i] - 1; //The node Id starts with 1, not with 0, therefore, decrement is necessary
+		for( j = 0 ; j < dim ; j++ ) velocities[dim * i + j] = ve[nodeIdx * mt + j + 1];
+	}
+}
+
 /*
    int getNodesPerFace(char * lakon, int elementIdx) {
 

--- a/adapter/CCXHelpers.h
+++ b/adapter/CCXHelpers.h
@@ -36,8 +36,10 @@ enum xloadVariable { DFLUX, FILM_H, FILM_T };
  *  Forces - dynamics data to be read/written (by the Calculix adapter)
  *  Displacements - dynamics data to be read/written (by the Calculix adapter)
  *  DisplacementDeltas - FSI data to be written (by the Calculix adapter)
+ *  Velocities - FSI data to be written (by the Calculix adapter)
+ *  Positions - FSI data to be written (by the Calculix adapter)
  */
-enum CouplingDataType { TEMPERATURE, HEAT_FLUX, CONVECTION, FORCES, DISPLACEMENTS, DISPLACEMENTDELTAS };
+enum CouplingDataType { TEMPERATURE, HEAT_FLUX, CONVECTION, FORCES, DISPLACEMENTS, DISPLACEMENTDELTAS, VELOCITIES, POSITIONS };
 
 /**
  * @brief Returns node set name with internal CalculiX format
@@ -119,6 +121,17 @@ void getNodeForces( ITG * nodes, ITG numNodes, int dim, double * fn, ITG mt, dou
  * @param displacements: output array with the displacements in preCICE-conform order of the input nodes
  */
 void getNodeDisplacements( ITG * nodes, ITG numNodes, int dim, double * v, ITG mt, double * displacements );
+
+/**
+ * @brief getNodeVelocities
+ * @param nodes: input node IDs
+ * @param numNodes: number of input nodes
+ * @param dim: coupling dimension
+ * @param ve: CalculiX solution array containing the velocities
+ * @param mt: CalculiX variable describing the number of solution variables in the solution array v
+ * @param velocities: output array with the velocities in preCICE-conform order of the input nodes
+ */
+void getNodeVelocities( ITG * nodes, ITG numNodes, int dim, double * ve, ITG mt, double * velocities );
 
 /**
  * @brief getNodeDisplacementDeltas

--- a/adapter/PreciceInterface.c
+++ b/adapter/PreciceInterface.c
@@ -204,6 +204,16 @@ void Precice_ReadCouplingData( SimulationData * sim )
 					fflush( stdout );
 					exit( EXIT_FAILURE );
 					break;
+				case VELOCITIES:
+					printf( "Velocities cannot be used as read data\n" );
+					fflush( stdout );
+					exit( EXIT_FAILURE );
+					break;
+				case POSITIONS:
+					printf( "Positions cannot be used as read data.\n" );
+					fflush( stdout );
+					exit( EXIT_FAILURE );
+					break;
 				}
 			}
 		}
@@ -288,6 +298,14 @@ void Precice_WriteCouplingData( SimulationData * sim )
 				case DISPLACEMENTDELTAS:
 					getNodeDisplacementDeltas( interfaces[i]->nodeIDs, interfaces[i]->numNodes, interfaces[i]->dim, sim->vold, sim->coupling_init_v, sim->mt, interfaces[i]->nodeVectorData );
 					precicec_writeBlockVectorData( interfaces[i]->displacementDeltasDataID, interfaces[i]->numNodes, interfaces[i]->preciceNodeIDs, interfaces[i]->nodeVectorData );
+					break;
+				case VELOCITIES:
+					getNodeVelocities( interfaces[i]->nodeIDs, interfaces[i]->numNodes, interfaces[i]->dim, sim->veold, sim->mt, interfaces[i]->nodeVectorData );
+					precicec_writeBlockVectorData( interfaces[i]->velocitiesDataID, interfaces[i]->numNodes, interfaces[i]->preciceNodeIDs, interfaces[i]->nodeVectorData );
+					break;
+				case POSITIONS:
+					getNodeCoordinates( interfaces[i]->nodeIDs, interfaces[i]->numNodes, interfaces[i]->dim, sim->co, sim->vold, sim->mt, interfaces[i]->nodeVectorData );
+					precicec_writeBlockVectorData( interfaces[i]->positionsDataID, interfaces[i]->numNodes, interfaces[i]->preciceNodeIDs, interfaces[i]->nodeVectorData );
 					break;
 				case FORCES:
 					getNodeForces( interfaces[i]->nodeIDs, interfaces[i]->numNodes, interfaces[i]->dim, sim->fn, sim->mt, interfaces[i]->nodeVectorData );
@@ -573,6 +591,20 @@ void PreciceInterface_ConfigureCouplingData( PreciceInterface * interface, Simul
 			PreciceInterface_EnsureValidNodesMeshID( interface );
 			interface->writeData[i] = DISPLACEMENTDELTAS;
 			interface->displacementDeltasDataID = precicec_getDataID( config->writeDataNames[i], interface->nodesMeshID );
+			printf( "Write data '%s' found.\n", config->writeDataNames[i] );
+		}
+		else if ( strcmp1( config->writeDataNames[i], "Positions" ) == 0 )
+		{
+			PreciceInterface_EnsureValidNodesMeshID( interface );
+			interface->writeData[i] = POSITIONS;
+			interface->positionsDataID = precicec_getDataID( config->writeDataNames[i], interface->nodesMeshID );
+			printf( "Write data '%s' found.\n", config->writeDataNames[i] );
+		}
+		else if ( strcmp1( config->writeDataNames[i], "Velocities" ) == 0 )
+		{
+			PreciceInterface_EnsureValidNodesMeshID( interface );
+			interface->writeData[i] = VELOCITIES;
+			interface->velocitiesDataID = precicec_getDataID( config->writeDataNames[i], interface->nodesMeshID );
 			printf( "Write data '%s' found.\n", config->writeDataNames[i] );
 		}
 		else if ( strcmp1( config->writeDataNames[i], "Forces" ) == 0 )

--- a/adapter/PreciceInterface.h
+++ b/adapter/PreciceInterface.h
@@ -45,7 +45,7 @@ typedef struct PreciceInterface {
 
 	// Arrays to store the coupling data
 	double * nodeScalarData;
-	double * nodeVectorData; //Forces, displacements and displacementDeltas are vector quantities
+	double * nodeVectorData; //Forces, displacements, velocities, positions and displacementDeltas are vector quantities
 	double * faceCenterData;
 
 	// preCICE Data IDs
@@ -58,6 +58,8 @@ typedef struct PreciceInterface {
 	int kDeltaTemperatureReadDataID;
 	int displacementsDataID; //New data ID for displacements
 	int displacementDeltasDataID; //New data ID for displacementDeltas
+	int positionsDataID; //New data ID for positions
+	int velocitiesDataID; //New data ID for velocities
 	int forcesDataID; //New data ID for forces
 
 	// Indices that indicate where to apply the boundary conditions / forces
@@ -115,6 +117,7 @@ typedef struct SimulationData {
 	double * xboun;
 	ITG * ntmat_;
 	double * vold;
+	double * veold;
 	double * fn;//values of forces read from calculix
 	double * cocon;
 	ITG * ncocon;

--- a/nonlingeo_precice.c
+++ b/nonlingeo_precice.c
@@ -223,6 +223,7 @@ void nonlingeo_precice(double **cop, ITG *nk, ITG **konp, ITG **ipkonp, char **l
       .xboun = xboun,
       .ntmat_ = ntmat_,
       .vold = vold,
+      .veold = veold,
       .fn = fn,
       .cocon = cocon,
       .ncocon = ncocon,


### PR DESCRIPTION
As the title says, this PR enables access to calculix's internal velocity and position fields. Similar to `DisplacementDeltas`, `Velocities` and `Positions` are right now implemented only as `write-data` fields. I'm not sure whether it makes sense to enable `read-data` too. Are there cases where we would like to initialise these fields in calculix from the interface?