### PR TITLE
Code refinement

### DIFF
--- a/adapter/CCXHelpers.c
+++ b/adapter/CCXHelpers.c
@@ -535,6 +535,11 @@ bool isDoubleEqual(const double a, const double b)
 	return fabs(a - b) < 1.e-14;
 }
 
+bool isQuasi2D3D(const int quasi2D3D)
+{
+	return quasi2D3D == 1;
+}
+
 void setDoubleArrayZero(double * values, const int length, const int dim)
 {
 	ITG i, j;

--- a/adapter/CCXHelpers.h
+++ b/adapter/CCXHelpers.h
@@ -309,6 +309,12 @@ bool isEqual(const char * lhs, const char * rhs);
 bool isDoubleEqual(const double a, const double b);
 
 /**
+ * @brief Returns whether it is a quasi 2D-3D case or a purely 3D case
+ * @param quasi2D3D is an integer toggled during initialization
+ */
+bool isQuasi2D3D(const int quasi2D3D);
+
+/**
  * @brief Set all values of an array to 0
  * @param values is the array carrying double values
  * @param length is the number of elements in array

--- a/adapter/PreciceInterface.c
+++ b/adapter/PreciceInterface.c
@@ -185,14 +185,14 @@ void Precice_ReadCouplingData( SimulationData * sim )
 				{
 				case TEMPERATURE:
 					// Read and set temperature BC
-          if ( !interfaces[i]->quasi2D3D )
-          {
-            precicec_readBlockScalarData( interfaces[i]->temperatureDataID, interfaces[i]->numNodes, interfaces[i]->preciceNodeIDs, interfaces[i]->nodeScalarData );
-          }
-          if ( interfaces[i]->quasi2D3D )
+          if ( isQuasi2D3D(interfaces[i]->quasi2D3D) )
           {
             precicec_readBlockScalarData( interfaces[i]->temperatureDataID, interfaces[i]->num2DNodes, interfaces[i]->preciceNodeIDs, interfaces[i]->node2DScalarData );
             mapData2Dto3DScalar(interfaces[i]->node2DScalarData, interfaces[i]->mapping2D3D, interfaces[i]->numNodes, interfaces[i]->nodeScalarData);
+          }
+          else
+          {
+            precicec_readBlockScalarData( interfaces[i]->temperatureDataID, interfaces[i]->numNodes, interfaces[i]->preciceNodeIDs, interfaces[i]->nodeScalarData );
           }
 					setNodeTemperatures( interfaces[i]->nodeScalarData, interfaces[i]->numNodes, interfaces[i]->xbounIndices, sim->xboun );
 					printf( "Reading TEMPERATURE coupling data with ID '%d'. \n",interfaces[i]->temperatureDataID );
@@ -217,28 +217,28 @@ void Precice_ReadCouplingData( SimulationData * sim )
 					break;
         case FORCES:
 					// Read and set forces as concentrated loads (Neumann BC)
-          if ( !interfaces[i]->quasi2D3D )
-          {
-            precicec_readBlockVectorData( interfaces[i]->forcesDataID, interfaces[i]->numNodes, interfaces[i]->preciceNodeIDs, interfaces[i]->nodeVectorData );
-          }
-          if ( interfaces[i]->quasi2D3D )
+          if ( isQuasi2D3D(interfaces[i]->quasi2D3D) )
           {
             precicec_readBlockVectorData( interfaces[i]->forcesDataID, interfaces[i]->num2DNodes, interfaces[i]->preciceNodeIDs, interfaces[i]->node2DVectorData );
             mapData2Dto3DVector(interfaces[i]->node2DVectorData, interfaces[i]->mapping2D3D, interfaces[i]->numNodes, interfaces[i]->nodeVectorData);
+          }
+          else
+          {
+            precicec_readBlockVectorData( interfaces[i]->forcesDataID, interfaces[i]->numNodes, interfaces[i]->preciceNodeIDs, interfaces[i]->nodeVectorData );
           }
 					setNodeForces( interfaces[i]->nodeVectorData, interfaces[i]->numNodes, interfaces[i]->dimCCX, interfaces[i]->xforcIndices, sim->xforc);
 					printf( "Reading FORCES coupling data with ID '%d'. \n",interfaces[i]->forcesDataID );
 					break;
 				case DISPLACEMENTS:
 					// Read and set displacements as single point constraints (Dirichlet BC)
-          if ( !interfaces[i]->quasi2D3D )
-          {
-            precicec_readBlockVectorData( interfaces[i]->displacementsDataID, interfaces[i]->numNodes, interfaces[i]->preciceNodeIDs, interfaces[i]->nodeVectorData );
-          }
-          if ( interfaces[i]->quasi2D3D )
+          if ( isQuasi2D3D(interfaces[i]->quasi2D3D) )
           {
             precicec_readBlockVectorData( interfaces[i]->displacementsDataID, interfaces[i]->num2DNodes, interfaces[i]->preciceNodeIDs, interfaces[i]->node2DVectorData );
             mapData2Dto3DVector(interfaces[i]->node2DVectorData, interfaces[i]->mapping2D3D, interfaces[i]->numNodes, interfaces[i]->nodeVectorData);
+          }
+          else
+          {
+            precicec_readBlockVectorData( interfaces[i]->displacementsDataID, interfaces[i]->numNodes, interfaces[i]->preciceNodeIDs, interfaces[i]->nodeVectorData );
           }
 					setNodeDisplacements( interfaces[i]->nodeVectorData, interfaces[i]->numNodes, interfaces[i]->dimCCX, interfaces[i]->xbounIndices, sim->xboun );
 					printf( "Reading DISPLACEMENTS coupling data with ID '%d'. \n",interfaces[i]->displacementsDataID );
@@ -287,15 +287,15 @@ void Precice_WriteCouplingData( SimulationData * sim )
 				{
 				case TEMPERATURE:
 					getNodeTemperatures( interfaces[i]->nodeIDs, interfaces[i]->numNodes, sim->vold, sim->mt, interfaces[i]->nodeScalarData );
-          if ( !interfaces[i]->quasi2D3D )
-          {
-            precicec_writeBlockScalarData( interfaces[i]->temperatureDataID, interfaces[i]->numNodes, interfaces[i]->preciceNodeIDs, interfaces[i]->nodeScalarData );
-          }
-          else if ( interfaces[i]->quasi2D3D )
+          if ( isQuasi2D3D(interfaces[i]->quasi2D3D) )
           {
             setDoubleArrayZero(interfaces[i]->node2DScalarData, interfaces[i]->num2DNodes, 1);
             mapData3Dto2DScalar(interfaces[i]->nodeScalarData, interfaces[i]->mapping2D3D, interfaces[i]->numNodes, interfaces[i]->node2DScalarData);
             precicec_writeBlockScalarData( interfaces[i]->temperatureDataID, interfaces[i]->num2DNodes, interfaces[i]->preciceNodeIDs, interfaces[i]->node2DScalarData );
+          }
+          else
+          {
+            precicec_writeBlockScalarData( interfaces[i]->temperatureDataID, interfaces[i]->numNodes, interfaces[i]->preciceNodeIDs, interfaces[i]->nodeScalarData );
           }
 					printf( "Writing TEMPERATURE coupling data with ID '%d'. \n",interfaces[i]->temperatureDataID );
 					break;
@@ -354,29 +354,29 @@ void Precice_WriteCouplingData( SimulationData * sim )
 					break;
 				case DISPLACEMENTS:
 					getNodeDisplacements( interfaces[i]->nodeIDs, interfaces[i]->numNodes, interfaces[i]->dimCCX, sim->vold, sim->mt, interfaces[i]->nodeVectorData );
-          if ( !interfaces[i]->quasi2D3D )
-          {
-            precicec_writeBlockVectorData( interfaces[i]->displacementsDataID, interfaces[i]->numNodes, interfaces[i]->preciceNodeIDs, interfaces[i]->nodeVectorData );
-          }
-          else if ( interfaces[i]->quasi2D3D )
+          if ( isQuasi2D3D(interfaces[i]->quasi2D3D) )
           {
             setDoubleArrayZero(interfaces[i]->node2DVectorData, interfaces[i]->num2DNodes, interfaces[i]->dim);
             mapData3Dto2DVector(interfaces[i]->nodeVectorData, interfaces[i]->mapping2D3D, interfaces[i]->numNodes, interfaces[i]->node2DVectorData);
             precicec_writeBlockVectorData( interfaces[i]->displacementsDataID, interfaces[i]->num2DNodes, interfaces[i]->preciceNodeIDs, interfaces[i]->node2DVectorData );
           }
+          else
+          {
+            precicec_writeBlockVectorData( interfaces[i]->displacementsDataID, interfaces[i]->numNodes, interfaces[i]->preciceNodeIDs, interfaces[i]->nodeVectorData );
+          }
 					printf( "Writing DISPLACEMENTS coupling data with ID '%d'. \n",interfaces[i]->displacementsDataID );
 					break;
 				case DISPLACEMENTDELTAS:
 					getNodeDisplacementDeltas( interfaces[i]->nodeIDs, interfaces[i]->numNodes, interfaces[i]->dimCCX, sim->vold, sim->coupling_init_v, sim->mt, interfaces[i]->nodeVectorData );
-          if ( !interfaces[i]->quasi2D3D )
-          {
-            precicec_writeBlockVectorData( interfaces[i]->displacementDeltasDataID, interfaces[i]->numNodes, interfaces[i]->preciceNodeIDs, interfaces[i]->nodeVectorData );
-          }
-          else if ( interfaces[i]->quasi2D3D )
+          if ( isQuasi2D3D(interfaces[i]->quasi2D3D) )
           {
             setDoubleArrayZero(interfaces[i]->node2DVectorData, interfaces[i]->num2DNodes, interfaces[i]->dim);
             mapData3Dto2DVector(interfaces[i]->nodeVectorData, interfaces[i]->mapping2D3D, interfaces[i]->numNodes, interfaces[i]->node2DVectorData);
             precicec_writeBlockVectorData( interfaces[i]->displacementDeltasDataID, interfaces[i]->num2DNodes, interfaces[i]->preciceNodeIDs, interfaces[i]->node2DVectorData );
+          }
+          else
+          {
+            precicec_writeBlockVectorData( interfaces[i]->displacementDeltasDataID, interfaces[i]->numNodes, interfaces[i]->preciceNodeIDs, interfaces[i]->nodeVectorData );
           }
 					printf( "Writing DISPLACEMENTDELTAS coupling data with ID '%d'. \n",interfaces[i]->displacementDeltasDataID );
 					break;
@@ -469,7 +469,7 @@ void PreciceInterface_Create( PreciceInterface * interface, SimulationData * sim
     printf( "Using quasi 2D-3D coupling\n" );
     interface->dimCCX = 3; // CalculiX always solves a 3D problem
   }
-  else if (interface->dim == 3)
+  else
   {
     interface->quasi2D3D = 0;
     interface->dimCCX = interface->dim;
@@ -538,7 +538,7 @@ void PreciceInterface_ConfigureNodesMesh( PreciceInterface * interface, Simulati
 	getNodeCoordinates( interface->nodeIDs, interface->numNodes, interface->dimCCX, sim->co, sim->vold, sim->mt, interface->nodeCoordinates );
 
   // Extract 2D coordinates from 3D coordinates for quasi 2D-3D coupling
-  if( interface->quasi2D3D )
+  if( isQuasi2D3D(interface->quasi2D3D) )
   {
     int count = 0;
     int dim = interface->dim;
@@ -583,15 +583,15 @@ void PreciceInterface_ConfigureNodesMesh( PreciceInterface * interface, Simulati
 	{
 		//printf("nodesMeshName is not null \n");
 		interface->nodesMeshID = precicec_getMeshID( interface->nodesMeshName );
-    if( !interface->quasi2D3D )
-    {
-      interface->preciceNodeIDs = malloc( interface->numNodes * sizeof( int ) );
-      precicec_setMeshVertices( interface->nodesMeshID, interface->numNodes, interface->nodeCoordinates, interface->preciceNodeIDs );
-    }
-    else if ( interface->quasi2D3D )
+    if ( isQuasi2D3D(interface->quasi2D3D) )
     {
       interface->preciceNodeIDs = malloc( interface->num2DNodes * sizeof( int ) );
       precicec_setMeshVertices( interface->nodesMeshID, interface->num2DNodes, interface->node2DCoordinates, interface->preciceNodeIDs );
+    }
+    else
+    {
+      interface->preciceNodeIDs = malloc( interface->numNodes * sizeof( int ) );
+      precicec_setMeshVertices( interface->nodesMeshID, interface->numNodes, interface->nodeCoordinates, interface->preciceNodeIDs );
     }
 	}
 
@@ -649,7 +649,7 @@ void PreciceInterface_ConfigureCouplingData( PreciceInterface * interface, Simul
 	interface->nodeScalarData = malloc( interface->numNodes * sizeof( double ) );
   interface->nodeVectorData = malloc( interface->numNodes * 3 * sizeof( double ) );
 
-  if ( interface->quasi2D3D )
+  if ( isQuasi2D3D(interface->quasi2D3D) )
   {
     interface->node2DScalarData = malloc( interface->num2DNodes * sizeof( double ));
     interface->node2DVectorData = malloc( interface->num2DNodes * 2 * sizeof( double ) );

--- a/adapter/PreciceInterface.h
+++ b/adapter/PreciceInterface.h
@@ -21,8 +21,8 @@
 typedef struct PreciceInterface {
 
 	char * name;
-	int dim;
-	int dimCCX;
+	int dim; // Dimension received from preCICE configuration
+	int dimCCX; // Dimension as seen by CalculiX
 
 	// Interface nodes
 	int numNodes;
@@ -49,8 +49,8 @@ typedef struct PreciceInterface {
 
 	// Arrays to store the coupling data
 	double * nodeScalarData;
-	double * node2DScalarData;
-	double * nodeVectorData; //Forces, displacements, velocities, positions and displacementDeltas are vector quantities
+	double * node2DScalarData; // Scalar quantities in 2D in case quasi 2D-3D coupling is done
+	double * nodeVectorData; // Forces, displacements, velocities, positions and displacementDeltas are vector quantities
 	double * node2DVectorData; // Vector quantities in 2D in case quasi 2D-3D coupling is done
 	double * faceCenterData;
 

--- a/nonlingeo_precice.c
+++ b/nonlingeo_precice.c
@@ -1309,12 +1309,6 @@ void nonlingeo_precice(double **cop, ITG *nk, ITG **konp, ITG **ipkonp, char **l
   /* Adapter: Give preCICE the control of the time stepping */
   while( Precice_IsCouplingOngoing() ){
 
-    if( Precice_IsWriteCheckpointRequired() )
-      {
-        Precice_WriteIterationCheckpoint( &simulationData, vini );
-        Precice_FulfilledWriteCheckpoint();
-      }
-
 	  /* Adapter: Adjust solver time step */
       Precice_AdjustSolverTimestep( &simulationData );
       /* Adapter read coupling data if available */
@@ -1336,6 +1330,12 @@ void nonlingeo_precice(double **cop, ITG *nk, ITG **konp, ITG **ipkonp, char **l
 
 	  isiz=mt**nk;cpypardou(vini,vold,&isiz,&num_cpus);
 //	  memcpy(&vini[0],&vold[0],sizeof(double)*mt**nk);
+
+    if( Precice_IsWriteCheckpointRequired() )
+    {
+      Precice_WriteIterationCheckpoint( &simulationData, vini );
+      Precice_FulfilledWriteCheckpoint();
+    }
 
 	  isiz=*nboun;cpypardou(xbounini,xbounact,&isiz,&num_cpus);
 //	  for(k=0;k<*nboun;++k){xbounini[k]=xbounact[k];}


### PR DESCRIPTION
This PR makes the 2D-3D implementation more readable and reverts a bug introduced in the PR: https://github.com/precice/calculix-adapter/pull/49
The bug was observed as the 3D_Tube tutorial case with OpenFOAM-CalculiX was failing. One major task:
- [x] Ensure the 3D_Tube tutorial case works for the full duration. @DavidSCN can you please check this to rule out system specific behavior on my side?
- [x] Ensure all FSI tutorial cases with CalculiX run and the results are reasonable