### PR TITLE
Use develop branch of systemtests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ python:
  - "3.5"
 jobs:
  include:
-   - script:
-       - curl -LO --retry 3 https://raw.githubusercontent.com/precice/systemtests/develop/trigger_systemtests.py
-       - travis_wait 60 python trigger_systemtests.py --adapter calculix --wait --st-branch EderK-ccx216
+     # trigger systemtests build only when pushing to master/develop branch
+    - if: fork = false AND ( branch = master OR branch = develop )
+      script:
+        - curl -LO --retry 3 https://raw.githubusercontent.com/precice/systemtests/master/trigger_systemtests.py
+        - travis_wait 60 python trigger_systemtests.py --adapter calculix --wait --st-branch master

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,5 +8,5 @@ jobs:
      # trigger systemtests build only when pushing to master/develop branch
     - if: fork = false AND ( branch = master OR branch = develop )
       script:
-        - curl -LO --retry 3 https://raw.githubusercontent.com/precice/systemtests/master/trigger_systemtests.py
-        - travis_wait 60 python trigger_systemtests.py --adapter calculix --wait --st-branch master
+        - curl -LO --retry 3 https://raw.githubusercontent.com/precice/systemtests/develop/trigger_systemtests.py
+        - travis_wait 60 python trigger_systemtests.py --adapter calculix --wait --st-branch develop


### PR DESCRIPTION
After https://github.com/precice/systemtests/pull/231 and https://github.com/precice/systemtests/pull/236 have been merged, it is no longer necessary to use the special ccx2.16 systemtests branch.