### PR TITLE
save state after every coupling iteration in explicit coupling

### DIFF
--- a/adapter/PreciceInterface.c
+++ b/adapter/PreciceInterface.c
@@ -48,7 +48,7 @@ void Precice_Setup( char * configFilename, char * participantName, SimulationDat
 	Precice_InitializeData( sim );
 
 	// find if coupling is implicit or explicit. Implicit coupling will return true at the very beginning and explicit will always return false
-	sim->coupling_explicit = !Precice_IsWriteCheckpointRequired();
+	sim->coupling_implicit = Precice_IsWriteCheckpointRequired();
 
 }
 

--- a/adapter/PreciceInterface.c
+++ b/adapter/PreciceInterface.c
@@ -114,6 +114,11 @@ bool Precice_IsWriteCheckpointRequired()
 	return precicec_isActionRequired( "write-iteration-checkpoint" );
 }
 
+bool Precice_IsCouplingTimestepComplete()
+{
+	return precicec_isCouplingTimestepComplete();
+}
+
 void Precice_FulfilledReadCheckpoint()
 {
 	precicec_fulfilledAction( "read-iteration-checkpoint" );

--- a/adapter/PreciceInterface.c
+++ b/adapter/PreciceInterface.c
@@ -47,6 +47,9 @@ void Precice_Setup( char * configFilename, char * participantName, SimulationDat
 	// Initialize coupling data
 	Precice_InitializeData( sim );
 
+	// find if coupling is implicit or explicit. Implicit coupling will return true at the very beginning and explicit will always return false
+	sim->coupling_explicit = !Precice_IsWriteCheckpointRequired();
+
 }
 
 void Precice_InitializeData( SimulationData * sim )

--- a/adapter/PreciceInterface.h
+++ b/adapter/PreciceInterface.h
@@ -133,7 +133,7 @@ typedef struct SimulationData {
 	double coupling_init_dtheta;
 	double precice_dt;
 	double solver_dt;
-	bool coupling_explicit;
+	bool coupling_implicit;
 
 } SimulationData;
 

--- a/adapter/PreciceInterface.h
+++ b/adapter/PreciceInterface.h
@@ -188,6 +188,12 @@ bool Precice_IsReadCheckpointRequired();
 bool Precice_IsWriteCheckpointRequired();
 
 /**
+ * @brief Returns true if coupling timestep is complete
+ * @return
+ */
+bool Precice_IsCouplingTimestepComplete();
+
+/**
  * @brief Tells preCICE that the checkpoint has been read
  */
 void Precice_FulfilledReadCheckpoint();

--- a/adapter/PreciceInterface.h
+++ b/adapter/PreciceInterface.h
@@ -133,6 +133,7 @@ typedef struct SimulationData {
 	double coupling_init_dtheta;
 	double precice_dt;
 	double solver_dt;
+	bool coupling_explicit;
 
 } SimulationData;
 

--- a/nonlingeo_precice.c
+++ b/nonlingeo_precice.c
@@ -1114,10 +1114,10 @@ void nonlingeo_precice(double **cop, ITG *nk, ITG **konp, ITG **ipkonp, char **l
 	  
 	  memcpy(&vini[0],&vold[0],sizeof(double)*mt**nk);
 
-	  if( Precice_IsWriteCheckpointRequired() )
+	  if( Precice_IsWriteCheckpointRequired() || simulationData.coupling_explicit)
       	  {
           	Precice_WriteIterationCheckpoint( &simulationData, vini );
-          	Precice_FulfilledWriteCheckpoint();
+          	if( Precice_IsWriteCheckpointRequired() ) Precice_FulfilledWriteCheckpoint();
           }
 	  
 	  for(k=0;k<*nboun;++k){xbounini[k]=xbounact[k];}

--- a/nonlingeo_precice.c
+++ b/nonlingeo_precice.c
@@ -1114,7 +1114,7 @@ void nonlingeo_precice(double **cop, ITG *nk, ITG **konp, ITG **ipkonp, char **l
 	  
 	  memcpy(&vini[0],&vold[0],sizeof(double)*mt**nk);
 
-	  if( Precice_IsWriteCheckpointRequired() || simulationData.coupling_explicit)
+	  if( Precice_IsWriteCheckpointRequired() == simulationData.coupling_implicit)
       	  {
           	Precice_WriteIterationCheckpoint( &simulationData, vini );
           	if( Precice_IsWriteCheckpointRequired() ) Precice_FulfilledWriteCheckpoint();

--- a/nonlingeo_precice.c
+++ b/nonlingeo_precice.c
@@ -1089,6 +1089,8 @@ void nonlingeo_precice(double **cop, ITG *nk, ITG **konp, ITG **ipkonp, char **l
   /* Adapter: Create the interfaces and initialize the coupling */
   printf("About to enter preCICE setup in Calculix with names %s and %s \n", preciceParticipantName, configFilename);
   Precice_Setup( configFilename, preciceParticipantName, &simulationData );
+  // Initialize for the first step because Precice_IsCouplingTimestepComplete will return false until the end of the first step
+  if( !simulationData.coupling_implicit ) Precice_WriteIterationCheckpoint( &simulationData, vini );
   
   /* Adapter: Give preCICE the control of the time stepping */
   while( Precice_IsCouplingOngoing() ){
@@ -1114,11 +1116,14 @@ void nonlingeo_precice(double **cop, ITG *nk, ITG **konp, ITG **ipkonp, char **l
 	  
 	  memcpy(&vini[0],&vold[0],sizeof(double)*mt**nk);
 
-	  if( Precice_IsWriteCheckpointRequired() == simulationData.coupling_implicit)
+	  if( Precice_IsWriteCheckpointRequired() ) // implicit coupling
       	  {
           	Precice_WriteIterationCheckpoint( &simulationData, vini );
-          	if( Precice_IsWriteCheckpointRequired() ) Precice_FulfilledWriteCheckpoint();
+          	Precice_FulfilledWriteCheckpoint();
           }
+      if( Precice_IsCouplingTimestepComplete() && !simulationData.coupling_implicit ) // explicit coupling
+      Precice_WriteIterationCheckpoint( &simulationData, vini );
+
 	  
 	  for(k=0;k<*nboun;++k){xbounini[k]=xbounact[k];}
 	  if((*ithermal==1)||(*ithermal>=3)){


### PR DESCRIPTION
fix #8 

A small hack to make DisplacementDeltas work for explicit coupling as well. My question however is, is DisplacementDeltas change in displacement within a sub-cycle or change in displacement relative to the displacement at the beginning of the coupling step. I hope I'm clear here. The changes here assume the former.