### PR TITLE
Remove -fallow-argument-mismatch (revert #45)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,8 @@ else
 	CC = mpicc
 endif
 
-FFLAGS = -Wall -O3 -fopenmp -fallow-argument-mismatch $(INCLUDES)
+FFLAGS = -Wall -O3 -fopenmp $(INCLUDES)
+# Note for GCC 10 or newer: add -fallow-argument-mismatch in the above flags
 FC = mpifort
 # FC = mpif90
 # FC = gfortran


### PR DESCRIPTION
In #45, I added `-fallow-argument-mismatch` to make the adapter compile also with GCC10 or newer, which is more picky. However, in older compilers (such as on Ubuntu 18.04), this option does not exist and `make` fails.

Until we get a proper solution, I propose to revert this and mention in in the documentation. I moved the additional flag to a comment.