### PR TITLE
Bugfix: remove -fallow-argument-mismatch from Makefile (add manually for GCC 10)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ else
 	CC = mpicc
 endif
 
-FFLAGS = -Wall -O3 -fopenmp $(INCLUDES)
+FFLAGS = -Wall -O3 -fopenmp -fallow-argument-mismatch $(INCLUDES)
 FC = mpifort
 # FC = mpif90
 # FC = gfortran

--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,8 @@ else
 	CC = mpicc
 endif
 
-FFLAGS = -Wall -O3 -fopenmp -fallow-argument-mismatch $(INCLUDES)
+FFLAGS = -Wall -O3 -fopenmp $(INCLUDES)
+# Note for GCC 10 or newer: add -fallow-argument-mismatch in the above flags
 FC = mpifort
 # FC = mpif90
 # FC = gfortran


### PR DESCRIPTION
See #47. We need this to restore compatibility with older compilers (currently prominent among our users).