### PR TITLE
Fixed missing "free"

### DIFF
--- a/adapter/PreciceInterface.c
+++ b/adapter/PreciceInterface.c
@@ -420,6 +420,7 @@ void Precice_FreeData( SimulationData * sim )
 		if( sim->preciceInterfaces[i] != NULL ){
 			free( sim->preciceInterfaces[i] );
 		}
+		free( sim->preciceInterfaces );
 	}
 
 	precicec_finalize();

--- a/adapter/PreciceInterface.c
+++ b/adapter/PreciceInterface.c
@@ -418,9 +418,9 @@ void Precice_FreeData( SimulationData * sim )
 	{
 		PreciceInterface_FreeData( sim->preciceInterfaces[i] );
 		free( sim->preciceInterfaces[i] );
-		free( sim->preciceInterfaces );
 	}
-
+	
+	free( sim->preciceInterfaces );
 	precicec_finalize();
 }
 

--- a/adapter/PreciceInterface.c
+++ b/adapter/PreciceInterface.c
@@ -417,9 +417,7 @@ void Precice_FreeData( SimulationData * sim )
 	for( i = 0 ; i < sim->numPreciceInterfaces ; i++ )
 	{
 		PreciceInterface_FreeData( sim->preciceInterfaces[i] );
-		if( sim->preciceInterfaces[i] != NULL ){
-			free( sim->preciceInterfaces[i] );
-		}
+		free( sim->preciceInterfaces[i] );
 		free( sim->preciceInterfaces );
 	}
 


### PR DESCRIPTION
While looking for some memory leaks ( https://github.com/precice/calculix-adapter/issues/10 ) I stumbled on this overlook.
I'm looking for bigger fish than this, but that's not a reason not to fix it.

There is a nested malloc in `Precice_Setup`, where we need to allocate an array of `adapterConfig.numInterfaces` different interfaces. So we create an array of pointers to interfaces, then populate it.
But in the cleanup function, we delete all the interfaces, but not the array itself.

Initialization : 
https://github.com/precice/calculix-adapter/blob/9fefcef8ade330280cb300c25c78df6827b44684/adapter/PreciceInterface.c#L39-L47

Cleanup : 
https://github.com/precice/calculix-adapter/blob/9fefcef8ade330280cb300c25c78df6827b44684/adapter/PreciceInterface.c#L417-L425

So I just added the required "free" call.
8 bytes less are leaked, a significant improvement :)