### PR TITLE
Update master with improved Makefile and GCC 10 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,12 @@
-sudo: true
+  sudo: true
 dist: trusty
 language: python
 python:
  - "3.5"
 jobs:
  include:
-   - script:
-       - curl -LO --retry 3 https://raw.githubusercontent.com/precice/systemtests/develop/trigger_systemtests.py
-       - travis_wait 60 python trigger_systemtests.py --adapter calculix --wait --st-branch EderK-ccx216
+     # trigger systemtests build only when pushing to master/develop branch
+    - if: fork = false AND ( branch = master OR branch = develop )
+      script:
+        - curl -LO --retry 3 https://raw.githubusercontent.com/precice/systemtests/develop/trigger_systemtests.py
+        - travis_wait 60 python trigger_systemtests.py --adapter calculix --wait --st-branch develop

--- a/Makefile
+++ b/Makefile
@@ -2,13 +2,23 @@
 # https://github.com/precice/calculix-adapter/wiki/Installation-instructions-for-CalculiX
 # Set the following variables before building:
 # Path to original CalculiX source (e.g. $(HOME)/ccx_2.16/src )
-CCX             = $(HOME)/PathTo/CalculiX/ccx_2.16/src
-# Path to SPOOLES main directory (e.g. $(HOME)/SPOOLES.2.2 )
-SPOOLES         = $(HOME)/PathTo/SPOOLES
-# Path to ARPACK main directory (e.g. $(HOME)/ARPACK )
-ARPACK          = $(HOME)/PathTo/ARPACK
-# Path to yaml-cpp prefix (e.g. $(HOME)/yaml-cpp, should contain "include" and "build")
-YAML            = $(HOME)/PathTo/yaml-cpp
+CCX             = $(HOME)/CalculiX/ccx_2.16/src
+
+### Change these if you built SPOOLES, ARPACK, or yaml-cpp from source ###
+# SPOOLES include flags (e.g. -I$(HOME)/SPOOLES.2.2 )
+SPOOLES_INCLUDE   = -I/usr/include/spooles/
+# SPOOLES library flags (e.g. $(HOME)/SPOOLES.2.2/spooles.a)
+SPOOLES_LIBS      = -lspooles
+#
+# ARPACK include flags (e.g. -I$(HOME)/ARPACK)
+ARPACK_INCLUDE    =
+# ARPACK library flags (e.g. $(HOME)/ARPACK/libarpack_INTEL.a)
+ARPACK_LIBS       = -larpack -llapack -lblas
+#
+# yaml-cpp include flags (e.g. -I$(HOME)/yaml-cpp/include)
+YAML_INCLUDE      = -I/usr/include/
+# yaml-cpp library flags (e.g. -L$(HOME)/yaml-cpp/build -lyaml-cpp)
+YAML_LIBS         = -lyaml-cpp
 
 # Get the CFLAGS and LIBS from pkg-config (preCICE version >= 1.4.0).
 # If pkg-config cannot find the libprecice.pc meta-file, you may need to set the
@@ -24,25 +34,18 @@ INCLUDES = \
 	-I./ \
 	-I./adapter \
 	-I$(CCX) \
-	-I$(SPOOLES) \
+	$(SPOOLES_INCLUDE) \
 	$(PKGCONF_CFLAGS) \
-	-I$(ARPACK) \
-	-I$(YAML)/include
+	$(ARPACK_INCLUDE) \
+	$(YAML_INCLUDE)
 
 LIBS = \
-	$(SPOOLES)/spooles.a \
+	$(SPOOLES_LIBS) \
 	$(PKGCONF_LIBS) \
 	-lstdc++ \
-	-L$(YAML)/build -lyaml-cpp \
-
-# OS-specific options
-UNAME_S := $(shell uname -s)
-ifeq ($(UNAME_S),Darwin)
-	LIBS += $(ARPACK)/libarpack_MAC.a
-else
-	LIBS += $(ARPACK)/libarpack_INTEL.a
-	LIBS += -lpthread -lm -lc
-endif
+	$(YAML_LIBS) \
+	$(ARPACK_LIBS) \
+	-lpthread -lm -lc
 
 # Compilers and flags
 #CFLAGS = -g -Wall -std=c++11 -O0 -fopenmp $(INCLUDES) -DARCH="Linux" -DSPOOLES -DARPACK -DMATRIXSTORAGE
@@ -51,6 +54,7 @@ endif
 CFLAGS = -Wall -O3 -fopenmp $(INCLUDES) -DARCH="Linux" -DSPOOLES -DARPACK -DMATRIXSTORAGE
 
 # OS-specific options
+UNAME_S := $(shell uname -s)
 ifeq ($(UNAME_S),Darwin)
 	CC = /usr/local/bin/gcc
 else

--- a/adapter/ConfigReader.cpp
+++ b/adapter/ConfigReader.cpp
@@ -25,8 +25,8 @@ void ConfigReader_Read(char const * configFilename, char const * participantName
   adapterConfig->preciceConfigFilename = strdup( config["precice-config-file"].as<std::string>().c_str() );
 
 	int numInterfaces = config["participants"][participantName]["interfaces"].size();
-  adapterConfig->numInterfaces = numInterfaces;
-  adapterConfig->interfaces = (InterfaceConfig*) calloc( numInterfaces, sizeof( InterfaceConfig ) );
+  	adapterConfig->numInterfaces = numInterfaces;
+  	adapterConfig->interfaces = (InterfaceConfig*) calloc( numInterfaces, sizeof( InterfaceConfig ) );
 
 	for( int i = 0 ; i < numInterfaces ; i++ )
 	{
@@ -38,6 +38,7 @@ void ConfigReader_Read(char const * configFilename, char const * participantName
 		if( config["participants"][participantName]["interfaces"][i]["nodes-mesh"] )
 		{
 			interface.nodesMeshName = strdup( config["participants"][participantName]["interfaces"][i]["nodes-mesh"].as<std::string>().c_str() );
+			interface.map = 0;
 		}
 		else if ( config["participants"][participantName]["interfaces"][i]["nodes-mesh-with-connectivity"] ) 
 		{
@@ -70,43 +71,50 @@ void ConfigReader_Read(char const * configFilename, char const * participantName
 		interface.numWriteData = config["participants"][participantName]["interfaces"][i]["write-data"].size();
 		interface.numReadData = config["participants"][participantName]["interfaces"][i]["read-data"].size();
 
-		if( interface.numWriteData == 0 )
+		if( config["participants"][participantName]["interfaces"][i]["write-data"] )
 		{
-			// write-data is a string
-			interface.numWriteData = 1;
-			interface.writeDataNames = (char**) malloc( sizeof( char* ) * interface.numWriteData );
-			interface.writeDataNames[0] = strdup( config["participants"][participantName]["interfaces"][i]["write-data"].as<std::string>().c_str() );
-		}
-		else
-		{
-			// write-data is an array
-			interface.writeDataNames = (char**) malloc( sizeof( char* ) * interface.numWriteData );
-
-			for( int j = 0 ; j < interface.numWriteData ; j++ )
+			if( interface.numWriteData == 0 )
 			{
-				interface.writeDataNames[j] = strdup( config["participants"][participantName]["interfaces"][i]["write-data"][j].as<std::string>().c_str() );
+				// write-data is a string
+				interface.numWriteData = 1;
+				interface.writeDataNames = (char**) malloc( sizeof( char* ) * interface.numWriteData );
+				interface.writeDataNames[0] = strdup( config["participants"][participantName]["interfaces"][i]["write-data"].as<std::string>().c_str() );
+			}
+			else
+			{
+				// write-data is an array
+				interface.writeDataNames = (char**) malloc( sizeof( char* ) * interface.numWriteData );
+
+				for( int j = 0 ; j < interface.numWriteData ; j++ )
+				{
+					interface.writeDataNames[j] = strdup( config["participants"][participantName]["interfaces"][i]["write-data"][j].as<std::string>().c_str() );
+				}
 			}
 		}
 
-		if( interface.numReadData == 0 )
+		if( config["participants"][participantName]["interfaces"][i]["read-data"] )
 		{
-			// read-data is a string
-			interface.numReadData = 1;
-			interface.readDataNames = (char**) malloc( sizeof( char* ) * interface.numReadData );
-			interface.readDataNames[0] = strdup( config["participants"][participantName]["interfaces"][i]["read-data"].as<std::string>().c_str() );
-		}
-		else
-		{
-			// read-data is an array
-			interface.readDataNames = (char**) malloc( sizeof( char* ) * interface.numReadData );
-
-			for( int j = 0 ; j < interface.numReadData ; j++ )
+			if( interface.numReadData == 0 )
 			{
-				interface.readDataNames[j] = strdup( config["participants"][participantName]["interfaces"][i]["read-data"][j].as<std::string>().c_str() );
+				// read-data is a string
+				interface.numReadData = 1;
+				interface.readDataNames = (char**) malloc( sizeof( char* ) * interface.numReadData );
+				interface.readDataNames[0] = strdup( config["participants"][participantName]["interfaces"][i]["read-data"].as<std::string>().c_str() );
 			}
-		}	
+			else
+			{
+				// read-data is an array
+				interface.readDataNames = (char**) malloc( sizeof( char* ) * interface.numReadData );
+
+				for( int j = 0 ; j < interface.numReadData ; j++ )
+				{
+					interface.readDataNames[j] = strdup( config["participants"][participantName]["interfaces"][i]["read-data"][j].as<std::string>().c_str() );
+				}
+			}	
+		}
 	}
 }
+
 
 void AdapterConfig_Free(AdapterConfig * adapterConfig)
 {


### PR DESCRIPTION
The latest master does not correspond to documentation. It refers to the latest state of the adapter's Makefile to support dependencies by APT (see #41) and this was not merged to master for a while.

Meanwhile:
- Ubuntu 20.10 and other distributions already have GCC 10, which is not directly compatible. I added a workaround in #45 and we need this in master.
- @KyleDavisSA is testing a branch for CalculiX 2.17 and we should not forget to integrate these changes first.

This also merges important changes by @Eder-K regarding the CI.

Travis will likely error for unrelated reasons, in which case I need to go on and merge (with permission by @KyleDavisSA).