### PR TITLE
Add -fallow-argument-mismatch to support GCC 10

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ else
 	CC = mpicc
 endif
 
-FFLAGS = -Wall -O3 -fopenmp $(INCLUDES)
+FFLAGS = -Wall -O3 -fopenmp -fallow-argument-mismatch $(INCLUDES)
 FC = mpifort
 # FC = mpif90
 # FC = gfortran


### PR DESCRIPTION
See https://calculix.discourse.group/t/build-failures-with-gcc-10/76/

This is needed e.g. in Ubuntu 20.10 with CalculiX 2.16. This should be fixed in CalculiX 2.17.

@fsimonis I assume this is what you meant in the above thread?
@KyleDavisSA please check if this small change works in your case and merge if you agree.