### PR TITLE
Initialize data ids to -1 for debugging purposes

### DIFF
--- a/adapter/PreciceInterface.c
+++ b/adapter/PreciceInterface.c
@@ -361,6 +361,21 @@ void PreciceInterface_Create( PreciceInterface * interface, SimulationData * sim
 	interface->xloadIndices = NULL;
 	interface->xforcIndices = NULL;
 	interface->mapNPType = NULL;
+
+  // Initialize data ids to -1
+	interface->temperatureDataID = -1;
+	interface->fluxDataID = -1;
+	interface->sinkTemperatureDataID = -1;
+	interface->kDeltaWriteDataID = -1;
+	interface->kDeltaTemperatureWriteDataID = -1;
+	interface->kDeltaReadDataID = -1;
+	interface->kDeltaTemperatureReadDataID = -1;
+	interface->displacementsDataID = -1;
+	interface->displacementDeltasDataID = -1;
+	interface->positionsDataID = -1;
+	interface->velocitiesDataID = -1;
+	interface->forcesDataID = -1;
+
 	//Mapping Type
 
 	// The patch identifies the set used as interface in Calculix


### PR DESCRIPTION
This PR initializes all data ids to `-1` allowing us to spot the use of uninitialized ids in the preCICE SolverInterface.

@KyleDavisSA Can you please check if this PR allows us to reliably triggers the problem #27 