### PR TITLE
Add support for clang-format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,120 @@
+---
+Language:        Cpp
+AccessModifierOffset: -2
+AlignAfterOpenBracket: Align
+AlignConsecutiveAssignments: true
+AlignConsecutiveDeclarations: true
+AlignEscapedNewlines: Right
+AlignOperands:   true
+AlignTrailingComments: true
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowShortBlocksOnASingleLine: false
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: Empty
+AllowShortIfStatementsOnASingleLine: false
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: false
+AlwaysBreakTemplateDeclarations: MultiLine
+BinPackArguments: true
+BinPackParameters: true
+BraceWrapping:   
+  AfterClass:      false
+  AfterControlStatement: false
+  AfterEnum:       false
+  AfterFunction:   true
+  AfterNamespace:  false
+  AfterObjCDeclaration: false
+  AfterStruct:     false
+  AfterUnion:      false
+  AfterExternBlock: false
+  BeforeCatch:     false
+  BeforeElse:      false
+  IndentBraces:    false
+  SplitEmptyFunction: true
+  SplitEmptyRecord: true
+  SplitEmptyNamespace: true
+BreakBeforeBinaryOperators: None
+BreakBeforeBraces: Custom
+BreakBeforeInheritanceComma: false
+BreakInheritanceList: BeforeColon
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializersBeforeComma: false
+BreakConstructorInitializers: BeforeColon
+BreakAfterJavaFieldAnnotations: false
+BreakStringLiterals: true
+ColumnLimit:     0
+CommentPragmas:  '^ IWYU pragma:'
+CompactNamespaces: false
+ConstructorInitializerAllOnOneLineOrOnePerLine: false
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: true
+DerivePointerAlignment: false
+DisableFormat:   false
+ExperimentalAutoDetectBinPacking: false
+FixNamespaceComments: true
+ForEachMacros:   
+  - foreach
+  - Q_FOREACH
+  - BOOST_FOREACH
+IncludeBlocks:   Preserve
+IncludeCategories: 
+  - Regex:           '^(<|"(gtest|isl|json)/)'
+    Priority:        1
+  - Regex:           '.*'
+    Priority:        2
+  - Regex:           '.*'
+    Priority:        1
+IncludeIsMainRegex: '$'
+IndentCaseLabels: false
+IndentPPDirectives: None
+IndentWidth:     2
+IndentWrappedFunctionNames: false
+JavaScriptQuotes: Leave
+JavaScriptWrapImports: true
+KeepEmptyLinesAtTheStartOfBlocks: true
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: None
+ObjCBinPackProtocolList: Auto
+ObjCBlockIndentWidth: 2
+ObjCSpaceAfterProperty: false
+ObjCSpaceBeforeProtocolList: true
+PenaltyBreakAssignment: 2
+PenaltyBreakBeforeFirstCallParameter: 19
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakString: 1000
+PenaltyBreakTemplateDeclaration: 10
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 100
+PointerAlignment: Right
+ReflowComments:  true
+SortIncludes:    true
+SortUsingDeclarations: true
+SpaceAfterCStyleCast: true
+SpaceAfterTemplateKeyword: true
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeCpp11BracedList: false
+SpaceBeforeCtorInitializerColon: true
+SpaceBeforeInheritanceColon: true
+SpaceBeforeParens: ControlStatements
+SpaceBeforeRangeBasedForLoopColon: true
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 1
+SpacesInAngles:  false
+SpacesInContainerLiterals: true
+SpacesInCStyleCastParentheses: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+Standard:        Cpp11
+StatementMacros: 
+  - Q_UNUSED
+  - QT_REQUIRE_VERSION
+TabWidth:        2
+UseTab:          Never
+...
+

--- a/.github/workflows/check-format.yml
+++ b/.github/workflows/check-format.yml
@@ -1,0 +1,13 @@
+name: Check code formatting
+on: [push, pull_request]
+jobs:
+  formatting-check:
+    name: Check formatting (clang-format)
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Run clang-format style check for C/C++ programs.
+      uses: jidicula/clang-format-action@v3.3.0
+      with:
+        clang-format-version: '11'
+        check-path: '.'

--- a/.github/workflows/check-format.yml
+++ b/.github/workflows/check-format.yml
@@ -7,7 +7,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Run clang-format style check for C/C++ programs.
-      uses: jidicula/clang-format-action@v3.3.0
+      uses: jidicula/clang-format-action@main
       with:
         clang-format-version: '11'
         check-path: '.'

--- a/CalculiX.h
+++ b/CalculiX.h
@@ -7,7 +7,7 @@
 /*     the License, or (at your option) any later version.               */
 
 /*     This program is distributed in the hope that it will be useful,   */
-/*     but WITHOUT ANY WARRANTY; without even the implied warranty of    */ 
+/*     but WITHOUT ANY WARRANTY; without even the implied warranty of    */
 /*     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the      */
 /*     GNU General Public License for more details.                      */
 
@@ -23,45 +23,53 @@
 #define HP 4
 
 #if ARCH == Linux
-#define FORTRAN(A,B) A##_  B
+#define FORTRAN(A, B) A##_ B
 #elif ARCH == IRIX || ARCH == IRIX64
-#define FORTRAN(A,B) A##_##B
+#define FORTRAN(A, B) A##_##B
 #elif ARCH == HP
-#define FORTRAN(A,B) A##B
+#define FORTRAN(A, B) A##B
 #endif
 
 #if ARCH == Linux
-#define CEE(A,B) A##_  B
+#define CEE(A, B) A##_ B
 #elif ARCH == IRIX || ARCH == IRIX64
-#define CEE(A,B) A##_##B
+#define CEE(A, B) A##_##B
 #elif ARCH == HP
-#define CEE(A,B) A##B
+#define CEE(A, B) A##B
 #endif
 
 /* setting arrays to constant values */
 
 /* serial */
-#define DMEMSET(a,b,c,d) for(im=b;im<c;im++)a[im]=d
+#define DMEMSET(a, b, c, d)  \
+  for (im = b; im < c; im++) \
+  a[im] = d
 /* parallel */
-#define DOUMEMSET(a,b,c,d) setpardou(&a[b],d,c-b,num_cpus)
-#define ITGMEMSET(a,b,c,d) setparitg(&a[b],d,c-b,num_cpus)
+#define DOUMEMSET(a, b, c, d) setpardou(&a[b], d, c - b, num_cpus)
+#define ITGMEMSET(a, b, c, d) setparitg(&a[b], d, c - b, num_cpus)
 
 /* memory allocation, reallocation, freeing */
 
 /* allocating memory for double reals and initializing it to zero (parallell) */
-#define DNEW(a,b,c) {a=(b *)u_malloc((c)*sizeof(b),__FILE__,__LINE__,#a); \
-        DOUMEMSET(a,0,c,0.);}
+#define DNEW(a, b, c)                                            \
+  {                                                              \
+    a = (b *) u_malloc((c) * sizeof(b), __FILE__, __LINE__, #a); \
+    DOUMEMSET(a, 0, c, 0.);                                      \
+  }
 /* allocating memory for ITG and initializing it to zero (parallell) */
-#define INEW(a,b,c) {a=(b *)u_malloc((c)*sizeof(b),__FILE__,__LINE__,#a); \
-        ITGMEMSET(a,0,c,0);}
+#define INEW(a, b, c)                                            \
+  {                                                              \
+    a = (b *) u_malloc((c) * sizeof(b), __FILE__, __LINE__, #a); \
+    ITGMEMSET(a, 0, c, 0);                                       \
+  }
 /* allocating memory without initialization */
-#define MNEW(a,b,c) a=(b *)u_malloc((c)*sizeof(b),__FILE__,__LINE__,#a)
+#define MNEW(a, b, c) a = (b *) u_malloc((c) * sizeof(b), __FILE__, __LINE__, #a)
 /* allocating memory and initializing it to zero (serial) */
-#define NNEW(a,b,c) a=(b *)u_calloc((c),sizeof(b),__FILE__,__LINE__,#a)
+#define NNEW(a, b, c) a = (b *) u_calloc((c), sizeof(b), __FILE__, __LINE__, #a)
 /* reallocating memory; no initialization */
-#define RENEW(a,b,c) a=(b *)u_realloc((b *)(a),(c)*sizeof(b),__FILE__,__LINE__,#a)
+#define RENEW(a, b, c) a = (b *) u_realloc((b *) (a), (c) * sizeof(b), __FILE__, __LINE__, #a)
 /* freeing memory */
-#define SFREE(a) u_free(a,__FILE__,__LINE__,#a)
+#define SFREE(a) u_free(a, __FILE__, __LINE__, #a)
 
 #ifdef LONGLONG
 #define ITG long long
@@ -71,2374 +79,2375 @@
 #define ITGFORMAT "d"
 #endif
 
-void FORTRAN(actideacti,(char *set,ITG *nset,ITG *istartset,ITG *iendset,
-                         ITG *ialset,char *objectset,ITG *ipkon,ITG *ibject,
-                         ITG *ne));
+void FORTRAN(actideacti, (char *set, ITG *nset, ITG *istartset, ITG *iendset,
+                          ITG *ialset, char *objectset, ITG *ipkon, ITG *ibject,
+                          ITG *ne));
 
-void FORTRAN(actideactistr,(char *set,ITG *nset,ITG *istartset,ITG *iendset,
-             ITG *ialset,char *objectset,ITG *ipkon,ITG *iobject,ITG *ne,
-             ITG *neinset,ITG *iponoel,ITG *inoel,ITG *nepar,
-             ITG *nkinsetinv,ITG *nk));
+void FORTRAN(actideactistr, (char *set, ITG *nset, ITG *istartset, ITG *iendset,
+                             ITG *ialset, char *objectset, ITG *ipkon, ITG *iobject, ITG *ne,
+                             ITG *neinset, ITG *iponoel, ITG *inoel, ITG *nepar,
+                             ITG *nkinsetinv, ITG *nk));
 
-void FORTRAN(adaptfields,(ITG *ipkonf,ITG *ipnei,ITG *ielmatf,ITG *ielorienf,
-                          ITG *neiel,ITG *neifa,ITG *neij,ITG *ipkonfcp,
-                          ITG *ipneicp,ITG *ielmatfcp,ITG *ielorienfcp,
-                          ITG *neielcp,ITG *neifacp,ITG *neijcp,ITG *mmm,
-                          ITG *nnn,ITG *nactdoh,ITG *nactdohinv,ITG *mi,
-                          ITG *nef,ITG *nface,ITG *ielfa,ITG *ielfacp,
-                          ITG *norien,char *lakonf,char *lakonfcp));
+void FORTRAN(adaptfields, (ITG * ipkonf, ITG *ipnei, ITG *ielmatf, ITG *ielorienf,
+                           ITG *neiel, ITG *neifa, ITG *neij, ITG *ipkonfcp,
+                           ITG *ipneicp, ITG *ielmatfcp, ITG *ielorienfcp,
+                           ITG *neielcp, ITG *neifacp, ITG *neijcp, ITG *mmm,
+                           ITG *nnn, ITG *nactdoh, ITG *nactdohinv, ITG *mi,
+                           ITG *nef, ITG *nface, ITG *ielfa, ITG *ielfacp,
+                           ITG *norien, char *lakonf, char *lakonfcp));
 
-void FORTRAN(addimdnodecload,(ITG *nodeforc,ITG *i,ITG *imdnode,
-             ITG *nmdnode,double *xforc,ITG *ikmpc,ITG *ilmpc,
-             ITG *ipompc,ITG *nodempc,ITG *nmpc,ITG *imddof,ITG *nmddof,
-             ITG *nactdof,ITG *mi,ITG *imdmpc,ITG *nmdmpc,ITG *imdboun,
-             ITG *nmdboun,ITG *ikboun,ITG *nboun,ITG *ilboun,ITG *ithermal));
+void FORTRAN(addimdnodecload, (ITG * nodeforc, ITG *i, ITG *imdnode,
+                               ITG *nmdnode, double *xforc, ITG *ikmpc, ITG *ilmpc,
+                               ITG *ipompc, ITG *nodempc, ITG *nmpc, ITG *imddof, ITG *nmddof,
+                               ITG *nactdof, ITG *mi, ITG *imdmpc, ITG *nmdmpc, ITG *imdboun,
+                               ITG *nmdboun, ITG *ikboun, ITG *nboun, ITG *ilboun, ITG *ithermal));
 
-void FORTRAN(addimdnodedload,(ITG *nelemload,char *sideload,ITG *ipkon,
-             ITG *kon,char *lakon,ITG *i,ITG *imdnode,ITG *nmdnode,
-             ITG *ikmpc,ITG *ilmpc,
-             ITG *ipompc,ITG *nodempc,ITG *nmpc,ITG *imddof,ITG *nmddof,
-             ITG *nactdof,ITG *mi,ITG *imdmpc,ITG *nmdmpc,ITG *imdboun,
-             ITG *nmdboun,ITG *ikboun,ITG *nboun,ITG *ilboun,ITG *ithermal));
+void FORTRAN(addimdnodedload, (ITG * nelemload, char *sideload, ITG *ipkon,
+                               ITG *kon, char *lakon, ITG *i, ITG *imdnode, ITG *nmdnode,
+                               ITG *ikmpc, ITG *ilmpc,
+                               ITG *ipompc, ITG *nodempc, ITG *nmpc, ITG *imddof, ITG *nmddof,
+                               ITG *nactdof, ITG *mi, ITG *imdmpc, ITG *nmdmpc, ITG *imdboun,
+                               ITG *nmdboun, ITG *ikboun, ITG *nboun, ITG *ilboun, ITG *ithermal));
 
-void FORTRAN(addizdofcload,(ITG *nodeforc,ITG *ndirforc,ITG *nactdof,
-             ITG *mi,ITG *izdof,ITG *nzdof,ITG *i,ITG *iznode,ITG *nznode,
-             ITG *nk,ITG *imdnode,ITG *nmdnode,double *xforc,
-             ITG *ntrans,ITG *inotr));
+void FORTRAN(addizdofcload, (ITG * nodeforc, ITG *ndirforc, ITG *nactdof,
+                             ITG *mi, ITG *izdof, ITG *nzdof, ITG *i, ITG *iznode, ITG *nznode,
+                             ITG *nk, ITG *imdnode, ITG *nmdnode, double *xforc,
+                             ITG *ntrans, ITG *inotr));
 
-void FORTRAN(addizdofdload,(ITG *nelemload,char *sideload,ITG *ipkon,
-             ITG *kon,char *lakon,ITG *nactdof,ITG *izdof,ITG *nzdof,
-             ITG *mi,ITG *i,ITG *iznode,ITG *nznode,ITG *nk,
-             ITG *imdnode,ITG *nmdnode));
+void FORTRAN(addizdofdload, (ITG * nelemload, char *sideload, ITG *ipkon,
+                             ITG *kon, char *lakon, ITG *nactdof, ITG *izdof, ITG *nzdof,
+                             ITG *mi, ITG *i, ITG *iznode, ITG *nznode, ITG *nk,
+                             ITG *imdnode, ITG *nmdnode));
 
-void FORTRAN(adjacentbounodes,(ITG *ifront,ITG *ifrontrel,ITG *nfront,
-			       ITG *iedno,ITG *iedg,ITG *nnfront,ITG *ifront2,
-			       ITG *ifrontrel2,ITG *ibounnod,ITG *nbounnod,
-			       ITG *istartfront,ITG *iendfront,ITG *ibounedg,
-			       ITG *istartcrackfro,ITG *iendcrackfro,
-			       ITG *ncrack,ITG *ibounnod2,ITG *istartcrackbou,
-			       ITG *iendcrackbou,ITG *isubsurffront,
-			       ITG *iedno2,double *stress,double *stress2,
-			       ITG *iresort,ITG *ieled,ITG *kontri,
-			       double *costruc,double *costruc2,double *temp,
-			       double *temp2,ITG *nstep,ITG *ier));
+void FORTRAN(adjacentbounodes, (ITG * ifront, ITG *ifrontrel, ITG *nfront,
+                                ITG *iedno, ITG *iedg, ITG *nnfront, ITG *ifront2,
+                                ITG *ifrontrel2, ITG *ibounnod, ITG *nbounnod,
+                                ITG *istartfront, ITG *iendfront, ITG *ibounedg,
+                                ITG *istartcrackfro, ITG *iendcrackfro,
+                                ITG *ncrack, ITG *ibounnod2, ITG *istartcrackbou,
+                                ITG *iendcrackbou, ITG *isubsurffront,
+                                ITG *iedno2, double *stress, double *stress2,
+                                ITG *iresort, ITG *ieled, ITG *kontri,
+                                double *costruc, double *costruc2, double *temp,
+                                double *temp2, ITG *nstep, ITG *ier));
 
-void FORTRAN(adjustcontactnodes,(char *tieset,ITG *ntie,ITG *itietri,double *cg,
-             double *straight,double *co,double *vold,double *xo,double *yo,
-             double *zo,double *x,double *y,double *z,ITG *nx,ITG *ny,
-             ITG *nz,ITG *istep,ITG *iinc,ITG *iit,ITG *mi,ITG *imastop,
-             ITG *nslavnode,ITG *islavnode,char *set,ITG *nset,ITG *istartset,
-             ITG *iendset,ITG *ialset,double *tietol,double *clearini,
-             double *clearslavnode,ITG *itiefac,ITG *ipkon,ITG *kon,
-             char *lakon,ITG *islavsurf));
+void FORTRAN(adjustcontactnodes, (char *tieset, ITG *ntie, ITG *itietri, double *cg,
+                                  double *straight, double *co, double *vold, double *xo, double *yo,
+                                  double *zo, double *x, double *y, double *z, ITG *nx, ITG *ny,
+                                  ITG *nz, ITG *istep, ITG *iinc, ITG *iit, ITG *mi, ITG *imastop,
+                                  ITG *nslavnode, ITG *islavnode, char *set, ITG *nset, ITG *istartset,
+                                  ITG *iendset, ITG *ialset, double *tietol, double *clearini,
+                                  double *clearslavnode, ITG *itiefac, ITG *ipkon, ITG *kon,
+                                  char *lakon, ITG *islavsurf));
 
-void FORTRAN(addshell,(ITG *nactdof,ITG *node,double *b,ITG *mi,ITG *iperturb,
-		       ITG *nmethod,double *cam,double *v));
+void FORTRAN(addshell, (ITG * nactdof, ITG *node, double *b, ITG *mi, ITG *iperturb,
+                        ITG *nmethod, double *cam, double *v));
 
-void FORTRAN(allocation,(ITG *nload_,ITG *nforc_,ITG *nboun_,
-			 ITG *nk_,ITG *ne_,ITG *nmpc_,ITG *nset_,ITG *nalset_,
-			 ITG *nmat_,ITG *ntmat_,ITG *npmat_,ITG *norien_,
-			 ITG *nam_,ITG *nprint_,ITG *mi,ITG *ntrans_,
-			 char *set,ITG *meminset,
-			 ITG *rmeminset,ITG *ncs_,ITG *namtot_,ITG *ncmat_,
-			 ITG *memmpc_,ITG *ne1d,ITG *ne2d,ITG *nflow,
-			 char *jobnamec,ITG *irstrt,ITG *ithermal,ITG *nener,
-			 ITG *nstate_,ITG *istep,char *inpc,
-			 ITG *ipoinp,ITG *inp,ITG *ntie_,ITG *nbody_,
-			 ITG *nprop_,ITG *ipoinpc,ITG *nevdamp,ITG *npt_,
-			 ITG *nslavsm,ITG *nkon_,ITG *mcs,ITG *mortar,
-			 ITG *ifacecount,ITG *nintpoint,ITG *infree,
-			 ITG *nheading_,ITG *nobject_,
-			 ITG *iuel,ITG *iprestr,ITG *nstam,ITG *ndamp,ITG *nef,
-			 ITG *nbounold,ITG *nforcold,ITG *nloadold,
-			 ITG *nbodyold,ITG *mpcend,ITG *irobustdesign,
-			 ITG *nfc_,ITG *ndc_));
+void FORTRAN(allocation, (ITG * nload_, ITG *nforc_, ITG *nboun_,
+                          ITG *nk_, ITG *ne_, ITG *nmpc_, ITG *nset_, ITG *nalset_,
+                          ITG *nmat_, ITG *ntmat_, ITG *npmat_, ITG *norien_,
+                          ITG *nam_, ITG *nprint_, ITG *mi, ITG *ntrans_,
+                          char *set, ITG *meminset,
+                          ITG *rmeminset, ITG *ncs_, ITG *namtot_, ITG *ncmat_,
+                          ITG *memmpc_, ITG *ne1d, ITG *ne2d, ITG *nflow,
+                          char *jobnamec, ITG *irstrt, ITG *ithermal, ITG *nener,
+                          ITG *nstate_, ITG *istep, char *inpc,
+                          ITG *ipoinp, ITG *inp, ITG *ntie_, ITG *nbody_,
+                          ITG *nprop_, ITG *ipoinpc, ITG *nevdamp, ITG *npt_,
+                          ITG *nslavsm, ITG *nkon_, ITG *mcs, ITG *mortar,
+                          ITG *ifacecount, ITG *nintpoint, ITG *infree,
+                          ITG *nheading_, ITG *nobject_,
+                          ITG *iuel, ITG *iprestr, ITG *nstam, ITG *ndamp, ITG *nef,
+                          ITG *nbounold, ITG *nforcold, ITG *nloadold,
+                          ITG *nbodyold, ITG *mpcend, ITG *irobustdesign,
+                          ITG *nfc_, ITG *ndc_));
 
-void FORTRAN(allocation_rfn,(ITG *nk_,ITG *ne_,ITG *nkon_,ITG *ipoinp,
-			    ITG *ipoinpc,char *inpc,ITG *inp));
+void FORTRAN(allocation_rfn, (ITG * nk_, ITG *ne_, ITG *nkon_, ITG *ipoinp,
+                              ITG *ipoinpc, char *inpc, ITG *inp));
 
-void FORTRAN(allocont,(ITG *ncont,ITG *ntie,char *tieset,ITG *nset,
-             char *set,ITG *istartset,ITG *iendset,ITG *ialset,
-             char *lakon,ITG *ncone,double *tietol,ITG *ismallsliding,
-             char *kind1,char *kind2,ITG *mortar,ITG *istep));
+void FORTRAN(allocont, (ITG * ncont, ITG *ntie, char *tieset, ITG *nset,
+                        char *set, ITG *istartset, ITG *iendset, ITG *ialset,
+                        char *lakon, ITG *ncone, double *tietol, ITG *ismallsliding,
+                        char *kind1, char *kind2, ITG *mortar, ITG *istep));
 
-void FORTRAN(applybounfem,(ITG *nodeboun,ITG *ndirboun,ITG *nboun,
-       double *xbounact,ITG *ithermal,ITG *nk,
-       double *vold,ITG *isolidsurf,
-       ITG *nsolidsurf,double *xsolidsurf,ITG *nfreestream,ITG *ifreestream,
-       ITG *turbulent,double *vcon,double *shcon,ITG *nshcon,
-       double *rhcon,ITG *nrhcon,ITG *ntmat_,double *physcon,
-       double *v,ITG *compressible,ITG *nmpc,ITG *nodempc,
-       ITG *ipompc,double *coefmpc,ITG *inomat,ITG *mi,
-       ITG *ilboun,ITG *ilmpc,char *labmpc,
-       double *coefmodmpc,ITG *ifreesurface,ITG *ierr,double *dgravity,
-       double *depth,ITG *iexplicit));
+void FORTRAN(applybounfem, (ITG * nodeboun, ITG *ndirboun, ITG *nboun,
+                            double *xbounact, ITG *ithermal, ITG *nk,
+                            double *vold, ITG *isolidsurf,
+                            ITG *nsolidsurf, double *xsolidsurf, ITG *nfreestream, ITG *ifreestream,
+                            ITG *turbulent, double *vcon, double *shcon, ITG *nshcon,
+                            double *rhcon, ITG *nrhcon, ITG *ntmat_, double *physcon,
+                            double *v, ITG *compressible, ITG *nmpc, ITG *nodempc,
+                            ITG *ipompc, double *coefmpc, ITG *inomat, ITG *mi,
+                            ITG *ilboun, ITG *ilmpc, char *labmpc,
+                            double *coefmodmpc, ITG *ifreesurface, ITG *ierr, double *dgravity,
+                            double *depth, ITG *iexplicit));
 
-void FORTRAN(applybounp,(ITG *nodeboun,ITG *ndirboun,ITG *nboun,
-			 double *xbounact,ITG *nk,double *vold,double *v,
-			 ITG *ipompc,ITG *nodempc,double *coefmpc,ITG *nmpc,
-			 ITG *inomat,ITG *mi));
+void FORTRAN(applybounp, (ITG * nodeboun, ITG *ndirboun, ITG *nboun,
+                          double *xbounact, ITG *nk, double *vold, double *v,
+                          ITG *ipompc, ITG *nodempc, double *coefmpc, ITG *nmpc,
+                          ITG *inomat, ITG *mi));
 
-void FORTRAN(applympc,(ITG *nface,ITG *ielfa,ITG *is,ITG *ie,ITG *ifabou,
-                       ITG *ipompc,double *vfa,double *coefmpc,ITG *nodempc,
-                       ITG *ipnei,ITG *neifa,char *labmpc,double *xbounact,
-                       ITG *nactdoh,ITG *ifaext,ITG *nfaext));
+void FORTRAN(applympc, (ITG * nface, ITG *ielfa, ITG *is, ITG *ie, ITG *ifabou,
+                        ITG *ipompc, double *vfa, double *coefmpc, ITG *nodempc,
+                        ITG *ipnei, ITG *neifa, char *labmpc, double *xbounact,
+                        ITG *nactdoh, ITG *ifaext, ITG *nfaext));
 
-void FORTRAN(applympc_dpel,(ITG *nface,ITG *ielfa,double *xrlfa,double *vel,
-             double *vfa,ITG *ifabou,double *xbounact,ITG *nef,
-             double *gradpcel,double *gradpcfa,ITG *neifa,double *rf,
-             double *area,double *volume,double *xle,double *xxi,
-             ITG *icyclic,double *xxn,ITG *ipnei,ITG *ifatie,
-             double *coefmpc,ITG *nmpc,char *labmpc,ITG *ipompc,
-             ITG *nodempc,ITG *ifaext,ITG *nfaext,ITG *nactdoh,
-             ITG *iflag,double *xxj,double *xlet));
+void FORTRAN(applympc_dpel, (ITG * nface, ITG *ielfa, double *xrlfa, double *vel,
+                             double *vfa, ITG *ifabou, double *xbounact, ITG *nef,
+                             double *gradpcel, double *gradpcfa, ITG *neifa, double *rf,
+                             double *area, double *volume, double *xle, double *xxi,
+                             ITG *icyclic, double *xxn, ITG *ipnei, ITG *ifatie,
+                             double *coefmpc, ITG *nmpc, char *labmpc, ITG *ipompc,
+                             ITG *nodempc, ITG *ifaext, ITG *nfaext, ITG *nactdoh,
+                             ITG *iflag, double *xxj, double *xlet));
 
-void FORTRAN(applympc_hfa,(ITG *nface,ITG *ielfa,ITG *is,ITG *ie,ITG *ifabou,
-                       ITG *ipompc,double *hfa,double *coefmpc,ITG *nodempc,
-                       ITG *ipnei,ITG *neifa,char *labmpc,double *xbounact,
-                       ITG *nactdoh));
+void FORTRAN(applympc_hfa, (ITG * nface, ITG *ielfa, ITG *is, ITG *ie, ITG *ifabou,
+                            ITG *ipompc, double *hfa, double *coefmpc, ITG *nodempc,
+                            ITG *ipnei, ITG *neifa, char *labmpc, double *xbounact,
+                            ITG *nactdoh));
 
-void arpack(double *co,ITG *nk,ITG **konp,ITG **ipkonp,char **lakonp,
-             ITG *ne,
-             ITG *nodeboun,ITG *ndirboun,double *xboun,ITG *nboun,
-             ITG *ipompc,ITG *nodempc,double *coefmpc,char *labmpc,
-             ITG *nmpc,
-             ITG *nodeforc,ITG *ndirforc,double *xforc,ITG *nforc,
-             ITG *nelemload,char *sideload,double *xload,
-             ITG *nload,
-             ITG *nactdof,
-             ITG *icol,ITG *jq,ITG **irowp,ITG *neq,ITG *nzl,
-             ITG *nmethod,ITG *ikmpc,ITG *ilmpc,ITG *ikboun,
-             ITG *ilboun,
-             double *elcon,ITG *nelcon,double *rhcon,ITG *nrhcon,
-             double *shcon,ITG *nshcon,double *cocon,ITG *ncocon,
-             double *alcon,ITG *nalcon,double *alzero,ITG **ielmatp,
-             ITG **ielorienp,ITG *norien,double *orab,ITG *ntmat_,
-             double *t0,double *t1,double *t1old,
-             ITG *ithermal,double *prestr,ITG *iprestr,
-             double *vold,ITG *iperturb,double *sti,ITG *nzs,
-             ITG *kode,ITG *mei,double *fei,char *filab,
-             ITG *iexpl,double *plicon,ITG *nplicon,double *plkcon,
-             ITG *nplkcon,
-             double **xstatep,ITG *npmat_,char *matname,ITG *mi,
-             ITG *ncmat_,ITG *nstate_,double **enerp,char *jobnamec,
-             char *output,char *set,ITG *nset,ITG *istartset,
-             ITG *iendset,ITG *ialset,ITG *nprint,char *prlab,
-             char *prset,ITG *nener,ITG *isolver,double *trab,
-             ITG *inotr,ITG *ntrans,double *ttime,double *fmpc,
-             ITG *ipobody,ITG *ibody,double *xbody,ITG *nbody,double *thicke,
-             ITG *nslavs,double *tietol,ITG *nkon,ITG *mpcinfo,ITG *ntie,
-             ITG *istep,ITG *mcs,ITG *ics,char *tieset,
-             double *cs,ITG *nintpoint,ITG *mortar,ITG *ifacecount,
-             ITG **islavsurfp,double **pslavsurfp,double **clearinip,
-             ITG *nmat,char *typeboun,ITG *ielprop,double *prop,
-	    char *orname,ITG *inewton,double *t0g,double *t1g);
+void arpack(double *co, ITG *nk, ITG **konp, ITG **ipkonp, char **lakonp,
+            ITG *ne,
+            ITG *nodeboun, ITG *ndirboun, double *xboun, ITG *nboun,
+            ITG *ipompc, ITG *nodempc, double *coefmpc, char *labmpc,
+            ITG *nmpc,
+            ITG *nodeforc, ITG *ndirforc, double *xforc, ITG *nforc,
+            ITG *nelemload, char *sideload, double *xload,
+            ITG *nload,
+            ITG *nactdof,
+            ITG *icol, ITG *jq, ITG **irowp, ITG *neq, ITG *nzl,
+            ITG *nmethod, ITG *ikmpc, ITG *ilmpc, ITG *ikboun,
+            ITG *   ilboun,
+            double *elcon, ITG *nelcon, double *rhcon, ITG *nrhcon,
+            double *shcon, ITG *nshcon, double *cocon, ITG *ncocon,
+            double *alcon, ITG *nalcon, double *alzero, ITG **ielmatp,
+            ITG **ielorienp, ITG *norien, double *orab, ITG *ntmat_,
+            double *t0, double *t1, double *t1old,
+            ITG *ithermal, double *prestr, ITG *iprestr,
+            double *vold, ITG *iperturb, double *sti, ITG *nzs,
+            ITG *kode, ITG *mei, double *fei, char *filab,
+            ITG *iexpl, double *plicon, ITG *nplicon, double *plkcon,
+            ITG *    nplkcon,
+            double **xstatep, ITG *npmat_, char *matname, ITG *mi,
+            ITG *ncmat_, ITG *nstate_, double **enerp, char *jobnamec,
+            char *output, char *set, ITG *nset, ITG *istartset,
+            ITG *iendset, ITG *ialset, ITG *nprint, char *prlab,
+            char *prset, ITG *nener, ITG *isolver, double *trab,
+            ITG *inotr, ITG *ntrans, double *ttime, double *fmpc,
+            ITG *ipobody, ITG *ibody, double *xbody, ITG *nbody, double *thicke,
+            ITG *nslavs, double *tietol, ITG *nkon, ITG *mpcinfo, ITG *ntie,
+            ITG *istep, ITG *mcs, ITG *ics, char *tieset,
+            double *cs, ITG *nintpoint, ITG *mortar, ITG *ifacecount,
+            ITG **islavsurfp, double **pslavsurfp, double **clearinip,
+            ITG *nmat, char *typeboun, ITG *ielprop, double *prop,
+            char *orname, ITG *inewton, double *t0g, double *t1g);
 
-void arpackbu(double *co,ITG *nk,ITG *kon,ITG *ipkon,char *lakon,
-	      ITG *ne,
-	      ITG *nodeboun,ITG *ndirboun,double *xboun,ITG *nboun,
-	      ITG *ipompc,ITG *nodempc,double *coefmpc,char *labmpc,
-	      ITG *nmpc,
-	      ITG *nodeforc,ITG *ndirforc,double *xforc,ITG *nforc,
-	      ITG *nelemload,char *sideload,double *xload,
-	      ITG *nload,
-	      ITG *nactdof,
-	      ITG *icol,ITG *jq,ITG *irow,ITG *neq,ITG *nzl,
-	      ITG *nmethod,ITG *ikmpc,ITG *ilmpc,ITG *ikboun,
-	      ITG *ilboun,
-	      double *elcon,ITG *nelcon,double *rhcon,ITG *nrhcon,
-	      double *alcon,ITG *nalcon,double *alzero,ITG *ielmat,
-	      ITG *ielorien,ITG *norien,double *orab,ITG *ntmat_,
-	      double *t0,double *t1,double *t1old,
-	      ITG *ithermal,double *prestr,ITG *iprestr,
-	      double *vold,ITG *iperturb,double *sti,ITG *nzs,
-	      ITG *kode,ITG *mei,double *fei,
-	      char *filab,double *eme,
-	      ITG *iexpl,double *plicon,ITG *nplicon,double *plkcon,
-	      ITG *nplkcon,
-	      double *xstate,ITG *npmat_,char *matname,ITG *mi,
-	      ITG *ncmat_,ITG *nstate_,double *ener,char *output,
-	      char *set,ITG *nset,ITG *istartset,
-	      ITG *iendset,ITG *ialset,ITG *nprint,char *prlab,
-	      char *prset,ITG *nener,ITG *isolver,double *trab,
-	      ITG *inotr,ITG *ntrans,double *ttime,double *fmpc,
-	      ITG *ipobody,ITG *ibody,double *xbody,ITG *nbody,
-	      double *thicke,char *jobnamec,ITG *nmat,ITG *ielprop,
-	      double *prop,char *orname,char *typeboun,double *t0g,
-	      double *t1g);
+void arpackbu(double *co, ITG *nk, ITG *kon, ITG *ipkon, char *lakon,
+              ITG *ne,
+              ITG *nodeboun, ITG *ndirboun, double *xboun, ITG *nboun,
+              ITG *ipompc, ITG *nodempc, double *coefmpc, char *labmpc,
+              ITG *nmpc,
+              ITG *nodeforc, ITG *ndirforc, double *xforc, ITG *nforc,
+              ITG *nelemload, char *sideload, double *xload,
+              ITG *nload,
+              ITG *nactdof,
+              ITG *icol, ITG *jq, ITG *irow, ITG *neq, ITG *nzl,
+              ITG *nmethod, ITG *ikmpc, ITG *ilmpc, ITG *ikboun,
+              ITG *   ilboun,
+              double *elcon, ITG *nelcon, double *rhcon, ITG *nrhcon,
+              double *alcon, ITG *nalcon, double *alzero, ITG *ielmat,
+              ITG *ielorien, ITG *norien, double *orab, ITG *ntmat_,
+              double *t0, double *t1, double *t1old,
+              ITG *ithermal, double *prestr, ITG *iprestr,
+              double *vold, ITG *iperturb, double *sti, ITG *nzs,
+              ITG *kode, ITG *mei, double *fei,
+              char *filab, double *eme,
+              ITG *iexpl, double *plicon, ITG *nplicon, double *plkcon,
+              ITG *   nplkcon,
+              double *xstate, ITG *npmat_, char *matname, ITG *mi,
+              ITG *ncmat_, ITG *nstate_, double *ener, char *output,
+              char *set, ITG *nset, ITG *istartset,
+              ITG *iendset, ITG *ialset, ITG *nprint, char *prlab,
+              char *prset, ITG *nener, ITG *isolver, double *trab,
+              ITG *inotr, ITG *ntrans, double *ttime, double *fmpc,
+              ITG *ipobody, ITG *ibody, double *xbody, ITG *nbody,
+              double *thicke, char *jobnamec, ITG *nmat, ITG *ielprop,
+              double *prop, char *orname, char *typeboun, double *t0g,
+              double *t1g);
 
-void arpackcs(double *co,ITG *nk,ITG **konp,ITG **ipkonp,char **lakonp,
-             ITG *ne,
-             ITG *nodeboun,ITG *ndirboun,double *xboun,ITG *nboun,
-             ITG *ipompc,ITG *nodempc,double *coefmpc,char *labmpc,
-             ITG *nmpc,
-             ITG *nodeforc,ITG *ndirforc,double *xforc,ITG *nforc,
-             ITG *nelemload,char *sideload,double *xload,
-             ITG *nload,ITG *nactdof,
-             ITG *icol,ITG *jq,ITG **irowp,ITG *neq,ITG *nzl,
-             ITG *nmethod,ITG *ikmpc,ITG *ilmpc,ITG *ikboun,
-             ITG *ilboun,
-             double *elcon,ITG *nelcon,double *rhcon,ITG *nrhcon,
-             double *alcon,ITG *nalcon,double *alzero,ITG **ielmatp,
-             ITG **ielorienp,ITG *norien,double *orab,ITG *ntmat_,
-             double *t0,double *t1,double *t1old,
-             ITG *ithermal,double *prestr,ITG *iprestr,
-             double *vold,ITG *iperturb,double *sti,ITG *nzs,
-             ITG *kode,ITG *mei,double *fei,
-             char *filab,
-             ITG *iexpl,double *plicon,ITG *nplicon,double *plkcon,
-             ITG *nplkcon,
-             double **xstatep,ITG *npmat_,char *matname,ITG *mi,
-             ITG *ics,double *cs,ITG *mpcend,ITG *ncmat_,ITG *nstate_,
-             ITG *mcs,ITG *nkon,char *jobnamec,
-             char *output,char *set,ITG *nset,ITG *istartset,
-             ITG *iendset,ITG *ialset,ITG *nprint,char *prlab,
-             char *prset,ITG *nener,ITG *isolver,double *trab,
-             ITG *inotr,ITG *ntrans,double *ttime,double *fmpc,
-             ITG *ipobody,ITG *ibody,double *xbody,ITG *nbody,
-             ITG *nevtot,double *thicke,ITG *nslavs,double *tietol,
-             ITG *mpcinfo,ITG *ntie,ITG *istep,
-             char *tieset,ITG *nintpoint,ITG *mortar,ITG *ifacecount,
-             ITG **islavsurfp,double **pslavsurfp,double **clearinip,
-             ITG *nmat,char *typeboun,ITG *ielprop,double *prop,
-	      char *orname,ITG *inewton,double *t0g,double *t1g);
+void arpackcs(double *co, ITG *nk, ITG **konp, ITG **ipkonp, char **lakonp,
+              ITG *ne,
+              ITG *nodeboun, ITG *ndirboun, double *xboun, ITG *nboun,
+              ITG *ipompc, ITG *nodempc, double *coefmpc, char *labmpc,
+              ITG *nmpc,
+              ITG *nodeforc, ITG *ndirforc, double *xforc, ITG *nforc,
+              ITG *nelemload, char *sideload, double *xload,
+              ITG *nload, ITG *nactdof,
+              ITG *icol, ITG *jq, ITG **irowp, ITG *neq, ITG *nzl,
+              ITG *nmethod, ITG *ikmpc, ITG *ilmpc, ITG *ikboun,
+              ITG *   ilboun,
+              double *elcon, ITG *nelcon, double *rhcon, ITG *nrhcon,
+              double *alcon, ITG *nalcon, double *alzero, ITG **ielmatp,
+              ITG **ielorienp, ITG *norien, double *orab, ITG *ntmat_,
+              double *t0, double *t1, double *t1old,
+              ITG *ithermal, double *prestr, ITG *iprestr,
+              double *vold, ITG *iperturb, double *sti, ITG *nzs,
+              ITG *kode, ITG *mei, double *fei,
+              char *filab,
+              ITG *iexpl, double *plicon, ITG *nplicon, double *plkcon,
+              ITG *    nplkcon,
+              double **xstatep, ITG *npmat_, char *matname, ITG *mi,
+              ITG *ics, double *cs, ITG *mpcend, ITG *ncmat_, ITG *nstate_,
+              ITG *mcs, ITG *nkon, char *jobnamec,
+              char *output, char *set, ITG *nset, ITG *istartset,
+              ITG *iendset, ITG *ialset, ITG *nprint, char *prlab,
+              char *prset, ITG *nener, ITG *isolver, double *trab,
+              ITG *inotr, ITG *ntrans, double *ttime, double *fmpc,
+              ITG *ipobody, ITG *ibody, double *xbody, ITG *nbody,
+              ITG *nevtot, double *thicke, ITG *nslavs, double *tietol,
+              ITG *mpcinfo, ITG *ntie, ITG *istep,
+              char *tieset, ITG *nintpoint, ITG *mortar, ITG *ifacecount,
+              ITG **islavsurfp, double **pslavsurfp, double **clearinip,
+              ITG *nmat, char *typeboun, ITG *ielprop, double *prop,
+              char *orname, ITG *inewton, double *t0g, double *t1g);
 
-void FORTRAN(assigndomtonodes,(ITG *ne,char *lakon,ITG *ipkon,ITG *kon,
-             ITG *ielmat,ITG *inomat,double *elcon,ITG *ncmat_,ITG *ntmat_,
-             ITG *mi,ITG *ne2));
+void FORTRAN(assigndomtonodes, (ITG * ne, char *lakon, ITG *ipkon, ITG *kon,
+                                ITG *ielmat, ITG *inomat, double *elcon, ITG *ncmat_, ITG *ntmat_,
+                                ITG *mi, ITG *ne2));
 
-void FORTRAN(auglag_inclusion,(double *gcontfull,double *cvec,ITG *nacti,
-			       ITG *iacti,ITG *ncdim,double*mufric,double*atol,
-			       double*rtol,double*pkglob,ITG*kitermax,
-			       double *auw,ITG *jqw,ITG *iroww,
-			       ITG *nslavs,double *pkvec,double *pkvecnew,
-			       double *eps_al));
+void FORTRAN(auglag_inclusion, (double *gcontfull, double *cvec, ITG *nacti,
+                                ITG *iacti, ITG *ncdim, double *mufric, double *atol,
+                                double *rtol, double *pkglob, ITG *kitermax,
+                                double *auw, ITG *jqw, ITG *iroww,
+                                ITG *nslavs, double *pkvec, double *pkvecnew,
+                                double *eps_al));
 
-void FORTRAN(autocovmatrix,(double *co,double *ad,double *au,ITG *jqs,
-			    ITG *irows,ITG *ndesi,ITG *nodedesi,double *corrlen,
-			    double *randomval,ITG *irobustdesign));
+void FORTRAN(autocovmatrix, (double *co, double *ad, double *au, ITG *jqs,
+                             ITG *irows, ITG *ndesi, ITG *nodedesi, double *corrlen,
+                             double *randomval, ITG *irobustdesign));
 
-void FORTRAN(basis,(double *x,double *y,double *z,double *xo,double *yo,
-                    double *zo,ITG *nx,ITG *ny,ITG *nz,double *planfa,
-                    ITG *ifatet,ITG *nktet,ITG *netet,double *field,
-                    ITG *nfield,double *cotet,ITG *kontyp,ITG *ipkon,
-                    ITG *kon,ITG *iparent,double *xp,double *yp,double *zp,
-                    double *value,double *ratio,ITG *iselect,ITG *nselect,
-                    ITG *istartset,ITG *iendset,ITG *ialset,ITG *imastset,
-                    ITG *ielemnr,ITG *nterms,ITG *konl));
+void FORTRAN(basis, (double *x, double *y, double *z, double *xo, double *yo,
+                     double *zo, ITG *nx, ITG *ny, ITG *nz, double *planfa,
+                     ITG *ifatet, ITG *nktet, ITG *netet, double *field,
+                     ITG *nfield, double *cotet, ITG *kontyp, ITG *ipkon,
+                     ITG *kon, ITG *iparent, double *xp, double *yp, double *zp,
+                     double *value, double *ratio, ITG *iselect, ITG *nselect,
+                     ITG *istartset, ITG *iendset, ITG *ialset, ITG *imastset,
+                     ITG *ielemnr, ITG *nterms, ITG *konl));
 
-void biosav(ITG *ipkon,ITG *kon,char *lakon,ITG *ne,double *co,
-            double *qfx,double *h0,ITG *mi,ITG *inomat,ITG *nk);
+void biosav(ITG *ipkon, ITG *kon, char *lakon, ITG *ne, double *co,
+            double *qfx, double *h0, ITG *mi, ITG *inomat, ITG *nk);
 
-void FORTRAN(biotsavart,(ITG *ipkon,ITG *kon,char *lakon,ITG *ne,double *co,
-                         double *qfx,double *h0,ITG *mi,ITG *nka,ITG *nkb));
+void FORTRAN(biotsavart, (ITG * ipkon, ITG *kon, char *lakon, ITG *ne, double *co,
+                          double *qfx, double *h0, ITG *mi, ITG *nka, ITG *nkb));
 
 void *biotsavartmt(ITG *i);
 
-void FORTRAN(blockanalysis,(char *set,ITG *nset,ITG *istartset,ITG *iendset,
-             ITG *ialset,ITG *nblk,ITG *ipkon,ITG *kon,ITG *ielfa,
-             ITG *nodface,ITG *neiel,ITG *neij,ITG *neifa,ITG *ipoface,
-             ITG *ipnei,ITG *konf,ITG *istartblk,ITG *iendblk,ITG *nactdoh,
-             ITG *nblket,ITG *nblkze,ITG *nef,ITG *ielblk,ITG *nk,
-             ITG *nactdohinv));
+void FORTRAN(blockanalysis, (char *set, ITG *nset, ITG *istartset, ITG *iendset,
+                             ITG *ialset, ITG *nblk, ITG *ipkon, ITG *kon, ITG *ielfa,
+                             ITG *nodface, ITG *neiel, ITG *neij, ITG *neifa, ITG *ipoface,
+                             ITG *ipnei, ITG *konf, ITG *istartblk, ITG *iendblk, ITG *nactdoh,
+                             ITG *nblket, ITG *nblkze, ITG *nef, ITG *ielblk, ITG *nk,
+                             ITG *nactdohinv));
 
-void FORTRAN(bodyforce,(char *cbody,ITG *ibody,ITG *ipobody,ITG *nbody,
-             char *set,ITG *istartset,ITG *iendset,ITG *ialset,
-             ITG *inewton,ITG *nset,ITG *ifreebody,ITG *k));
+void FORTRAN(bodyforce, (char *cbody, ITG *ibody, ITG *ipobody, ITG *nbody,
+                         char *set, ITG *istartset, ITG *iendset, ITG *ialset,
+                         ITG *inewton, ITG *nset, ITG *ifreebody, ITG *k));
 
-void FORTRAN(calcdatarget,(ITG *ifront,double *co,ITG *nnfront,
-			   ITG *istartfront,ITG *iendfront,ITG *isubsurffront,
-			   double *tinc,double *datarget,double *acrack,
-			   ITG *nstep));
+void FORTRAN(calcdatarget, (ITG * ifront, double *co, ITG *nnfront,
+                            ITG *istartfront, ITG *iendfront, ITG *isubsurffront,
+                            double *tinc, double *datarget, double *acrack,
+                            ITG *nstep));
 
-void FORTRAN(calcenergy,(ITG *ipkon,char *lakon,ITG *kon,double *co,
-                         double *ener,ITG *mi,ITG *ne,double *thicke,
-                         ITG *ielmat,
-                         double *energy,ITG *ielprop,double *prop,ITG *nea,
-                         ITG *neb));
+void FORTRAN(calcenergy, (ITG * ipkon, char *lakon, ITG *kon, double *co,
+                          double *ener, ITG *mi, ITG *ne, double *thicke,
+                          ITG *   ielmat,
+                          double *energy, ITG *ielprop, double *prop, ITG *nea,
+                          ITG *neb));
 
 void *calcenergymt(ITG *i);
 
-void FORTRAN(calcexternalwork,(double *co,double *vold,ITG *istartset,
-			       ITG *iendset,ITG *ipkon,char *lakon,ITG *kon,
-			       ITG *ialset,ITG *nset,char *set,ITG *mi,
-			       char *externalfaces,ITG *nelemload,ITG *nload,
-			       double *xload,char *sideload,
-			       double *delexternalwork,double *voldprev));
+void FORTRAN(calcexternalwork, (double *co, double *vold, ITG *istartset,
+                                ITG *iendset, ITG *ipkon, char *lakon, ITG *kon,
+                                ITG *ialset, ITG *nset, char *set, ITG *mi,
+                                char *externalfaces, ITG *nelemload, ITG *nload,
+                                double *xload, char *sideload,
+                                double *delexternalwork, double *voldprev));
 
-void FORTRAN(calch0interface,(ITG *nmpc,ITG *ipompc,ITG *nodempc,
-                              double *coefmpc,double *h0));
-                      
-void FORTRAN(calcmac,(ITG *neq,double *z,double *zz,ITG *nev,double *mac,
-                      double* maccpx,ITG *istartnmd,ITG *iendnmd,ITG *nmd,
-                      ITG *cyclicsymmetry,ITG *neqact,double *bett,
-                      double *betm,ITG *nevcomplex));
+void FORTRAN(calch0interface, (ITG * nmpc, ITG *ipompc, ITG *nodempc,
+                               double *coefmpc, double *h0));
 
-void FORTRAN(calcmach,(double *vold,double *v,ITG *nk,ITG *ntmat_,
-		       double *shcon,ITG *nshcon,double *physcon,ITG *inomat,
-		       ITG *mi));
+void FORTRAN(calcmac, (ITG * neq, double *z, double *zz, ITG *nev, double *mac,
+                       double *maccpx, ITG *istartnmd, ITG *iendnmd, ITG *nmd,
+                       ITG *cyclicsymmetry, ITG *neqact, double *bett,
+                       double *betm, ITG *nevcomplex));
 
-void FORTRAN(calcmass,(ITG *ipkon,char *lakon,ITG *kon,double *co,ITG *mi,
-             ITG *nelem,ITG *ne,double *thicke,ITG *ielmat,
-             ITG *nope,double *t0,double *rhcon,
-             ITG *nrhcon,ITG *ntmat_,ITG *ithermal,double *csmass,
-             ITG *ielprop,double *prop));
+void FORTRAN(calcmach, (double *vold, double *v, ITG *nk, ITG *ntmat_,
+                        double *shcon, ITG *nshcon, double *physcon, ITG *inomat,
+                        ITG *mi));
 
-void FORTRAN(calcpel,(ITG *ne,ITG *nactdoh,double *vel,double *b,ITG *nef));
+void FORTRAN(calcmass, (ITG * ipkon, char *lakon, ITG *kon, double *co, ITG *mi,
+                        ITG *nelem, ITG *ne, double *thicke, ITG *ielmat,
+                        ITG *nope, double *t0, double *rhcon,
+                        ITG *nrhcon, ITG *ntmat_, ITG *ithermal, double *csmass,
+                        ITG *ielprop, double *prop));
 
-void calcresidual(ITG *nmethod,ITG *neq,double *b,double *fext,double *f,
-        ITG *iexpl,ITG *nactdof,double *aux2,double *vold,
-        double *vini,double *dtime,double *accold,ITG *nk,double *adb,
-        double *aub,ITG *icol,ITG *irow,ITG *nzl,double *alpha,
-        double *fextini,double *fini,ITG *islavnode,ITG *nslavnode,
-        ITG *mortar,ITG *ntie,
-        double *f_cm,double *f_cs,ITG *mi,ITG *nzs,ITG *nasym,
-        ITG *idamping,double *veold,double *adc,double *auc,double *cvini,
-        double *cv,double *alpham,ITG *num_cpus);
+void FORTRAN(calcpel, (ITG * ne, ITG *nactdoh, double *vel, double *b, ITG *nef));
 
-void calcresidual_em(ITG *nmethod,ITG *neq,double *b,double *fext,double *f,
-        ITG *iexpl,ITG *nactdof,double *aux1,double *aux2,double *vold,
-        double *vini,double *dtime,double *accold,ITG *nk,double *adb,
-        double *aub,ITG *icol,ITG *irow,ITG *nzl,double *alpha,
-        double *fextini,double *fini,ITG *islavnode,ITG *nslavnode,
-        ITG *mortar,ITG *ntie,
-        double *f_cm,double *f_cs,ITG *mi,ITG *nzs,ITG *nasym,ITG *ithermal);
+void calcresidual(ITG *nmethod, ITG *neq, double *b, double *fext, double *f,
+                  ITG *iexpl, ITG *nactdof, double *aux2, double *vold,
+                  double *vini, double *dtime, double *accold, ITG *nk, double *adb,
+                  double *aub, ITG *icol, ITG *irow, ITG *nzl, double *alpha,
+                  double *fextini, double *fini, ITG *islavnode, ITG *nslavnode,
+                  ITG *mortar, ITG *ntie,
+                  double *f_cm, double *f_cs, ITG *mi, ITG *nzs, ITG *nasym,
+                  ITG *idamping, double *veold, double *adc, double *auc, double *cvini,
+                  double *cv, double *alpham, ITG *num_cpus);
 
-void calcshapef(ITG *nvar_,ITG *ipvar,double **var,ITG *ne,
-		char *lakon,double *co,ITG *ipkon,ITG *kon,
-		ITG *nelemface,char *sideface,ITG *nface,
-		ITG *nvarf_,ITG *ipvarf,double **varfp,
-		ITG *iturbulent,double *yy);
+void calcresidual_em(ITG *nmethod, ITG *neq, double *b, double *fext, double *f,
+                     ITG *iexpl, ITG *nactdof, double *aux1, double *aux2, double *vold,
+                     double *vini, double *dtime, double *accold, ITG *nk, double *adb,
+                     double *aub, ITG *icol, ITG *irow, ITG *nzl, double *alpha,
+                     double *fextini, double *fini, ITG *islavnode, ITG *nslavnode,
+                     ITG *mortar, ITG *ntie,
+                     double *f_cm, double *f_cs, ITG *mi, ITG *nzs, ITG *nasym, ITG *ithermal);
 
-void FORTRAN(calcstabletimeinccont,(ITG *ne,char *lakon,ITG *kon,ITG *ipkon,
-             ITG *mi,ITG *ielmat,double *elcon,ITG *mortar,double *adb,
-             double *alpha,ITG *nactdof,double *springarea,ITG *ne0,
-             ITG *ntmat_,ITG *ncmat_,double *dtcont,double *smscale,
-             double *dtset,ITG *mscalmethod));
+void calcshapef(ITG *nvar_, ITG *ipvar, double **var, ITG *ne,
+                char *lakon, double *co, ITG *ipkon, ITG *kon,
+                ITG *nelemface, char *sideface, ITG *nface,
+                ITG *nvarf_, ITG *ipvarf, double **varfp,
+                ITG *iturbulent, double *yy);
 
-void FORTRAN(calcstabletimeincvol,(ITG *ne0,double *elcon,ITG *nelcon,
-            double *rhcon,ITG *nrhcon,double *alcon,ITG *nalcon,double *orab,
-            ITG *ntmat_,ITG *ithermal,double *alzero,double *plicon,
-            ITG *nplicon,double *plkcon,ITG *nplkcon,ITG *npmat_,ITG *mi,
-            double *dtime,double *xstiff,ITG *ncmat_,double *vold,ITG *ielmat,
-            double *t0,double *t1,char *matname,char *lakon,
-            double *xmatwavespeed,ITG *nmat,ITG *ipkon,double *co,ITG *kon,
-            double *dtvol,double *alpha,double *smscale,double *dtset,
-            ITG *mscalmethod));
+void FORTRAN(calcstabletimeinccont, (ITG * ne, char *lakon, ITG *kon, ITG *ipkon,
+                                     ITG *mi, ITG *ielmat, double *elcon, ITG *mortar, double *adb,
+                                     double *alpha, ITG *nactdof, double *springarea, ITG *ne0,
+                                     ITG *ntmat_, ITG *ncmat_, double *dtcont, double *smscale,
+                                     double *dtset, ITG *mscalmethod));
 
-void FORTRAN(calcstressheatfluxfem,(ITG *kon,char *lakon,ITG *ipkon,ITG *ielmat,
-             ITG *ntmat_,double *vold,char *matname,ITG *mi,double *shcon,
-             ITG *nshcon,ITG *turbulent,ITG *compressible,ITG *ipvar,
-             double *var,double *sti,double *qfx,double *cocon,ITG *ncocon,
-	     ITG *ne,ITG *isti,ITG *iqfx,ITG *ithermal,double *rhcon,
-	     ITG *nrhcon,double *vcon,ITG *nk));
+void FORTRAN(calcstabletimeincvol, (ITG * ne0, double *elcon, ITG *nelcon,
+                                    double *rhcon, ITG *nrhcon, double *alcon, ITG *nalcon, double *orab,
+                                    ITG *ntmat_, ITG *ithermal, double *alzero, double *plicon,
+                                    ITG *nplicon, double *plkcon, ITG *nplkcon, ITG *npmat_, ITG *mi,
+                                    double *dtime, double *xstiff, ITG *ncmat_, double *vold, ITG *ielmat,
+                                    double *t0, double *t1, char *matname, char *lakon,
+                                    double *xmatwavespeed, ITG *nmat, ITG *ipkon, double *co, ITG *kon,
+                                    double *dtvol, double *alpha, double *smscale, double *dtset,
+                                    ITG *mscalmethod));
 
-void FORTRAN(calcttel,(ITG *nef,double *vel,double *shcon,ITG *nshcon,
-                       ITG *ielmatf,ITG *ntmat_,ITG *mi,double *physcon,
-                       double *ttel));
+void FORTRAN(calcstressheatfluxfem, (ITG * kon, char *lakon, ITG *ipkon, ITG *ielmat,
+                                     ITG *ntmat_, double *vold, char *matname, ITG *mi, double *shcon,
+                                     ITG *nshcon, ITG *turbulent, ITG *compressible, ITG *ipvar,
+                                     double *var, double *sti, double *qfx, double *cocon, ITG *ncocon,
+                                     ITG *ne, ITG *isti, ITG *iqfx, ITG *ithermal, double *rhcon,
+                                     ITG *nrhcon, double *vcon, ITG *nk));
 
-void FORTRAN(calcttfaext,(ITG *nfaext,double *vfa,double *shcon,ITG *nshcon,
-                          ITG *ielmatf,ITG *ntmat_,ITG *mi,double *physcon,
-                          double *ttfa,ITG *ifaext,ITG *ielfa));
+void FORTRAN(calcttel, (ITG * nef, double *vel, double *shcon, ITG *nshcon,
+                        ITG *ielmatf, ITG *ntmat_, ITG *mi, double *physcon,
+                        double *ttel));
 
-void FORTRAN(calculated,(ITG *nktet,double *d,double *dmin,
-                             ITG *ipoed,ITG *iedg,double *cotet));
+void FORTRAN(calcttfaext, (ITG * nfaext, double *vfa, double *shcon, ITG *nshcon,
+                           ITG *ielmatf, ITG *ntmat_, ITG *mi, double *physcon,
+                           double *ttfa, ITG *ifaext, ITG *ielfa));
 
-void FORTRAN(calculateh,(ITG *nk,double *v,double *veold,double *stn,
-                         double *een,double *emn,double *epn,double *enern,
-                         double *qfn,double *errn,double *h,char *filab,
-                         ITG *mi,double *d,ITG *nh,double *dmin,ITG *ipoed,
-                         ITG *iedg,double *cotet,ITG *jfix));
+void FORTRAN(calculated, (ITG * nktet, double *d, double *dmin,
+                          ITG *ipoed, ITG *iedg, double *cotet));
 
-void FORTRAN(calculatehmid,(ITG *nktet_,double *h,ITG *ipoed,ITG *iedg,
-			    ITG *iedgmid));
+void FORTRAN(calculateh, (ITG * nk, double *v, double *veold, double *stn,
+                          double *een, double *emn, double *epn, double *enern,
+                          double *qfn, double *errn, double *h, char *filab,
+                          ITG *mi, double *d, ITG *nh, double *dmin, ITG *ipoed,
+                          ITG *iedg, double *cotet, ITG *jfix));
 
-void CalculiXstep(int argc,char argv[][133],ITG **nelemloadp,double **xloadp,
-		  ITG *nload,char **sideloadp,double *timepar,ITG *ne,
-                  ITG **ipkonp,ITG **konp,char **lakonp,ITG *nk,double **cop,
-                  double **voldp,double **veoldp,double **accoldp,
-                  ITG *nboun,ITG **ikbounp,ITG **ilbounp,double **xbounp,
-                  ITG *nmethod,char *externalfaces,double *delexternalwork,
-                  ITG *inputsteps,ITG *iperturb,ITG *irstrt,char **filabp,
+void FORTRAN(calculatehmid, (ITG * nktet_, double *h, ITG *ipoed, ITG *iedg,
+                             ITG *iedgmid));
+
+void CalculiXstep(int argc, char argv[][133], ITG **nelemloadp, double **xloadp,
+                  ITG *nload, char **sideloadp, double *timepar, ITG *ne,
+                  ITG **ipkonp, ITG **konp, char **lakonp, ITG *nk, double **cop,
+                  double **voldp, double **veoldp, double **accoldp,
+                  ITG *nboun, ITG **ikbounp, ITG **ilbounp, double **xbounp,
+                  ITG *nmethod, char *externalfaces, double *delexternalwork,
+                  ITG *inputsteps, ITG *iperturb, ITG *irstrt, char **filabp,
                   ITG *nlabel);
 
-void FORTRAN(calcvel,(ITG *ne,ITG *nactdoh,double *vel,double *b,
-                      ITG *neq,ITG *nef));
+void FORTRAN(calcvel, (ITG * ne, ITG *nactdoh, double *vel, double *b,
+                       ITG *neq, ITG *nef));
 
-void FORTRAN(calcview,(char *sideload,double *vold,double *co,
-             double *pmid,double *e1,double *e2,double *e3,
-             ITG *kontri,ITG *nloadtr,double *adview,double *auview,
-             double *dist,ITG *idist,double *area,ITG *ntrit,ITG *mi,ITG *jqrad,
-             ITG *irowrad,ITG *nzsrad,double *sidemean,ITG *ntria,
-             ITG *ntrib,char *covered,ITG *ng));
+void FORTRAN(calcview, (char *sideload, double *vold, double *co,
+                        double *pmid, double *e1, double *e2, double *e3,
+                        ITG *kontri, ITG *nloadtr, double *adview, double *auview,
+                        double *dist, ITG *idist, double *area, ITG *ntrit, ITG *mi, ITG *jqrad,
+                        ITG *irowrad, ITG *nzsrad, double *sidemean, ITG *ntria,
+                        ITG *ntrib, char *covered, ITG *ng));
 
 void *calcviewmt(ITG *i);
 
-void FORTRAN(calinput,(double *co,ITG *nk,ITG *kon,ITG *ipkon,char *lakon,
-		       ITG *nkon,ITG *ne,
-		       ITG *nodeboun,ITG *ndirboun,double *xboun,ITG *nboun,
-		       ITG *ipompc,ITG *nodempc,double *coefmpc,ITG *nmpc,
-		       ITG *nmpc_,ITG *nodeforc,ITG *ndirforc,double *xforc,
-		       ITG *nforc,ITG *nforc_,ITG *nelemload,char *sideload,
-		       double *xload,ITG *nload,ITG *nload_,
-		       ITG *nprint,char *prlab,char *prset,ITG *mpcfree,
-		       ITG *nboun_,
-		       ITG *mei,char *set,ITG *istartset,
-		       ITG *iendset,ITG *ialset,ITG *nset,ITG *nalset,
-		       double *elcon,ITG *nelcon,double *rhcon,ITG *nrhcon,
-		       double *alcon,ITG *nalcon,double *alzero,double *t0,
-		       double *t1,char *matname,
-		       ITG *ielmat,char *orname,double *orab,ITG *ielorien,
-		       char *amname,double *amta,ITG *namta,ITG *nam,
-		       ITG *nmethod,ITG *iamforc,ITG *iamload,
-		       ITG *iamt1,ITG *ithermal,ITG *iperturb,
-		       ITG *istat,ITG *istep,ITG *nmat,
-		       ITG *ntmat_,ITG *norien,double *prestr,ITG *iprestr,
-		       ITG *isolver,double *fei,double *veold,double *timepar,
-		       double *xmodal,char *filab,ITG *jout,ITG *nlabel,
-		       ITG *idrct,ITG *jmax,ITG *iexpl,double *alpha,
-		       ITG *iamboun,
-		       double *plicon,ITG *nplicon,double *plkcon,ITG *nplkcon,
-		       ITG *iplas,ITG *npmat_,ITG *mi,ITG *nk_,
-		       double *trab,ITG *inotr,ITG *ntrans,ITG *ikboun,
-		       ITG *ilboun,ITG *ikmpc,ITG *ilmpc,ITG *ics,
-		       double *dcs,ITG *ncs_,ITG *namtot_,double *cs,
-		       ITG *nstate_,ITG *ncmat_,ITG *iumat,ITG *mcs,
-		       char *labmpc,ITG *iponor,double *xnor,ITG *knor,
-		       double *thickn,double *thicke,ITG *ikforc,ITG *ilforc,
-		       double *offset,ITG *iponoel,ITG *inoel,ITG *rig,
-		       ITG *infree,ITG *nshcon,double *shcon,double *cocon,
-		       ITG *ncocon,double *physcon,ITG *nflow,double *ctrl,
-		       ITG *maxlenmpc,ITG *ne1d,ITG *ne2d,ITG *nener,
-		       double *vold,ITG *nodebounold,
-		       ITG *ndirbounold,double *xbounold,double *xforcold,
-		       double *xloadold,double *t1old,double *eme,
-		       double *sti,double *ener,
-		       double *xstate,char *jobnamec,ITG *irstrt,
-		       double *ttime,double *qaold,
-		       char *output,char *typeboun,char *inpc,
-		       ITG *ipoinp,ITG *inp,char *tieset,double *tietol,
-		       ITG *ntie,double *fmpc,char *cbody,ITG *ibody,
-		       double *xbody,
-		       ITG *nbody,ITG *nbody_,double *xbodyold,ITG *nam_,
-		       ITG *ielprop,ITG *nprop,ITG *nprop_,double *prop,
-		       ITG *itpamp,ITG *iviewfile,ITG *ipoinpc,
-		       ITG *nslavs,double *t0g,double *t1g,ITG *network,
-		       ITG *cyclicsymmetry,ITG *idefforc,ITG *idefload,
-		       ITG *idefbody,ITG *mortar,ITG *ifacecount,ITG *islavsurf,
-		       double *pslavsurf,double *clearini,char *heading,
-		       ITG *iaxial,ITG *nobject,char *objectset,ITG *nprint_,
-		       ITG *iuel,ITG *nuel_,ITG *nodempcref,double *coefmpcref,
-		       ITG *ikmpcref,ITG *memmpcref_,ITG *mpcfreeref,
-		       ITG *maxlenmpcref,ITG *memmpc_,ITG *isens,ITG *namtot,
-		       ITG *stam,double *dacon,double *vel,ITG *nef,
-		       double *velo,double *veloo,ITG *ne2boun,ITG *itempuser,
-		       ITG *irobustdesign,ITG *irandomtype,double *randomval,
-		       ITG *nfc,ITG *nfc_,double *coeffc,ITG *idck,ITG *ndc,
-		       ITG *ndc_,double *edc));
+void FORTRAN(calinput, (double *co, ITG *nk, ITG *kon, ITG *ipkon, char *lakon,
+                        ITG *nkon, ITG *ne,
+                        ITG *nodeboun, ITG *ndirboun, double *xboun, ITG *nboun,
+                        ITG *ipompc, ITG *nodempc, double *coefmpc, ITG *nmpc,
+                        ITG *nmpc_, ITG *nodeforc, ITG *ndirforc, double *xforc,
+                        ITG *nforc, ITG *nforc_, ITG *nelemload, char *sideload,
+                        double *xload, ITG *nload, ITG *nload_,
+                        ITG *nprint, char *prlab, char *prset, ITG *mpcfree,
+                        ITG *nboun_,
+                        ITG *mei, char *set, ITG *istartset,
+                        ITG *iendset, ITG *ialset, ITG *nset, ITG *nalset,
+                        double *elcon, ITG *nelcon, double *rhcon, ITG *nrhcon,
+                        double *alcon, ITG *nalcon, double *alzero, double *t0,
+                        double *t1, char *matname,
+                        ITG *ielmat, char *orname, double *orab, ITG *ielorien,
+                        char *amname, double *amta, ITG *namta, ITG *nam,
+                        ITG *nmethod, ITG *iamforc, ITG *iamload,
+                        ITG *iamt1, ITG *ithermal, ITG *iperturb,
+                        ITG *istat, ITG *istep, ITG *nmat,
+                        ITG *ntmat_, ITG *norien, double *prestr, ITG *iprestr,
+                        ITG *isolver, double *fei, double *veold, double *timepar,
+                        double *xmodal, char *filab, ITG *jout, ITG *nlabel,
+                        ITG *idrct, ITG *jmax, ITG *iexpl, double *alpha,
+                        ITG *   iamboun,
+                        double *plicon, ITG *nplicon, double *plkcon, ITG *nplkcon,
+                        ITG *iplas, ITG *npmat_, ITG *mi, ITG *nk_,
+                        double *trab, ITG *inotr, ITG *ntrans, ITG *ikboun,
+                        ITG *ilboun, ITG *ikmpc, ITG *ilmpc, ITG *ics,
+                        double *dcs, ITG *ncs_, ITG *namtot_, double *cs,
+                        ITG *nstate_, ITG *ncmat_, ITG *iumat, ITG *mcs,
+                        char *labmpc, ITG *iponor, double *xnor, ITG *knor,
+                        double *thickn, double *thicke, ITG *ikforc, ITG *ilforc,
+                        double *offset, ITG *iponoel, ITG *inoel, ITG *rig,
+                        ITG *infree, ITG *nshcon, double *shcon, double *cocon,
+                        ITG *ncocon, double *physcon, ITG *nflow, double *ctrl,
+                        ITG *maxlenmpc, ITG *ne1d, ITG *ne2d, ITG *nener,
+                        double *vold, ITG *nodebounold,
+                        ITG *ndirbounold, double *xbounold, double *xforcold,
+                        double *xloadold, double *t1old, double *eme,
+                        double *sti, double *ener,
+                        double *xstate, char *jobnamec, ITG *irstrt,
+                        double *ttime, double *qaold,
+                        char *output, char *typeboun, char *inpc,
+                        ITG *ipoinp, ITG *inp, char *tieset, double *tietol,
+                        ITG *ntie, double *fmpc, char *cbody, ITG *ibody,
+                        double *xbody,
+                        ITG *nbody, ITG *nbody_, double *xbodyold, ITG *nam_,
+                        ITG *ielprop, ITG *nprop, ITG *nprop_, double *prop,
+                        ITG *itpamp, ITG *iviewfile, ITG *ipoinpc,
+                        ITG *nslavs, double *t0g, double *t1g, ITG *network,
+                        ITG *cyclicsymmetry, ITG *idefforc, ITG *idefload,
+                        ITG *idefbody, ITG *mortar, ITG *ifacecount, ITG *islavsurf,
+                        double *pslavsurf, double *clearini, char *heading,
+                        ITG *iaxial, ITG *nobject, char *objectset, ITG *nprint_,
+                        ITG *iuel, ITG *nuel_, ITG *nodempcref, double *coefmpcref,
+                        ITG *ikmpcref, ITG *memmpcref_, ITG *mpcfreeref,
+                        ITG *maxlenmpcref, ITG *memmpc_, ITG *isens, ITG *namtot,
+                        ITG *stam, double *dacon, double *vel, ITG *nef,
+                        double *velo, double *veloo, ITG *ne2boun, ITG *itempuser,
+                        ITG *irobustdesign, ITG *irandomtype, double *randomval,
+                        ITG *nfc, ITG *nfc_, double *coeffc, ITG *idck, ITG *ndc,
+                        ITG *ndc_, double *edc));
 
-void FORTRAN(calinput_rfn,(double *co,char *filab,char *set,ITG *istartset,
-			   ITG *iendset,ITG *ialset,ITG *nset,ITG *nset_,
-			   ITG *nalset,ITG *nalset_,ITG *mi,ITG *kon,
-			   ITG *ipkon,char *lakon,ITG *nkon,ITG *ne,ITG *ne_,
-			   ITG *iponor,double *xnor,ITG *istep,
-			   ITG *ipoinp,ITG *inp,ITG *iaxial,ITG *ipoinpc,
-			   ITG *network,ITG *nlabel,ITG *iuel,ITG *nuel_,
-			   ITG *ielmat,char *inpc,ITG *iperturb,ITG *iprestr,
-			   ITG *nk,ITG *nk_,ITG *ntie,char *tieset,
-			   ITG *iparentel,double *tietol));
+void FORTRAN(calinput_rfn, (double *co, char *filab, char *set, ITG *istartset,
+                            ITG *iendset, ITG *ialset, ITG *nset, ITG *nset_,
+                            ITG *nalset, ITG *nalset_, ITG *mi, ITG *kon,
+                            ITG *ipkon, char *lakon, ITG *nkon, ITG *ne, ITG *ne_,
+                            ITG *iponor, double *xnor, ITG *istep,
+                            ITG *ipoinp, ITG *inp, ITG *iaxial, ITG *ipoinpc,
+                            ITG *network, ITG *nlabel, ITG *iuel, ITG *nuel_,
+                            ITG *ielmat, char *inpc, ITG *iperturb, ITG *iprestr,
+                            ITG *nk, ITG *nk_, ITG *ntie, char *tieset,
+                            ITG *iparentel, double *tietol));
 
-void cascade(ITG *ipompc,double **coefmpcp,ITG **nodempcp,ITG *nmpc,
-   ITG *mpcfree,ITG *nodeboun,ITG *ndirboun,ITG*nboun,ITG*ikmpc,
-   ITG *ilmpc,ITG *ikboun,ITG *ilboun,ITG *mpcend,
-   char *labmpc,ITG *nk,ITG *memmpc_,ITG *icascade,ITG *maxlenmpc,
-   ITG *callfrommain,ITG *iperturb,ITG *ithermal);
+void cascade(ITG *ipompc, double **coefmpcp, ITG **nodempcp, ITG *nmpc,
+             ITG *mpcfree, ITG *nodeboun, ITG *ndirboun, ITG *nboun, ITG *ikmpc,
+             ITG *ilmpc, ITG *ikboun, ITG *ilboun, ITG *mpcend,
+             char *labmpc, ITG *nk, ITG *memmpc_, ITG *icascade, ITG *maxlenmpc,
+             ITG *callfrommain, ITG *iperturb, ITG *ithermal);
 
-void cascadefem(ITG *ipompc,double **coefmpcp,ITG **nodempcp,ITG *nmpc,
-   ITG *mpcfree,ITG *nodeboun,ITG *ndirboun,ITG*nboun,ITG*ikmpc,
-   ITG *ilmpc,ITG *ikboun,ITG *ilboun,ITG *mpcend,ITG *mpcmult,
-   char *labmpc,ITG *nk,ITG *memmpc_,ITG *icascade,ITG *maxlenmpc,
-   ITG *callfrommain,ITG *iperturb,ITG *ithermal);
+void cascadefem(ITG *ipompc, double **coefmpcp, ITG **nodempcp, ITG *nmpc,
+                ITG *mpcfree, ITG *nodeboun, ITG *ndirboun, ITG *nboun, ITG *ikmpc,
+                ITG *ilmpc, ITG *ikboun, ITG *ilboun, ITG *mpcend, ITG *mpcmult,
+                char *labmpc, ITG *nk, ITG *memmpc_, ITG *icascade, ITG *maxlenmpc,
+                ITG *callfrommain, ITG *iperturb, ITG *ithermal);
 
-void FORTRAN(catedges_crackprop,(ITG *ipoed,ITG *iedg,ITG *ntri,ITG *ieled,
-				 ITG *kontri,ITG *nedg,ITG *ier));
+void FORTRAN(catedges_crackprop, (ITG * ipoed, ITG *iedg, ITG *ntri, ITG *ieled,
+                                  ITG *kontri, ITG *nedg, ITG *ier));
 
-void FORTRAN(catedges_mesh,(ITG *kontet,ITG *netet_,ITG *iedg,ITG *ipoed,
-			    ITG *ifreeed,ITG *ifac,
-			    ITG *ipoeled,ITG *ieled,ITG *ifreele,
-			    ITG *iedtet,ITG *iexternfa,ITG *iexternedg,
-			    ITG *nktet,ITG *ipofa));
-    
-void FORTRAN(catedges_refine,(ITG *netet_,ITG *iedg,ITG *kontet,ITG *ipoed,
-                       ITG *ifreeed,ITG *iedtet,ITG *ipoeled,ITG *ieled,
-                       ITG *ifreele));
+void FORTRAN(catedges_mesh, (ITG * kontet, ITG *netet_, ITG *iedg, ITG *ipoed,
+                             ITG *ifreeed, ITG *ifac,
+                             ITG *ipoeled, ITG *ieled, ITG *ifreele,
+                             ITG *iedtet, ITG *iexternfa, ITG *iexternedg,
+                             ITG *nktet, ITG *ipofa));
 
-void FORTRAN(catnodes,(ITG *ifreenn,ITG *inn,ITG *iponn,ITG *iedg,ITG *ipoed,
-		       ITG *nktet_,ITG *iexternnode,ITG *idimsh,ITG *sharp,
-		       ITG *iexternedg));
+void FORTRAN(catedges_refine, (ITG * netet_, ITG *iedg, ITG *kontet, ITG *ipoed,
+                               ITG *ifreeed, ITG *iedtet, ITG *ipoeled, ITG *ieled,
+                               ITG *ifreele));
 
-void FORTRAN(cattet,(ITG *kontet,ITG *netet_,ITG *ifac,ITG *ne,ITG *ipkon,
-                     ITG *kon,ITG *ifatet,ITG *ifreetet,double *bc,
-                     ITG *itetfa,ITG *ifreefa,double *planfa,ITG *ipofa,
-                     double *cotet,double *cg,ITG *ipoeln,ITG *ieln,
-                     ITG *ifreeln,char *lakon,ITG *kontetor,ITG *iquad,
-		     ITG *istartset,ITG *iendset,ITG *ialset,char *set,
-		     ITG *nset,char *filab,ITG *jfix,ITG *iparentel,
-		     char *jobnamec));
+void FORTRAN(catnodes, (ITG * ifreenn, ITG *inn, ITG *iponn, ITG *iedg, ITG *ipoed,
+                        ITG *nktet_, ITG *iexternnode, ITG *idimsh, ITG *sharp,
+                        ITG *iexternedg));
 
-void FORTRAN(cattri,(ITG *ne,char *lakon,ITG *ipkon,ITG *kon,ITG *kontri,
-		     ITG *ntri));
+void FORTRAN(cattet, (ITG * kontet, ITG *netet_, ITG *ifac, ITG *ne, ITG *ipkon,
+                      ITG *kon, ITG *ifatet, ITG *ifreetet, double *bc,
+                      ITG *itetfa, ITG *ifreefa, double *planfa, ITG *ipofa,
+                      double *cotet, double *cg, ITG *ipoeln, ITG *ieln,
+                      ITG *ifreeln, char *lakon, ITG *kontetor, ITG *iquad,
+                      ITG *istartset, ITG *iendset, ITG *ialset, char *set,
+                      ITG *nset, char *filab, ITG *jfix, ITG *iparentel,
+                      char *jobnamec));
 
-void FORTRAN(cavity_mesh,(ITG *kontet,ITG *ifatet,ITG *ifreetet,double *bc,
-			  ITG *ifac,ITG *itetfa,ITG *ifreefa,double *planfa,
-			  ITG *ipofa,ITG *nodes,double *cotet,ITG *ipocatt,
-			  ITG *ncat_,double *xmin,double *ymin,double *zmin,
-			  double *charlen,ITG *ndx,ITG *ndy,ITG *ndz,
-			  ITG *ibase,ITG *node,ITG *ifree,ITG *iexternfa,
-			  ITG *netet_,ITG *ierr));
+void FORTRAN(cattri, (ITG * ne, char *lakon, ITG *ipkon, ITG *kon, ITG *kontri,
+                      ITG *ntri));
 
-void FORTRAN(cavity_refine,(ITG *kontet,ITG *ifatet,ITG *ifreetet,double *bc,
-			    ITG *ifac,ITG *itetfa,ITG *ifreefa,double *planfa,
-			    ITG *ipofa,double *cotet,ITG *ibase,ITG *node,
-			    ITG *iexternfa,ITG *ipoed,ITG *iedg,ITG *ifreeed,
-			    ITG *ipoeled,ITG *ieled,ITG *ifreele,ITG *nktet,
-			    ITG *netet_,ITG *ibasenewnodes,double *conewnodes,
-			    ITG *ipoeln,ITG *ieln,ITG *ifreeln,ITG *nnewnodes,
-			    ITG *iexternedg,ITG *iedtet,double *cg,
-			    double *height,ITG *iparentel));
+void FORTRAN(cavity_mesh, (ITG * kontet, ITG *ifatet, ITG *ifreetet, double *bc,
+                           ITG *ifac, ITG *itetfa, ITG *ifreefa, double *planfa,
+                           ITG *ipofa, ITG *nodes, double *cotet, ITG *ipocatt,
+                           ITG *ncat_, double *xmin, double *ymin, double *zmin,
+                           double *charlen, ITG *ndx, ITG *ndy, ITG *ndz,
+                           ITG *ibase, ITG *node, ITG *ifree, ITG *iexternfa,
+                           ITG *netet_, ITG *ierr));
 
-void FORTRAN(cavityext_refine,(ITG *kontet,ITG *ifatet,ITG *ifreetet,double *bc,
-			       ITG *ifac,ITG *itetfa,ITG *ifreefa,
-			       double *planfa,ITG *ipofa,double *cotet,
-			       ITG *ibase,ITG *node,ITG *iexternfa,ITG *ipoed,
-			       ITG *iedg,ITG *ifreeed,ITG *ipoeled,ITG *ieled,
-			       ITG *ifreele,ITG *nktet,ITG *netet_,
-			       ITG *ibasenewnodes,double *conewnodes,
-			       ITG *ipoeln,ITG *ieln,ITG *ifreeln,
-			       ITG *nnewnodes,ITG *iexternedg,ITG *iedtet,
-			       double *cotetorig,ITG *iedge,ITG *iexternnode,
-			       double *cg,double *height,ITG *iparentel));
+void FORTRAN(cavity_refine, (ITG * kontet, ITG *ifatet, ITG *ifreetet, double *bc,
+                             ITG *ifac, ITG *itetfa, ITG *ifreefa, double *planfa,
+                             ITG *ipofa, double *cotet, ITG *ibase, ITG *node,
+                             ITG *iexternfa, ITG *ipoed, ITG *iedg, ITG *ifreeed,
+                             ITG *ipoeled, ITG *ieled, ITG *ifreele, ITG *nktet,
+                             ITG *netet_, ITG *ibasenewnodes, double *conewnodes,
+                             ITG *ipoeln, ITG *ieln, ITG *ifreeln, ITG *nnewnodes,
+                             ITG *iexternedg, ITG *iedtet, double *cg,
+                             double *height, ITG *iparentel));
 
-void FORTRAN(cfdconv,(double *vold,double *vcon,double *v,ITG *nk,
-		      ITG *nmethod,ITG *iconvergence,ITG *ithermal,ITG *iit,
-		      ITG *turbulent,ITG *mi,double *dtimef,double *vconmax,
-		      ITG *iexplicit));
+void FORTRAN(cavityext_refine, (ITG * kontet, ITG *ifatet, ITG *ifreetet, double *bc,
+                                ITG *ifac, ITG *itetfa, ITG *ifreefa,
+                                double *planfa, ITG *ipofa, double *cotet,
+                                ITG *ibase, ITG *node, ITG *iexternfa, ITG *ipoed,
+                                ITG *iedg, ITG *ifreeed, ITG *ipoeled, ITG *ieled,
+                                ITG *ifreele, ITG *nktet, ITG *netet_,
+                                ITG *ibasenewnodes, double *conewnodes,
+                                ITG *ipoeln, ITG *ieln, ITG *ifreeln,
+                                ITG *nnewnodes, ITG *iexternedg, ITG *iedtet,
+                                double *cotetorig, ITG *iedge, ITG *iexternnode,
+                                double *cg, double *height, ITG *iparentel));
 
-ITG cgsolver(double *A,double *x,double *b,ITG neq,ITG len,ITG *ia,ITG *iz,
-                                double *eps,ITG *niter,ITG precFlg);
+void FORTRAN(cfdconv, (double *vold, double *vcon, double *v, ITG *nk,
+                       ITG *nmethod, ITG *iconvergence, ITG *ithermal, ITG *iit,
+                       ITG *turbulent, ITG *mi, double *dtimef, double *vconmax,
+                       ITG *iexplicit));
 
-void FORTRAN(characteristiclength,(double *co,ITG *istartcrackfro,
-				   ITG *iendcrackfro,ITG *ncrack,ITG *ifront,
-				   double *charlen,double *datarget));
+ITG cgsolver(double *A, double *x, double *b, ITG neq, ITG len, ITG *ia, ITG *iz,
+             double *eps, ITG *niter, ITG precFlg);
 
-void checkconvergence(double *co,ITG *nk,ITG *kon,ITG *ipkon,char *lakon,
-          ITG *ne,double *stn,ITG *nmethod,
-          ITG *kode,char *filab,double *een,double *t1act,
-          double *time,double *epn,ITG *ielmat,char *matname,
-          double *enern,double *xstaten,ITG *nstate_,ITG *istep,
-          ITG *iinc,ITG *iperturb,double *ener,ITG *mi,char *output,
-          ITG *ithermal,double *qfn,ITG *mode,ITG *noddiam,double *trab,
-          ITG *inotr,ITG *ntrans,double *orab,ITG *ielorien,ITG *norien,
-          char *description,double *sti,
-          ITG *icutb,ITG *iit,double *dtime,double *qa,double *vold,
-          double *qam,double *ram1,double *ram2,double *ram,
-          double *cam,double *uam,ITG *ntg,double *ttime,
-          ITG *icntrl,double *theta,double *dtheta,double *veold,
-          double *vini,ITG *idrct,double *tper,ITG *istab,double *tmax,
-          ITG *nactdof,double *b,double *tmin,double *ctrl,double *amta,
-          ITG *namta,ITG *itpamp,ITG *inext,double *dthetaref,ITG *itp,
-          ITG *jprint,ITG *jout,ITG *uncoupled,double *t1,ITG *iitterm,
-          ITG *nelemload,ITG *nload,ITG *nodeboun,ITG *nboun,ITG *itg,
-          ITG *ndirboun,double *deltmx,ITG *iflagact,char *set,ITG *nset,
-          ITG *istartset,ITG *iendset,ITG *ialset,double *emn,double *thicke,
-          char *jobnamec,ITG *mortar,ITG *nmat,ITG *ielprop,double *prop,
-          ITG *ialeatoric,ITG *kscale,
-          double *energy,double *allwk,double *energyref,
-          double *emax,double *enres,double *enetoll,double *energyini,
-          double *allwkini,double *temax,double *reswk,ITG *ne0,
-          ITG *neini,double *dampwk,double *dampwkini,double *energystartstep);
+void FORTRAN(characteristiclength, (double *co, ITG *istartcrackfro,
+                                    ITG *iendcrackfro, ITG *ncrack, ITG *ifront,
+                                    double *charlen, double *datarget));
 
-void checkconvnet(ITG *icutb,ITG *iin,
-                  double *cam1t,double *cam1f,double *cam1p,
-                  double *cam2t,double *cam2f,double *cam2p,
-                  double *camt,double *camf,double *camp,
-                  ITG *icntrl,double *dtheta,double *ctrl,
-                  double *cam1a,double *cam2a,double *cama,
-                  double *vamt,double *vamf,double *vamp,double *vama,
-                  double *qa,double *qamt,double *qamf,double *ramt,
-                  double *ramf,double *ramp,ITG *iplausi,ITG *ichannel,
-		  ITG *iaxial);
+void checkconvergence(double *co, ITG *nk, ITG *kon, ITG *ipkon, char *lakon,
+                      ITG *ne, double *stn, ITG *nmethod,
+                      ITG *kode, char *filab, double *een, double *t1act,
+                      double *time, double *epn, ITG *ielmat, char *matname,
+                      double *enern, double *xstaten, ITG *nstate_, ITG *istep,
+                      ITG *iinc, ITG *iperturb, double *ener, ITG *mi, char *output,
+                      ITG *ithermal, double *qfn, ITG *mode, ITG *noddiam, double *trab,
+                      ITG *inotr, ITG *ntrans, double *orab, ITG *ielorien, ITG *norien,
+                      char *description, double *sti,
+                      ITG *icutb, ITG *iit, double *dtime, double *qa, double *vold,
+                      double *qam, double *ram1, double *ram2, double *ram,
+                      double *cam, double *uam, ITG *ntg, double *ttime,
+                      ITG *icntrl, double *theta, double *dtheta, double *veold,
+                      double *vini, ITG *idrct, double *tper, ITG *istab, double *tmax,
+                      ITG *nactdof, double *b, double *tmin, double *ctrl, double *amta,
+                      ITG *namta, ITG *itpamp, ITG *inext, double *dthetaref, ITG *itp,
+                      ITG *jprint, ITG *jout, ITG *uncoupled, double *t1, ITG *iitterm,
+                      ITG *nelemload, ITG *nload, ITG *nodeboun, ITG *nboun, ITG *itg,
+                      ITG *ndirboun, double *deltmx, ITG *iflagact, char *set, ITG *nset,
+                      ITG *istartset, ITG *iendset, ITG *ialset, double *emn, double *thicke,
+                      char *jobnamec, ITG *mortar, ITG *nmat, ITG *ielprop, double *prop,
+                      ITG *ialeatoric, ITG *kscale,
+                      double *energy, double *allwk, double *energyref,
+                      double *emax, double *enres, double *enetoll, double *energyini,
+                      double *allwkini, double *temax, double *reswk, ITG *ne0,
+                      ITG *neini, double *dampwk, double *dampwkini, double *energystartstep);
 
-void FORTRAN(checkconstraint,(ITG *nobject,char *objectset,double *g0,
-			      ITG *nactive,ITG *nnlconst,ITG *ipoacti,
-			      ITG *ndesi,double *dgdxglob,ITG *nk,
-			      ITG *nodedesi,ITG *iconstacti,double *objnorm,
-			      ITG *inameacti));
+void checkconvnet(ITG *icutb, ITG *iin,
+                  double *cam1t, double *cam1f, double *cam1p,
+                  double *cam2t, double *cam2f, double *cam2p,
+                  double *camt, double *camf, double *camp,
+                  ITG *icntrl, double *dtheta, double *ctrl,
+                  double *cam1a, double *cam2a, double *cama,
+                  double *vamt, double *vamf, double *vamp, double *vama,
+                  double *qa, double *qamt, double *qamf, double *ramt,
+                  double *ramf, double *ramp, ITG *iplausi, ITG *ichannel,
+                  ITG *iaxial);
 
-void checkdivergence(double *co,ITG *nk,ITG *kon,ITG *ipkon,char *lakon,
-          ITG *ne,double *stn,ITG *nmethod,
-          ITG *kode,char *filab,double *een,double *t1act,
-          double *time,double *epn,ITG *ielmat,char *matname,
-          double *enern,double *xstaten,ITG *nstate_,ITG *istep,
-          ITG *iinc,ITG *iperturb,double *ener,ITG *mi,char *output,
-          ITG *ithermal,double *qfn,ITG *mode,ITG *noddiam,double *trab,
-          ITG *inotr,ITG *ntrans,double *orab,ITG *ielorien,ITG *norien,
-          char *description,double *sti,
-          ITG *icutb,ITG *iit,double *dtime,double *qa,double *vold,
-          double *qam,double *ram1,double *ram2,double *ram,
-          double *cam,double *uam,ITG *ntg,double *ttime,
-          ITG *icntrl,double *theta,double *dtheta,double *veold,
-          double *vini,ITG *idrct,double *tper,ITG *istab,double *tmax,
-          ITG *nactdof,double *b,double *tmin,double *ctrl,double *amta,
-          ITG *namta,ITG *itpamp,ITG *inext,double *dthetaref,ITG *itp,
-          ITG *jprint,ITG *jout,ITG *uncoupled,double *t1,ITG *iitterm,
-          ITG *nelemload,ITG *nload,ITG *nodeboun,ITG *nboun,ITG *itg,
-          ITG *ndirboun,double *deltmx,ITG *iflagact,char *set,ITG *nset,
-          ITG *istartset,ITG *iendset,ITG *ialset,double *emn,double *thicke,
-          char *jobnamec,ITG *mortar,ITG *nmat,ITG *ielprop,double *prop,
-          ITG *ialeatoric,ITG *kscale,
-          double *energy,double *allwk,double *energyref,
-          double *emax,double *enres,double *enetoll,double *energyini,
-          double *allwkini,double *temax,double *reswk,ITG *ne0,
-          ITG *neini,double *dampwk,double *dampwkini,double *energystartstep);
+void FORTRAN(checkconstraint, (ITG * nobject, char *objectset, double *g0,
+                               ITG *nactive, ITG *nnlconst, ITG *ipoacti,
+                               ITG *ndesi, double *dgdxglob, ITG *nk,
+                               ITG *nodedesi, ITG *iconstacti, double *objnorm,
+                               ITG *inameacti));
 
-void FORTRAN(checkexiedge,(ITG *n1newnodes,ITG *n2newnodes,ITG *ipoed,ITG *iedg,
-		   ITG *node));
+void checkdivergence(double *co, ITG *nk, ITG *kon, ITG *ipkon, char *lakon,
+                     ITG *ne, double *stn, ITG *nmethod,
+                     ITG *kode, char *filab, double *een, double *t1act,
+                     double *time, double *epn, ITG *ielmat, char *matname,
+                     double *enern, double *xstaten, ITG *nstate_, ITG *istep,
+                     ITG *iinc, ITG *iperturb, double *ener, ITG *mi, char *output,
+                     ITG *ithermal, double *qfn, ITG *mode, ITG *noddiam, double *trab,
+                     ITG *inotr, ITG *ntrans, double *orab, ITG *ielorien, ITG *norien,
+                     char *description, double *sti,
+                     ITG *icutb, ITG *iit, double *dtime, double *qa, double *vold,
+                     double *qam, double *ram1, double *ram2, double *ram,
+                     double *cam, double *uam, ITG *ntg, double *ttime,
+                     ITG *icntrl, double *theta, double *dtheta, double *veold,
+                     double *vini, ITG *idrct, double *tper, ITG *istab, double *tmax,
+                     ITG *nactdof, double *b, double *tmin, double *ctrl, double *amta,
+                     ITG *namta, ITG *itpamp, ITG *inext, double *dthetaref, ITG *itp,
+                     ITG *jprint, ITG *jout, ITG *uncoupled, double *t1, ITG *iitterm,
+                     ITG *nelemload, ITG *nload, ITG *nodeboun, ITG *nboun, ITG *itg,
+                     ITG *ndirboun, double *deltmx, ITG *iflagact, char *set, ITG *nset,
+                     ITG *istartset, ITG *iendset, ITG *ialset, double *emn, double *thicke,
+                     char *jobnamec, ITG *mortar, ITG *nmat, ITG *ielprop, double *prop,
+                     ITG *ialeatoric, ITG *kscale,
+                     double *energy, double *allwk, double *energyref,
+                     double *emax, double *enres, double *enetoll, double *energyini,
+                     double *allwkini, double *temax, double *reswk, ITG *ne0,
+                     ITG *neini, double *dampwk, double *dampwkini, double *energystartstep);
 
-void checkinclength(double *time,double *ttime,double *theta,double *dtheta,
-          ITG *idrct,double *tper,double *tmax,double *tmin,double *ctrl,
-          double *amta,ITG *namta,ITG *itpamp,ITG *inext,double *dthetaref,
-          ITG *itp,ITG *jprint,ITG *jout);
-         
-void FORTRAN(checkimpacts,(ITG *ne,ITG *neini,double *temax,
-                   double *sizemaxinc,double *energyref,double *tmin,
-                   double *tper,
-                   ITG *idivergence,ITG *idirinctime,ITG *istab,
-                   double *dtheta,double *enres,double *energy,
-                   double *energyini,double *allwk,double *allwkini,
-                   double *dampwk,double *dampwkini,double *emax,
-                   ITG *mortar,double *maxdecay,double *enetoll));
+void FORTRAN(checkexiedge, (ITG * n1newnodes, ITG *n2newnodes, ITG *ipoed, ITG *iedg,
+                            ITG *node));
 
-void FORTRAN(checkinputvaluesnet,(ITG *ieg,ITG *nflow,double *prop,
-                                  ITG *ielprop,char *lakon));
+void checkinclength(double *time, double *ttime, double *theta, double *dtheta,
+                    ITG *idrct, double *tper, double *tmax, double *tmin, double *ctrl,
+                    double *amta, ITG *namta, ITG *itpamp, ITG *inext, double *dthetaref,
+                    ITG *itp, ITG *jprint, ITG *jout);
 
-void FORTRAN(checkprojectgrad,(ITG *nactiveold,ITG *nactive,ITG *ipoacti,
-                               ITG *ipoactiold,char *objectset,double *lambda,
-                               ITG *nnlconst,ITG *iconstacti,ITG *iconstactiold,
-                               ITG *inameacti,ITG *inameactiold,double *g0,
-		               ITG *nobject,ITG *ndesi,ITG *nodedesi,
-			       double *dgdxglob,ITG *nk));
+void FORTRAN(checkimpacts, (ITG * ne, ITG *neini, double *temax,
+                            double *sizemaxinc, double *energyref, double *tmin,
+                            double *tper,
+                            ITG *idivergence, ITG *idirinctime, ITG *istab,
+                            double *dtheta, double *enres, double *energy,
+                            double *energyini, double *allwk, double *allwkini,
+                            double *dampwk, double *dampwkini, double *emax,
+                            ITG *mortar, double *maxdecay, double *enetoll));
 
-void FORTRAN(checksharp,(ITG *nexternedg,ITG *iedgextfa,double *cotet,
-			 ITG *ifacext,ITG *isharp));
+void FORTRAN(checkinputvaluesnet, (ITG * ieg, ITG *nflow, double *prop,
+                                   ITG *ielprop, char *lakon));
 
-void FORTRAN(checktime,(ITG *itpamp,ITG *namta,double *tinc,double *ttime,
-             double *amta,double *tmin,ITG *inext,ITG *itp,ITG *istep,
-             double *tper));
+void FORTRAN(checkprojectgrad, (ITG * nactiveold, ITG *nactive, ITG *ipoacti,
+                                ITG *ipoactiold, char *objectset, double *lambda,
+                                ITG *nnlconst, ITG *iconstacti, ITG *iconstactiold,
+                                ITG *inameacti, ITG *inameactiold, double *g0,
+                                ITG *nobject, ITG *ndesi, ITG *nodedesi,
+                                double *dgdxglob, ITG *nk));
 
-void FORTRAN(checktruecontact,(ITG *ntie,char *tieset,double *tietol,
-             double *elcon,ITG *itruecontact,ITG *ncmat_,ITG *ntmat_));
+void FORTRAN(checksharp, (ITG * nexternedg, ITG *iedgextfa, double *cotet,
+                          ITG *ifacext, ITG *isharp));
 
-void FORTRAN(clonesensitivies,(ITG *nobject,ITG *nk,char *objectset,
-			       double *g0,double *dgdxglob));
+void FORTRAN(checktime, (ITG * itpamp, ITG *namta, double *tinc, double *ttime,
+                         double *amta, double *tmin, ITG *inext, ITG *itp, ITG *istep,
+                         double *tper));
 
-void FORTRAN(closefile,());
+void FORTRAN(checktruecontact, (ITG * ntie, char *tieset, double *tietol,
+                                double *elcon, ITG *itruecontact, ITG *ncmat_, ITG *ntmat_));
 
-void FORTRAN(closefilefluid,());
+void FORTRAN(clonesensitivies, (ITG * nobject, ITG *nk, char *objectset,
+                                double *g0, double *dgdxglob));
 
-void FORTRAN(cmatrix,(double *ad,double *au,ITG *jqs,ITG *irows,ITG *icols,
-		      ITG *ndesi,ITG *nodedesi,double *auc,ITG *jqc,
-		      ITG *irowc,ITG *nodedesibou));
+void FORTRAN(closefile, ());
 
-void FORTRAN(combilcfhcf,(double *tempf,double *stressf,double *stress,
-			  double *hcfstress,double *temp,ITG *nbounnod,
-			  ITG *mei,ITG *nstep));
-  
-void FORTRAN(compdt,(ITG *nk,double *dt,ITG *nshcon,double *shcon,
-		     double *vold,ITG *ntmat_,ITG *iponoel,
-		     ITG *inoel,double *dtimef,ITG *ielmat,
-		     double *dh,double *cocon,ITG *ncocon,
-		     ITG *ithermal,ITG *mi,
-		     double *vcon,ITG *compressible,double *tincf,
-		     ITG *ierr,ITG *ifreesurface,double *dgravity,
-		     ITG *iit));
+void FORTRAN(closefilefluid, ());
 
-void compfluidfem(double **cop,ITG *nk,ITG **ipkonp,ITG **konp,char **lakonp,
-    ITG *ne,char **sideface,ITG *ifreestream,
-    ITG *nfreestream,ITG *isolidsurf,ITG *neighsolidsurf,
-    ITG *nsolidsurf,ITG *iponoel,ITG *inoel,ITG *nshcon,double *shcon,
-    ITG *nrhcon,double *rhcon,double **voldp,ITG *ntmat_,ITG *nodeboun,
-    ITG *ndirboun,ITG *nboun,ITG **ipompcp,ITG **nodempcp,ITG *nmpc,
-    ITG **ikmpcp,ITG **ilmpcp,ITG *ithermal,ITG *ikboun,ITG *ilboun,
-    ITG *turbulent,ITG *isolver,ITG *iexpl,double *ttime,
-    double *time,double *dtime,ITG *nodeforc,ITG *ndirforc,double *xforc,
-    ITG *nforc,ITG *nelemload,char *sideload,double *xload,ITG *nload,
-    double *xbody,ITG *ipobody,ITG *nbody,ITG **ielmatp,char *matname,
-    ITG *mi,ITG *ncmat_,double *physcon,ITG *istep,ITG *iinc,
-    ITG *ibody,double *xloadold,double *xboun,
-    double **coefmpcp,ITG *nmethod,double *xforcold,double *xforcact,
-    ITG *iamforc,ITG *iamload,double *xbodyold,double *xbodyact,
-    double *t1old,double *t1,double *t1act,ITG *iamt1,double *amta,
-    ITG *namta,ITG *nam,double *ampli,double *xbounold,double *xbounact,
-    ITG *iamboun,ITG *itg,ITG *ntg,char *amname,double *t0,ITG **nelemface,
-    ITG *nface,double *cocon,ITG *ncocon,double *xloadact,double *tper,
-    ITG *jmax,ITG *jout,char *set,ITG *nset,ITG *istartset,
-    ITG *iendset,ITG *ialset,char *prset,char *prlab,ITG *nprint,
-    double *trab,ITG *inotr,ITG *ntrans,char *filab,char **labmpcp,
-    double *sti,ITG *norien,double *orab,char *jobnamef,char *tieset,
-    ITG *ntie,ITG *mcs,ITG *ics,double *cs,ITG *nkon,ITG *mpcfree,
-    ITG *memmpc_,double **fmpcp,ITG *nef,ITG **inomat,double *qfx,
-    ITG *kode,ITG *ipface,ITG *ielprop,double *prop,char *orname,
-    double *tincf,ITG *ifreesurface,ITG *nkftot,ITG *ielorien,
-    ITG *nelold,ITG *nkold,ITG *nknew,ITG *nelnew);
+void FORTRAN(cmatrix, (double *ad, double *au, ITG *jqs, ITG *irows, ITG *icols,
+                       ITG *ndesi, ITG *nodedesi, double *auc, ITG *jqc,
+                       ITG *irowc, ITG *nodedesibou));
 
-void FORTRAN(complete_hel,(ITG *neq,double *b,double *hel,double *ad,
-             double *au,ITG *jq,ITG *irow,ITG *nzs));
+void FORTRAN(combilcfhcf, (double *tempf, double *stressf, double *stress,
+                           double *hcfstress, double *temp, ITG *nbounnod,
+                           ITG *mei, ITG *nstep));
 
-void FORTRAN(complete_hel_blk,(double *vel,double *hel,double *auv6,
-             ITG *ipnei,ITG *neiel,ITG *nef,ITG *nactdohinv));
+void FORTRAN(compdt, (ITG * nk, double *dt, ITG *nshcon, double *shcon,
+                      double *vold, ITG *ntmat_, ITG *iponoel,
+                      ITG *inoel, double *dtimef, ITG *ielmat,
+                      double *dh, double *cocon, ITG *ncocon,
+                      ITG *ithermal, ITG *mi,
+                      double *vcon, ITG *compressible, double *tincf,
+                      ITG *ierr, ITG *ifreesurface, double *dgravity,
+                      ITG *iit));
 
-void FORTRAN(complete_hel_cyclic,(ITG *neq,double *b,double *hel,double *ad,
-             double *au,ITG *jq,ITG *irow,ITG *ipnei,ITG *neiel,
-             ITG *ifatie,double *c,char *lakonf,ITG *neifa,ITG *nzs));
+void compfluidfem(double **cop, ITG *nk, ITG **ipkonp, ITG **konp, char **lakonp,
+                  ITG *ne, char **sideface, ITG *ifreestream,
+                  ITG *nfreestream, ITG *isolidsurf, ITG *neighsolidsurf,
+                  ITG *nsolidsurf, ITG *iponoel, ITG *inoel, ITG *nshcon, double *shcon,
+                  ITG *nrhcon, double *rhcon, double **voldp, ITG *ntmat_, ITG *nodeboun,
+                  ITG *ndirboun, ITG *nboun, ITG **ipompcp, ITG **nodempcp, ITG *nmpc,
+                  ITG **ikmpcp, ITG **ilmpcp, ITG *ithermal, ITG *ikboun, ITG *ilboun,
+                  ITG *turbulent, ITG *isolver, ITG *iexpl, double *ttime,
+                  double *time, double *dtime, ITG *nodeforc, ITG *ndirforc, double *xforc,
+                  ITG *nforc, ITG *nelemload, char *sideload, double *xload, ITG *nload,
+                  double *xbody, ITG *ipobody, ITG *nbody, ITG **ielmatp, char *matname,
+                  ITG *mi, ITG *ncmat_, double *physcon, ITG *istep, ITG *iinc,
+                  ITG *ibody, double *xloadold, double *xboun,
+                  double **coefmpcp, ITG *nmethod, double *xforcold, double *xforcact,
+                  ITG *iamforc, ITG *iamload, double *xbodyold, double *xbodyact,
+                  double *t1old, double *t1, double *t1act, ITG *iamt1, double *amta,
+                  ITG *namta, ITG *nam, double *ampli, double *xbounold, double *xbounact,
+                  ITG *iamboun, ITG *itg, ITG *ntg, char *amname, double *t0, ITG **nelemface,
+                  ITG *nface, double *cocon, ITG *ncocon, double *xloadact, double *tper,
+                  ITG *jmax, ITG *jout, char *set, ITG *nset, ITG *istartset,
+                  ITG *iendset, ITG *ialset, char *prset, char *prlab, ITG *nprint,
+                  double *trab, ITG *inotr, ITG *ntrans, char *filab, char **labmpcp,
+                  double *sti, ITG *norien, double *orab, char *jobnamef, char *tieset,
+                  ITG *ntie, ITG *mcs, ITG *ics, double *cs, ITG *nkon, ITG *mpcfree,
+                  ITG *memmpc_, double **fmpcp, ITG *nef, ITG **inomat, double *qfx,
+                  ITG *kode, ITG *ipface, ITG *ielprop, double *prop, char *orname,
+                  double *tincf, ITG *ifreesurface, ITG *nkftot, ITG *ielorien,
+                  ITG *nelold, ITG *nkold, ITG *nknew, ITG *nelnew);
 
-void FORTRAN(complete_hel_cyclic_blk,(double *vel,double *hel,double *auv6,
-             double *c,ITG *ipnei,ITG *neiel,ITG *neifa,ITG *ifatie,
-             ITG *nef));
+void FORTRAN(complete_hel, (ITG * neq, double *b, double *hel, double *ad,
+                            double *au, ITG *jq, ITG *irow, ITG *nzs));
 
-void complete_hel_blk_main(double *vel,double *hel,double *auv6,double *c,
-      ITG *ipnei,ITG *neiel,ITG *neifa,ITG *ifatie,ITG *nef);
+void FORTRAN(complete_hel_blk, (double *vel, double *hel, double *auv6,
+                                ITG *ipnei, ITG *neiel, ITG *nef, ITG *nactdohinv));
 
-void complexfreq(double **cop,ITG *nk,ITG **konp,ITG **ipkonp,char **lakonp,ITG *ne,
-               ITG **nodebounp,ITG **ndirbounp,double **xbounp,ITG *nboun,
-               ITG **ipompcp,ITG **nodempcp,double **coefmpcp,char **labmpcp,
-               ITG *nmpc,ITG *nodeforc,ITG *ndirforc,double *xforc,
-               ITG *nforc,ITG *nelemload,char *sideload,double *xload,
-               ITG *nload,
-               ITG **nactdofp,ITG *neq,ITG *nzl,ITG *icol,ITG *irow,
-               ITG *nmethod,ITG **ikmpcp,ITG **ilmpcp,ITG **ikbounp,
-               ITG **ilbounp,double *elcon,ITG *nelcon,double *rhcon,
-               ITG *nrhcon,double *cocon,ITG *ncocon,
-               double *alcon,ITG *nalcon,double *alzero,
-               ITG **ielmatp,ITG **ielorienp,ITG *norien,double *orab,
-               ITG *ntmat_,double **t0p,
-               double **t1p,ITG *ithermal,double *prestr,ITG *iprestr,
-               double **voldp,ITG *iperturb,double **stip,ITG *nzs,
-               double *timepar,double *xmodal,
-               double **veoldp,char *amname,double *amta,
-               ITG *namta,ITG *nam,ITG *iamforc,ITG *iamload,
-               ITG **iamt1p,ITG *jout,
-               ITG *kode,char *filab,double **emep,double *xforcold,
-               double *xloadold,
-               double **t1oldp,ITG **iambounp,double **xbounoldp,ITG *iexpl,
-               double *plicon,ITG *nplicon,double *plkcon,ITG *nplkcon,
-               double *xstate,ITG *npmat_,char *matname,ITG *mi,
-               ITG *ncmat_,ITG *nstate_,double **enerp,char *jobnamec,
-               double *ttime,char *set,ITG *nset,ITG *istartset,
-               ITG *iendset,ITG **ialsetp,ITG *nprint,char *prlab,
-               char *prset,ITG *nener,double *trab,
-               ITG **inotrp,ITG *ntrans,double **fmpcp,ITG *ipobody,ITG *ibody,
-               double *xbody,ITG *nbody,double *xbodyold,ITG *istep,
-               ITG *isolver,ITG *jq,char *output,ITG *mcs,ITG *nkon,
-               ITG *mpcend,ITG *ics,double *cs,ITG *ntie,char *tieset,
-               ITG *idrct,ITG *jmax,
-               double *ctrl,ITG *itpamp,double *tietol,ITG *nalset,
-               ITG *ikforc,ITG *ilforc,double *thicke,
-               char *jobnamef,ITG *mei,ITG *nmat,ITG *ielprop,double *prop,
-               char *orname,char *typeboun,double *t0g,double *t1g);
+void FORTRAN(complete_hel_cyclic, (ITG * neq, double *b, double *hel, double *ad,
+                                   double *au, ITG *jq, ITG *irow, ITG *ipnei, ITG *neiel,
+                                   ITG *ifatie, double *c, char *lakonf, ITG *neifa, ITG *nzs));
 
-void FORTRAN(con2phys,(double *vold,double *voldaux,ITG *nk,
-           ITG *ntmat_,double *shcon,ITG *nshcon,double *rhcon,
-	   ITG *nrhcon,
-           double *physcon,ITG *ithermal,
-           ITG *compressible,
-           ITG *turbulent,ITG *inomat,ITG *mi,
-	   ITG *ierr,ITG *ifreesurface,
-	   double *dgravity,double *depth));
+void FORTRAN(complete_hel_cyclic_blk, (double *vel, double *hel, double *auv6,
+                                       double *c, ITG *ipnei, ITG *neiel, ITG *neifa, ITG *ifatie,
+                                       ITG *nef));
 
-void FORTRAN(condrandomfield,(double *ad,double *au,ITG *jqs,ITG *irows,
-			      ITG *ndesi,double *rhs,double *vector,
-			      ITG *idesvar,ITG *jqc,double *auc,ITG *irowc));
+void complete_hel_blk_main(double *vel, double *hel, double *auv6, double *c,
+                           ITG *ipnei, ITG *neiel, ITG *neifa, ITG *ifatie, ITG *nef);
 
-void contact(ITG *ncont,ITG *ntie,char *tieset,ITG *nset,char *set,
-             ITG *istartset,ITG *iendset,ITG *ialset,ITG *itietri,
-             char *lakon,ITG *ipkon,ITG *kon,ITG *koncont,ITG *ne,
-             double *cg,double *straight,ITG *ifree,double *co,
-             double *vold,ITG *ielmat,double *cs,double *elcon,
-             ITG *istep,ITG *iinc,ITG *iit,ITG *ncmat_,ITG *ntmat_,
-             ITG *ne0,double *vini,
+void complexfreq(double **cop, ITG *nk, ITG **konp, ITG **ipkonp, char **lakonp, ITG *ne,
+                 ITG **nodebounp, ITG **ndirbounp, double **xbounp, ITG *nboun,
+                 ITG **ipompcp, ITG **nodempcp, double **coefmpcp, char **labmpcp,
+                 ITG *nmpc, ITG *nodeforc, ITG *ndirforc, double *xforc,
+                 ITG *nforc, ITG *nelemload, char *sideload, double *xload,
+                 ITG * nload,
+                 ITG **nactdofp, ITG *neq, ITG *nzl, ITG *icol, ITG *irow,
+                 ITG *nmethod, ITG **ikmpcp, ITG **ilmpcp, ITG **ikbounp,
+                 ITG **ilbounp, double *elcon, ITG *nelcon, double *rhcon,
+                 ITG *nrhcon, double *cocon, ITG *ncocon,
+                 double *alcon, ITG *nalcon, double *alzero,
+                 ITG **ielmatp, ITG **ielorienp, ITG *norien, double *orab,
+                 ITG *ntmat_, double **t0p,
+                 double **t1p, ITG *ithermal, double *prestr, ITG *iprestr,
+                 double **voldp, ITG *iperturb, double **stip, ITG *nzs,
+                 double *timepar, double *xmodal,
+                 double **veoldp, char *amname, double *amta,
+                 ITG *namta, ITG *nam, ITG *iamforc, ITG *iamload,
+                 ITG **iamt1p, ITG *jout,
+                 ITG *kode, char *filab, double **emep, double *xforcold,
+                 double * xloadold,
+                 double **t1oldp, ITG **iambounp, double **xbounoldp, ITG *iexpl,
+                 double *plicon, ITG *nplicon, double *plkcon, ITG *nplkcon,
+                 double *xstate, ITG *npmat_, char *matname, ITG *mi,
+                 ITG *ncmat_, ITG *nstate_, double **enerp, char *jobnamec,
+                 double *ttime, char *set, ITG *nset, ITG *istartset,
+                 ITG *iendset, ITG **ialsetp, ITG *nprint, char *prlab,
+                 char *prset, ITG *nener, double *trab,
+                 ITG **inotrp, ITG *ntrans, double **fmpcp, ITG *ipobody, ITG *ibody,
+                 double *xbody, ITG *nbody, double *xbodyold, ITG *istep,
+                 ITG *isolver, ITG *jq, char *output, ITG *mcs, ITG *nkon,
+                 ITG *mpcend, ITG *ics, double *cs, ITG *ntie, char *tieset,
+                 ITG *idrct, ITG *jmax,
+                 double *ctrl, ITG *itpamp, double *tietol, ITG *nalset,
+                 ITG *ikforc, ITG *ilforc, double *thicke,
+                 char *jobnamef, ITG *mei, ITG *nmat, ITG *ielprop, double *prop,
+                 char *orname, char *typeboun, double *t0g, double *t1g);
+
+void FORTRAN(con2phys, (double *vold, double *voldaux, ITG *nk,
+                        ITG *ntmat_, double *shcon, ITG *nshcon, double *rhcon,
+                        ITG *   nrhcon,
+                        double *physcon, ITG *ithermal,
+                        ITG *compressible,
+                        ITG *turbulent, ITG *inomat, ITG *mi,
+                        ITG *ierr, ITG *ifreesurface,
+                        double *dgravity, double *depth));
+
+void FORTRAN(condrandomfield, (double *ad, double *au, ITG *jqs, ITG *irows,
+                               ITG *ndesi, double *rhs, double *vector,
+                               ITG *idesvar, ITG *jqc, double *auc, ITG *irowc));
+
+void contact(ITG *ncont, ITG *ntie, char *tieset, ITG *nset, char *set,
+             ITG *istartset, ITG *iendset, ITG *ialset, ITG *itietri,
+             char *lakon, ITG *ipkon, ITG *kon, ITG *koncont, ITG *ne,
+             double *cg, double *straight, ITG *ifree, double *co,
+             double *vold, ITG *ielmat, double *cs, double *elcon,
+             ITG *istep, ITG *iinc, ITG *iit, ITG *ncmat_, ITG *ntmat_,
+             ITG *ne0, double *vini,
              ITG *nmethod,
-             ITG *iperturb,ITG *ikboun,ITG *nboun,ITG *mi,ITG *imastop,
-             ITG *nslavnode,ITG *islavnode,ITG *islavsurf,ITG *itiefac,
-             double *areaslav,ITG *iponoels,ITG *inoels,double *springarea,
-             double *tietol,double *reltime,ITG *imastnode,ITG *nmastnode,
-             double *xmastnor,char *filab,ITG *mcs,
-             ITG *ics,ITG *nasym,double *xnoels,ITG *mortar,
-             double *pslavsurf,double *pmastsurf,double *clearini,
-             double *theta,double *xstateini,double *xstate,ITG *nstate_,
-             ITG *icutb,ITG *ialeatoric,char *jobnamef,double *alea,
-	     double *auw,ITG *jqw,ITG *iroww,ITG *nzsw);
+             ITG *iperturb, ITG *ikboun, ITG *nboun, ITG *mi, ITG *imastop,
+             ITG *nslavnode, ITG *islavnode, ITG *islavsurf, ITG *itiefac,
+             double *areaslav, ITG *iponoels, ITG *inoels, double *springarea,
+             double *tietol, double *reltime, ITG *imastnode, ITG *nmastnode,
+             double *xmastnor, char *filab, ITG *mcs,
+             ITG *ics, ITG *nasym, double *xnoels, ITG *mortar,
+             double *pslavsurf, double *pmastsurf, double *clearini,
+             double *theta, double *xstateini, double *xstate, ITG *nstate_,
+             ITG *icutb, ITG *ialeatoric, char *jobnamef, double *alea,
+             double *auw, ITG *jqw, ITG *iroww, ITG *nzsw);
 
-void convert2rowbyrow(double *ad,double *au, ITG *icol,ITG *irow, 
-		      ITG *jq,ITG *neq,ITG *nzs,double **aupardisop,
-		      ITG **pointersp,ITG **icolpardisop);
-    
-void FORTRAN(coriolissolve,(double *cc,ITG *nev,double *aa,double *bb,
-             double *xx,double *eiga,double *eigb,double *eigxx,
-             ITG *iter,double *d,double *temp,ITG *nevcomplex));
-      
-void FORTRAN(correctem,(double *stx,double *stn,
-			char *prlab,ITG *nprint,ITG *ne,ITG *ipkon,char *lakon,
-			double *elcon,ITG *ncmat_,ITG *ntmat_,ITG *nk,
-			double *om,char *filab,ITG *mi,ITG *ielmat));
+void convert2rowbyrow(double *ad, double *au, ITG *icol, ITG *irow,
+                      ITG *jq, ITG *neq, ITG *nzs, double **aupardisop,
+                      ITG **pointersp, ITG **icolpardisop);
 
-void cpypardou(double *var1,double *var2,ITG *size,ITG *num_cpus);
+void FORTRAN(coriolissolve, (double *cc, ITG *nev, double *aa, double *bb,
+                             double *xx, double *eiga, double *eigb, double *eigxx,
+                             ITG *iter, double *d, double *temp, ITG *nevcomplex));
+
+void FORTRAN(correctem, (double *stx, double *stn,
+                         char *prlab, ITG *nprint, ITG *ne, ITG *ipkon, char *lakon,
+                         double *elcon, ITG *ncmat_, ITG *ntmat_, ITG *nk,
+                         double *om, char *filab, ITG *mi, ITG *ielmat));
+
+void cpypardou(double *var1, double *var2, ITG *size, ITG *num_cpus);
 
 void *cpypardoumt(ITG *i);
 
-void cpyparitg(ITG *iva1,ITG *iva2,ITG *size,ITG *num_cpus);
+void cpyparitg(ITG *iva1, ITG *iva2, ITG *size, ITG *num_cpus);
 
 void *cpyparitgmt(ITG *i);
 
-void crackfrd(ITG *nk,ITG *ngraph,ITG *noddiam,double *cs,ITG *kode,ITG *inum,
-	      ITG *nmethod,double *time,ITG *istep,ITG *iinc,ITG *mode,
-	      char *description,char *set,ITG *nset,ITG *istartset,
-	      ITG *iendset,ITG *ialset,char *jobnamec,char *output,
-	      double *dkeqglob,double *dk1glob,double *dk2glob,double *dk3glob,
-	      double *phiglob,double *dadnglob,double *dnglob,
-	      double *acrackglob,double *xkeqminglob,double *xkeqmaxglob,
-	      ITG *iincglob,double *domstepglob,double *rglob);
+void crackfrd(ITG *nk, ITG *ngraph, ITG *noddiam, double *cs, ITG *kode, ITG *inum,
+              ITG *nmethod, double *time, ITG *istep, ITG *iinc, ITG *mode,
+              char *description, char *set, ITG *nset, ITG *istartset,
+              ITG *iendset, ITG *ialset, char *jobnamec, char *output,
+              double *dkeqglob, double *dk1glob, double *dk2glob, double *dk3glob,
+              double *phiglob, double *dadnglob, double *dnglob,
+              double *acrackglob, double *xkeqminglob, double *xkeqmaxglob,
+              ITG *iincglob, double *domstepglob, double *rglob);
 
-void FORTRAN(cracklength,(ITG *ncrack,ITG *istartcrackfro,ITG *iendcrackfro,
-			  double *co,ITG *istartcrackbou,ITG *iendcrackbou,
-			  double *coproj,ITG *ibounnod,double *xt,
-			  double *acrack,ITG *istartfront,ITG *iendfront,
-			  ITG *nnfront,ITG *isubcrackfront,ITG *ifrontrel,
-			  ITG *ifront,double *posfront,
-			  double *doubleglob,ITG *integerglob,
-			  ITG *nproc,ITG *iinc,double *acrackglob,ITG *ier));
+void FORTRAN(cracklength, (ITG * ncrack, ITG *istartcrackfro, ITG *iendcrackfro,
+                           double *co, ITG *istartcrackbou, ITG *iendcrackbou,
+                           double *coproj, ITG *ibounnod, double *xt,
+                           double *acrack, ITG *istartfront, ITG *iendfront,
+                           ITG *nnfront, ITG *isubcrackfront, ITG *ifrontrel,
+                           ITG *ifront, double *posfront,
+                           double *doubleglob, ITG *integerglob,
+                           ITG *nproc, ITG *iinc, double *acrackglob, ITG *ier));
 
-void FORTRAN(cracklength_smoothing,(ITG *nnfront,ITG *isubsurffront,
-				    ITG *istartfront,ITG *iendfront,
-				    ITG *ifrontrel,double *costruc,double *dist,
-				    double *a,ITG *istartcrackfro,
-				    ITG *iendcrackfro,double *acrack,
-				    double *amin,ITG *nfront,ITG *ncrack,
-				    ITG *idist,ITG *nstep));
+void FORTRAN(cracklength_smoothing, (ITG * nnfront, ITG *isubsurffront,
+                                     ITG *istartfront, ITG *iendfront,
+                                     ITG *ifrontrel, double *costruc, double *dist,
+                                     double *a, ITG *istartcrackfro,
+                                     ITG *iendcrackfro, double *acrack,
+                                     double *amin, ITG *nfront, ITG *ncrack,
+                                     ITG *idist, ITG *nstep));
 
-void FORTRAN(crackprop,(ITG *ifrontrel,ITG *ibounnod,
-			double *phi,double *da,double *co,double *costruc,
-			ITG *nk,double *xa,double *xn,ITG *nnfront,
-			ITG *istartfront,ITG *iendfront,double *doubleglob,
-			ITG *integerglob,ITG *isubsurffront,
-			double *dadn,ITG *ncyc,ITG *ifrontprop,
-			ITG *nstep,double *acrack,double *acrackglob,
-			double *datarget,ITG *ieqspace,ITG *iincglob,
-			ITG *iinc));
+void FORTRAN(crackprop, (ITG * ifrontrel, ITG *ibounnod,
+                         double *phi, double *da, double *co, double *costruc,
+                         ITG *nk, double *xa, double *xn, ITG *nnfront,
+                         ITG *istartfront, ITG *iendfront, double *doubleglob,
+                         ITG *integerglob, ITG *isubsurffront,
+                         double *dadn, ITG *ncyc, ITG *ifrontprop,
+                         ITG *nstep, double *acrack, double *acrackglob,
+                         double *datarget, ITG *ieqspace, ITG *iincglob,
+                         ITG *iinc));
 
-void crackpropagation(ITG **ipkonp,ITG **konp,char **lakonp,ITG *ne,ITG *nk,
-		      char *jobnamec,ITG *nboun,ITG *iamboun,double *xboun,
-		      ITG *nload,char *sideload,ITG *iamload,ITG *nforc,
-		      ITG *iamforc,double *xforc,ITG *ithermal,double *t1,
-		      ITG *iamt1,double **cop,ITG *nkon,ITG *mi,ITG **ielmatp,
-		      char *matname,char *output,ITG *nmat,char *set,ITG *nset,
-		      ITG *istartset,ITG *iendset,ITG *ialset,ITG *jmax,
-		      double *timepar,ITG *nelcon,double *elcon,ITG *ncmat_,
-		      ITG *ntmat_,ITG *istep,char *filab,ITG *nmethod,
-		      ITG *mei);
+void crackpropagation(ITG **ipkonp, ITG **konp, char **lakonp, ITG *ne, ITG *nk,
+                      char *jobnamec, ITG *nboun, ITG *iamboun, double *xboun,
+                      ITG *nload, char *sideload, ITG *iamload, ITG *nforc,
+                      ITG *iamforc, double *xforc, ITG *ithermal, double *t1,
+                      ITG *iamt1, double **cop, ITG *nkon, ITG *mi, ITG **ielmatp,
+                      char *matname, char *output, ITG *nmat, char *set, ITG *nset,
+                      ITG *istartset, ITG *iendset, ITG *ialset, ITG *jmax,
+                      double *timepar, ITG *nelcon, double *elcon, ITG *ncmat_,
+                      ITG *ntmat_, ITG *istep, char *filab, ITG *nmethod,
+                      ITG *mei);
 
-void crackpropdata(char *jobnamec,ITG *nelcon,double *elcon,double **crconp,
-		   ITG *ncrconst,ITG *ncrtem,ITG *imat,char *matname,
-		   ITG *ntmat_,ITG *ncmat_,char **paramp,ITG *nparam,ITG *law);
+void crackpropdata(char *jobnamec, ITG *nelcon, double *elcon, double **crconp,
+                   ITG *ncrconst, ITG *ncrtem, ITG *imat, char *matname,
+                   ITG *ntmat_, ITG *ncmat_, char **paramp, ITG *nparam, ITG *law);
 
-void FORTRAN(crackrate,(ITG *nfront,ITG *ifrontrel,double *xkeq,
-			double *phi,ITG *ifront,
-			double *dadn,ITG *ncyc,ITG *icritic,
-			double *datarget,double *crcon,
-			double *temp,ITG *ntmat_,double *crconloc,
-			ITG *ncrconst,double *dk1,double *dk2,double *dk3,
-			ITG *nstep,double *acrack,
-			double *wk1,double *wk2,double *wk3,double *xkeqmin,
-			double *xkeqmax,double *dkeq,double *dompstep,
-			double *domphi,char *param,ITG *nparam,ITG *law,
-			ITG *ier,double *r));
+void FORTRAN(crackrate, (ITG * nfront, ITG *ifrontrel, double *xkeq,
+                         double *phi, ITG *ifront,
+                         double *dadn, ITG *ncyc, ITG *icritic,
+                         double *datarget, double *crcon,
+                         double *temp, ITG *ntmat_, double *crconloc,
+                         ITG *ncrconst, double *dk1, double *dk2, double *dk3,
+                         ITG *nstep, double *acrack,
+                         double *wk1, double *wk2, double *wk3, double *xkeqmin,
+                         double *xkeqmax, double *dkeq, double *dompstep,
+                         double *domphi, char *param, ITG *nparam, ITG *law,
+                         ITG *ier, double *r));
 
-void FORTRAN(crackshape,(ITG *nnfront,ITG *ifront,ITG *istartfront,
-			 ITG *iendfront,ITG *isubsurffront,double *angle,
-			 double *posfront,double *shape));
+void FORTRAN(crackshape, (ITG * nnfront, ITG *ifront, ITG *istartfront,
+                          ITG *iendfront, ITG *isubsurffront, double *angle,
+                          double *posfront, double *shape));
 
-void FORTRAN(create_contactdofs,(ITG *kslav,ITG *lslav,ITG *ktot,ITG *ltot,
-				 ITG *nslavs,ITG *islavnode,ITG *nmasts,
-				 ITG *imastnode,ITG *nactdof,ITG *mi,
-				 ITG *neqslav,ITG *neqtot));
+void FORTRAN(create_contactdofs, (ITG * kslav, ITG *lslav, ITG *ktot, ITG *ltot,
+                                  ITG *nslavs, ITG *islavnode, ITG *nmasts,
+                                  ITG *imastnode, ITG *nactdof, ITG *mi,
+                                  ITG *neqslav, ITG *neqtot));
 
-void FORTRAN(createblock_struct,(ITG *neq,ITG *ipointers,ITG *icolpardiso,
-                                double *aupardiso,ITG *nestart,ITG *num_cpus,
-                                ITG *ja,ITG *nz_num));
+void FORTRAN(createblock_struct, (ITG * neq, ITG *ipointers, ITG *icolpardiso,
+                                  double *aupardiso, ITG *nestart, ITG *num_cpus,
+                                  ITG *ja, ITG *nz_num));
 
-void FORTRAN(createbounf,(ITG *nkf,ITG *ikf,ITG *ithermal,ITG *ipofano,
-			  ITG *ipbount,ITG *ibount,double *xbount,ITG *nbpt,
-			  ITG *ipbounv1,ITG *ibounv1,double *xbounv1,
-			  ITG *nbpv1,ITG *ipbounv2,ITG *ibounv2,
-			  double *xbounv2,ITG *nbpv2,ITG *ipbounv3,
-			  ITG *ibounv3,double *xbounv3,ITG *nbpv3,ITG *ipbounp,
-			  ITG *ibounp,double *xbounp,ITG *nbpp,ITG *ifano,
-			  ITG *ielfa,ITG *nbt,ITG *nbv1,ITG *nbv2,ITG *nbv3,
-			  ITG *nbp,ITG *ifabou));
+void FORTRAN(createbounf, (ITG * nkf, ITG *ikf, ITG *ithermal, ITG *ipofano,
+                           ITG *ipbount, ITG *ibount, double *xbount, ITG *nbpt,
+                           ITG *ipbounv1, ITG *ibounv1, double *xbounv1,
+                           ITG *nbpv1, ITG *ipbounv2, ITG *ibounv2,
+                           double *xbounv2, ITG *nbpv2, ITG *ipbounv3,
+                           ITG *ibounv3, double *xbounv3, ITG *nbpv3, ITG *ipbounp,
+                           ITG *ibounp, double *xbounp, ITG *nbpp, ITG *ifano,
+                           ITG *ielfa, ITG *nbt, ITG *nbv1, ITG *nbv2, ITG *nbv3,
+                           ITG *nbp, ITG *ifabou));
 
-void FORTRAN(createelemneigh,(ITG *nk,ITG *iponoel,ITG *inoel,
-                          ITG *istartnneigh,ITG *ialnneigh,
-                          ITG *icheckelems,ITG *istarteneigh,
-                          ITG *ialeneigh));
+void FORTRAN(createelemneigh, (ITG * nk, ITG *iponoel, ITG *inoel,
+                               ITG *istartnneigh, ITG *ialnneigh,
+                               ITG *icheckelems, ITG *istarteneigh,
+                               ITG *ialeneigh));
 
-void FORTRAN(createfint,(ITG *ne,ITG *ipkon,char *lakon,ITG *kon,
-                         ITG *nactdof,ITG *mi,double *fn0,double *fint));
+void FORTRAN(createfint, (ITG * ne, ITG *ipkon, char *lakon, ITG *kon,
+                          ITG *nactdof, ITG *mi, double *fn0, double *fint));
 
-void FORTRAN(createialnk,(ITG *nk,ITG *iponoel,ITG *inoel,ITG *istartnk,
-                          ITG *ialnk,ITG *ipkon));
+void FORTRAN(createialnk, (ITG * nk, ITG *iponoel, ITG *inoel, ITG *istartnk,
+                           ITG *ialnk, ITG *ipkon));
 
-void FORTRAN(createinterfacempcs,(ITG *imastnode,double *xmastnor,
-             ITG *nmastnode,ITG *ikmpc,ITG *ilmpc,ITG *nmpc,ITG *ipompc,
-             ITG *nodempc,double *coefmpc,char *labmpc,ITG *mpcfree,
-             ITG *ikboun,ITG *nboun));
+void FORTRAN(createinterfacempcs, (ITG * imastnode, double *xmastnor,
+                                   ITG *nmastnode, ITG *ikmpc, ITG *ilmpc, ITG *nmpc, ITG *ipompc,
+                                   ITG *nodempc, double *coefmpc, char *labmpc, ITG *mpcfree,
+                                   ITG *ikboun, ITG *nboun));
 
-void FORTRAN(createinum,(ITG *ipkon,ITG *inum,ITG *kon,char *lakon,ITG *nk,
-             ITG *ne,char *cflag,ITG *nelemload,ITG *nload,ITG *nodeboun,
-             ITG *nboun,ITG *ndirboun,ITG *ithermal,double *co,
-             double *vold,ITG *mi,ITG *ielmat,ITG *ielprop,double *prop));
+void FORTRAN(createinum, (ITG * ipkon, ITG *inum, ITG *kon, char *lakon, ITG *nk,
+                          ITG *ne, char *cflag, ITG *nelemload, ITG *nload, ITG *nodeboun,
+                          ITG *nboun, ITG *ndirboun, ITG *ithermal, double *co,
+                          double *vold, ITG *mi, ITG *ielmat, ITG *ielprop, double *prop));
 
-void FORTRAN(createlocalsys,(ITG *nnofront,ITG *istartnode,ITG *iendnode,
-			     ITG *ifront,double *co,double *xt,double *xn,
-			     double *xa,ITG *nfront,ITG *ifrontrel,
-			     double *stress,ITG *iedno,ITG *ibounedg,
-			     ITG *ieled,ITG *kontri,ITG *isubsurffront,
-			     ITG *istartcrackfro,ITG *iendcrackfro,
-			     ITG *ncrack,double *angle,ITG *nstep,
-			     ITG *ier));
+void FORTRAN(createlocalsys, (ITG * nnofront, ITG *istartnode, ITG *iendnode,
+                              ITG *ifront, double *co, double *xt, double *xn,
+                              double *xa, ITG *nfront, ITG *ifrontrel,
+                              double *stress, ITG *iedno, ITG *ibounedg,
+                              ITG *ieled, ITG *kontri, ITG *isubsurffront,
+                              ITG *istartcrackfro, ITG *iendcrackfro,
+                              ITG *ncrack, double *angle, ITG *nstep,
+                              ITG *ier));
 
-void FORTRAN(createmddof,(ITG *imddof,ITG *nmddof,ITG *istartset,
-       ITG *iendset,ITG *ialset,ITG *nactdof,ITG *ithermal,ITG *mi,
-       ITG *imdnode,ITG *nmdnode,ITG *ikmpc,ITG *ilmpc,ITG *ipompc,
-       ITG *nodempc,ITG *nmpc,ITG *imdmpc,
-       ITG *nmdmpc,ITG *imdboun,ITG *nmdboun,ITG *ikboun,ITG *nboun,
-       ITG *nset,ITG *ntie,char *tieset,char *set,char *lakon,ITG *kon,
-       ITG *ipkon,char *labmpc,ITG *ilboun,char *filab,char *prlab,
-       char *prset,ITG *nprint,ITG *ne,ITG *cyclicsymmetry));
+void FORTRAN(createmddof, (ITG * imddof, ITG *nmddof, ITG *istartset,
+                           ITG *iendset, ITG *ialset, ITG *nactdof, ITG *ithermal, ITG *mi,
+                           ITG *imdnode, ITG *nmdnode, ITG *ikmpc, ITG *ilmpc, ITG *ipompc,
+                           ITG *nodempc, ITG *nmpc, ITG *imdmpc,
+                           ITG *nmdmpc, ITG *imdboun, ITG *nmdboun, ITG *ikboun, ITG *nboun,
+                           ITG *nset, ITG *ntie, char *tieset, char *set, char *lakon, ITG *kon,
+                           ITG *ipkon, char *labmpc, ITG *ilboun, char *filab, char *prlab,
+                           char *prset, ITG *nprint, ITG *ne, ITG *cyclicsymmetry));
 
-void FORTRAN(createmdelem,(ITG *imdnode,ITG *nmdnode,
-             ITG *ikmpc,ITG *ilmpc,ITG *ipompc,ITG *nodempc,ITG *nmpc,
-             ITG *imddof,ITG *nmddof,ITG *nactdof,ITG *mi,ITG *imdmpc,
-             ITG *nmdmpc,ITG *imdboun,ITG *nmdboun,ITG *ikboun,ITG *nboun,
-             ITG *ilboun,ITG *ithermal,ITG *imdelem,ITG *nmdelem,
-             ITG *iponoel,ITG *inoel,char *prlab,char *prset,ITG *nprint,
-             char *lakon,char *set,ITG *nset,ITG *ialset,ITG *ipkon,
-             ITG *kon,ITG *istartset,ITG *iendset,ITG *nforc,
-             ITG *ikforc,ITG *ilforc));
+void FORTRAN(createmdelem, (ITG * imdnode, ITG *nmdnode,
+                            ITG *ikmpc, ITG *ilmpc, ITG *ipompc, ITG *nodempc, ITG *nmpc,
+                            ITG *imddof, ITG *nmddof, ITG *nactdof, ITG *mi, ITG *imdmpc,
+                            ITG *nmdmpc, ITG *imdboun, ITG *nmdboun, ITG *ikboun, ITG *nboun,
+                            ITG *ilboun, ITG *ithermal, ITG *imdelem, ITG *nmdelem,
+                            ITG *iponoel, ITG *inoel, char *prlab, char *prset, ITG *nprint,
+                            char *lakon, char *set, ITG *nset, ITG *ialset, ITG *ipkon,
+                            ITG *kon, ITG *istartset, ITG *iendset, ITG *nforc,
+                            ITG *ikforc, ITG *ilforc));
 
-void FORTRAN(createnodeneigh,(ITG *nk,ITG *istartnk,
-                          ITG *ialnk,ITG *istartnneigh,ITG *ialnneigh,
-                          ITG *ichecknodes,char *lakon,ITG *ipkon,ITG *kon,
-                          ITG *nkinsetinv,ITG *neielemtot));
+void FORTRAN(createnodeneigh, (ITG * nk, ITG *istartnk,
+                               ITG *ialnk, ITG *istartnneigh, ITG *ialnneigh,
+                               ITG *ichecknodes, char *lakon, ITG *ipkon, ITG *kon,
+                               ITG *nkinsetinv, ITG *neielemtot));
 
-void FORTRAN(createparacfd,(ITG *nk,ITG *iponoel,ITG *inoel,ITG *ne,
-			    ITG *num_cpus,ITG *irowcpu,ITG *jqcpu));
+void FORTRAN(createparacfd, (ITG * nk, ITG *iponoel, ITG *inoel, ITG *ne,
+                             ITG *num_cpus, ITG *irowcpu, ITG *jqcpu));
 
-void FORTRAN(createtet,(ITG *kontet,ITG *ifatet,ITG *netet,
-             ITG *inodfa,ITG *ifreefa,double *planfa,ITG *ipofa,
-             ITG *nodes,double *cotet,ITG *iparentelement));
+void FORTRAN(createtet, (ITG * kontet, ITG *ifatet, ITG *netet,
+                         ITG *inodfa, ITG *ifreefa, double *planfa, ITG *ipofa,
+                         ITG *nodes, double *cotet, ITG *iparentelement));
 
-void FORTRAN(createtiedsurfs,(ITG *nodface,ITG *ipoface,char *set,
-             ITG *istartset,ITG *iendset,ITG *ialset,char *tieset,
-             ITG *inomat,ITG *ne,ITG *ipkon,char *lakon,ITG *kon,
-             ITG *ntie,double *tietol,ITG *nalset,ITG *nk,ITG *nset,
-             ITG *iactive));
+void FORTRAN(createtiedsurfs, (ITG * nodface, ITG *ipoface, char *set,
+                               ITG *istartset, ITG *iendset, ITG *ialset, char *tieset,
+                               ITG *inomat, ITG *ne, ITG *ipkon, char *lakon, ITG *kon,
+                               ITG *ntie, double *tietol, ITG *nalset, ITG *nk, ITG *nset,
+                               ITG *iactive));
 
-void FORTRAN(create_inoelf,(ITG *nef,ITG *ipkonf,char *lakonf,ITG *konf,
-			    ITG *iponoelf,ITG *inoelf,ITG *ifreenoelf));
+void FORTRAN(create_inoelf, (ITG * nef, ITG *ipkonf, char *lakonf, ITG *konf,
+                             ITG *iponoelf, ITG *inoelf, ITG *ifreenoelf));
 
-void FORTRAN(dattime,(char *date,char *clock));
+void FORTRAN(dattime, (char *date, char *clock));
 
-void CEE(ddotc,(ITG *n,double *dx,ITG *incx,double *dy,ITG *incy,
-                double *funcddot));
+void CEE(ddotc, (ITG * n, double *dx, ITG *incx, double *dy, ITG *incy,
+                 double *funcddot));
 
-void dam1parll(ITG *mt,ITG *nactdof,double *aux2,double *v,
-                    double *vini,ITG *nk,ITG *num_cpus);
+void dam1parll(ITG *mt, ITG *nactdof, double *aux2, double *v,
+               double *vini, ITG *nk, ITG *num_cpus);
 
 void *dam1parllmt(ITG *i);
 
-void dam2parll(double *dampwk,double *cv,double *cvini,
-                    double *aux2,ITG *neq0,ITG *num_cpus);
+void dam2parll(double *dampwk, double *cv, double *cvini,
+               double *aux2, ITG *neq0, ITG *num_cpus);
 
 void *dam2parllmt(ITG *i);
 
 void *ddotc1mt(ITG *i);
 
-void FORTRAN(deactiextfaces,(ITG *nktet,ITG *ipofa,ITG *ifac,double *planfa,
-			     ITG *iexternfa));
+void FORTRAN(deactiextfaces, (ITG * nktet, ITG *ipofa, ITG *ifac, double *planfa,
+                              ITG *iexternfa));
 
-void dealloc_cal(ITG *ncs_,ITG **icsp,ITG *mcs,double **csp,
-		 char **tiesetp,double **tietolp,double **cop,
-		 ITG **konp,ITG **ipkonp,char **lakonp,ITG **nodebounp,
-		 ITG **ndirbounp,char **typebounp,double **xbounp,
-		 ITG **ikbounp,ITG **ilbounp,ITG **nodebounoldp,
-		 ITG **ndirbounoldp,double **xbounoldp,ITG **ipompcp,
-		 char **labmpcp,ITG **ikmpcp,ITG **ilmpcp,
-		 double **fmpcp,ITG **nodempcp,double **coefmpcp,
-		 ITG **nodempcrefp,double **coefmpcrefp,ITG **ikmpcrefp,
-		 ITG **nodeforcp,ITG **ndirforc,double **xforcp,
-		 ITG **ikforcp,ITG **ilforcp,double **xforcoldp,
-		 ITG **nelemloadp,char **sideloadp,double **xloadp,
-		 double **xloadoldp,char **cbodyp,ITG **ibodyp,
-		 double **xbodyp,double **xbodyoldp,ITG *nam,
-		 ITG **iambounp,ITG **iamforcp,ITG **iamloadp,
-		 char **amnamep,double **amtap,ITG **namtap,char **setp,
-		 ITG **istartsetp,ITG **iendsetp,ITG **ialsetp,
-		 double **elconp,ITG **nelconp,double **rhconp,
-		 ITG **nrhconp,double **shconp,ITG **nshconp,
-		 double **coconp,ITG **ncoconp,double **alconp,
-		 ITG **nalconp,double **alzerop,ITG *nprop,
-		 ITG **ielpropp,double **propp,ITG *npmat_,
-		 double **pliconp,ITG **npliconp,double **plkconp,
-		 ITG **nplkconp,ITG *ndamp,double **daconp,ITG *norien,
-		 char **ornamep,double **orabp,ITG **ielorienp,
-		 ITG *ntrans,double **trabp,ITG **inotrp,ITG *iprestr,
-		 double **prestrp,ITG *ithermal,double **t0p,
-		 double **t1p,double **t1oldp,ITG **iamt1p,ITG *ne1d,
-		 ITG *ne2d,double **t0gp,double **t1gp,
-		 ITG *irobustdesign,ITG **irandomtypep,
-		 double **randompvalp,char **prlabp,char **prsetp,
-		 char **filabp,double **xmodalp,ITG **ielmatp,
-		 char **matnamep,double **stip,double **emep,
-		 double **enerp,double **xstatep,double **voldp,
-		 double **veoldp,double **velp,double **velop,
-		 double **veloop,ITG **iponorp,double **xnorp,
-		 ITG **knorp,double **thickep,double **offsetp,
-		 ITG **iponoelp,ITG **inoelp,ITG **rigp,
-		 ITG **ne2bounp,ITG **islavsurfp,ITG *mortar,
-		 double **pslavsurfp,double **clearinip,
-		 ITG *nobject_,char **objectsetp,ITG *nmethod,ITG *iperturb,
-		 ITG *irefineloop,ITG **iparentelp,ITG **iprfnp,ITG **konrfnp,
-		 double **ratiorfnp,char **headingp,ITG **nodedesip,
-		 double **dgdxglobp,double **g0p,ITG *nuel_,double **xdesip,
-		 ITG *nfc,double **coeffcp,ITG **idckp,double **edcp);
+void dealloc_cal(ITG *ncs_, ITG **icsp, ITG *mcs, double **csp,
+                 char **tiesetp, double **tietolp, double **cop,
+                 ITG **konp, ITG **ipkonp, char **lakonp, ITG **nodebounp,
+                 ITG **ndirbounp, char **typebounp, double **xbounp,
+                 ITG **ikbounp, ITG **ilbounp, ITG **nodebounoldp,
+                 ITG **ndirbounoldp, double **xbounoldp, ITG **ipompcp,
+                 char **labmpcp, ITG **ikmpcp, ITG **ilmpcp,
+                 double **fmpcp, ITG **nodempcp, double **coefmpcp,
+                 ITG **nodempcrefp, double **coefmpcrefp, ITG **ikmpcrefp,
+                 ITG **nodeforcp, ITG **ndirforc, double **xforcp,
+                 ITG **ikforcp, ITG **ilforcp, double **xforcoldp,
+                 ITG **nelemloadp, char **sideloadp, double **xloadp,
+                 double **xloadoldp, char **cbodyp, ITG **ibodyp,
+                 double **xbodyp, double **xbodyoldp, ITG *nam,
+                 ITG **iambounp, ITG **iamforcp, ITG **iamloadp,
+                 char **amnamep, double **amtap, ITG **namtap, char **setp,
+                 ITG **istartsetp, ITG **iendsetp, ITG **ialsetp,
+                 double **elconp, ITG **nelconp, double **rhconp,
+                 ITG **nrhconp, double **shconp, ITG **nshconp,
+                 double **coconp, ITG **ncoconp, double **alconp,
+                 ITG **nalconp, double **alzerop, ITG *nprop,
+                 ITG **ielpropp, double **propp, ITG *npmat_,
+                 double **pliconp, ITG **npliconp, double **plkconp,
+                 ITG **nplkconp, ITG *ndamp, double **daconp, ITG *norien,
+                 char **ornamep, double **orabp, ITG **ielorienp,
+                 ITG *ntrans, double **trabp, ITG **inotrp, ITG *iprestr,
+                 double **prestrp, ITG *ithermal, double **t0p,
+                 double **t1p, double **t1oldp, ITG **iamt1p, ITG *ne1d,
+                 ITG *ne2d, double **t0gp, double **t1gp,
+                 ITG *irobustdesign, ITG **irandomtypep,
+                 double **randompvalp, char **prlabp, char **prsetp,
+                 char **filabp, double **xmodalp, ITG **ielmatp,
+                 char **matnamep, double **stip, double **emep,
+                 double **enerp, double **xstatep, double **voldp,
+                 double **veoldp, double **velp, double **velop,
+                 double **veloop, ITG **iponorp, double **xnorp,
+                 ITG **knorp, double **thickep, double **offsetp,
+                 ITG **iponoelp, ITG **inoelp, ITG **rigp,
+                 ITG **ne2bounp, ITG **islavsurfp, ITG *mortar,
+                 double **pslavsurfp, double **clearinip,
+                 ITG *nobject_, char **objectsetp, ITG *nmethod, ITG *iperturb,
+                 ITG *irefineloop, ITG **iparentelp, ITG **iprfnp, ITG **konrfnp,
+                 double **ratiorfnp, char **headingp, ITG **nodedesip,
+                 double **dgdxglobp, double **g0p, ITG *nuel_, double **xdesip,
+                 ITG *nfc, double **coeffcp, ITG **idckp, double **edcp);
 
-void FORTRAN(desiperelem,(ITG *ndesi,ITG *istartdesi,ITG *ialdesi,
-                          ITG *ipoeldi,ITG *ieldi,ITG *ne,
-                          ITG *istartelem,ITG *ialelem));
+void FORTRAN(desiperelem, (ITG * ndesi, ITG *istartdesi, ITG *ialdesi,
+                           ITG *ipoeldi, ITG *ieldi, ITG *ne,
+                           ITG *istartelem, ITG *ialelem));
 
-void  FORTRAN(resforccont,(double *vold,ITG *nk,ITG *mi,double *aubi,
-			   ITG *irowbi,ITG *jqbi,ITG *neqtot,ITG *ktot,
-			   double *fext,double *gapdof,
-			   double *auib,ITG *irowib,ITG *jqib,
-			   ITG *nactdof,double *volddof,
-			   ITG *neq,double *qik_kbi));
+void FORTRAN(resforccont, (double *vold, ITG *nk, ITG *mi, double *aubi,
+                           ITG *irowbi, ITG *jqbi, ITG *neqtot, ITG *ktot,
+                           double *fext, double *gapdof,
+                           double *auib, ITG *irowib, ITG *jqib,
+                           ITG *nactdof, double *volddof,
+                           ITG *neq, double *qik_kbi));
 
-void FORTRAN(detectactivecont,(double *gapnorm,double *gapdisp,double *auw,
-			       ITG *iroww,ITG *jqw,ITG *nslavs,
-			       double *springarea,ITG *iacti,ITG *nacti));
+void FORTRAN(detectactivecont, (double *gapnorm, double *gapdisp, double *auw,
+                                ITG *iroww, ITG *jqw, ITG *nslavs,
+                                double *springarea, ITG *iacti, ITG *nacti));
 
-void FORTRAN(determineextern,(ITG *ifac,ITG *itetfa,ITG *iedg,ITG *ipoed,
-                              ITG *iexternedg,ITG *iexternfa,ITG *iexternnode,
-                              ITG *nktet_,ITG *ipofa));
+void FORTRAN(determineextern, (ITG * ifac, ITG *itetfa, ITG *iedg, ITG *ipoed,
+                               ITG *iexternedg, ITG *iexternfa, ITG *iexternnode,
+                               ITG *nktet_, ITG *ipofa));
 
-void dfdbj(double *bcont,double **dbcontp,ITG *neq,ITG *nope,
-           ITG *konl,ITG *nactdof,double *s,double *z,ITG *ikmpc,
-           ITG *ilmpc,ITG *ipompc,ITG *nodempc,ITG *nmpc,
-           double *coefmpc,double *fnl,ITG *nev,
-           ITG **ikactcontp,ITG **ilactcontp,ITG *nactcont,ITG *nactcont_,
-           ITG *mi,ITG *cyclicsymmetry,ITG *izdof,ITG *nzdof);
-      
-void FORTRAN(dgesv,(ITG *nteq,ITG *nhrs,double *ac,ITG *lda,ITG *ipiv,
-                     double *bc,ITG *ldb,ITG *info)); 
+void dfdbj(double *bcont, double **dbcontp, ITG *neq, ITG *nope,
+           ITG *konl, ITG *nactdof, double *s, double *z, ITG *ikmpc,
+           ITG *ilmpc, ITG *ipompc, ITG *nodempc, ITG *nmpc,
+           double *coefmpc, double *fnl, ITG *nev,
+           ITG **ikactcontp, ITG **ilactcontp, ITG *nactcont, ITG *nactcont_,
+           ITG *mi, ITG *cyclicsymmetry, ITG *izdof, ITG *nzdof);
 
-void FORTRAN(dgetrs,(char *trans,ITG *nteq,ITG *nrhs,double *ac,ITG *lda,
-                      ITG *ipiv,double *bc,ITG *ldb,ITG *info));
+void FORTRAN(dgesv, (ITG * nteq, ITG *nhrs, double *ac, ITG *lda, ITG *ipiv,
+                     double *bc, ITG *ldb, ITG *info));
 
-void FORTRAN(dgmres1,(ITG *n,double *b,double *x,ITG *nelt,ITG *ia,ITG *ja,
-             double *a,ITG *isym,ITG *itol,double *tol,ITG *itmax,ITG *iter,
-             double *err,ITG *ierr,ITG *iunit,double *sb,double *sx,
-             double *rgwk,ITG *lrgw,ITG *igwk,ITG *ligw,double *rwork,
-             ITG *iwork));
+void FORTRAN(dgetrs, (char *trans, ITG *nteq, ITG *nrhs, double *ac, ITG *lda,
+                      ITG *ipiv, double *bc, ITG *ldb, ITG *info));
 
-void dgmresmain(ITG *n,double *b,double *x,ITG *nelt,ITG *ia,ITG *ja,
-             double *a,ITG *isym,ITG *itol,double *tol,ITG *itmax,ITG *iter,
-             double *err,ITG *ierr,ITG *iunit,double *sb,double *sx,
-             double *rgwk,ITG *lrgw,ITG *igwk,ITG *ligw,double *rwork,
-	     ITG *iwork,ITG *nestart,ITG *num_cpus,double *dgmrestol);
+void FORTRAN(dgmres1, (ITG * n, double *b, double *x, ITG *nelt, ITG *ia, ITG *ja,
+                       double *a, ITG *isym, ITG *itol, double *tol, ITG *itmax, ITG *iter,
+                       double *err, ITG *ierr, ITG *iunit, double *sb, double *sx,
+                       double *rgwk, ITG *lrgw, ITG *igwk, ITG *ligw, double *rwork,
+                       ITG *iwork));
+
+void dgmresmain(ITG *n, double *b, double *x, ITG *nelt, ITG *ia, ITG *ja,
+                double *a, ITG *isym, ITG *itol, double *tol, ITG *itmax, ITG *iter,
+                double *err, ITG *ierr, ITG *iunit, double *sb, double *sx,
+                double *rgwk, ITG *lrgw, ITG *igwk, ITG *ligw, double *rwork,
+                ITG *iwork, ITG *nestart, ITG *num_cpus, double *dgmrestol);
 
 void *dgmres1mt(ITG *i);
 
-void FORTRAN(disp_sen_dv,(ITG *nodeset,ITG *istartset,ITG *iendset,ITG *ialset,
-                          ITG *iobject,ITG *mi,ITG *nactdof,double *dgdu,
-                          double *vold,char *objectset,ITG *nactdofinv,
-                          ITG *neq,double *g0));
+void FORTRAN(disp_sen_dv, (ITG * nodeset, ITG *istartset, ITG *iendset, ITG *ialset,
+                           ITG *iobject, ITG *mi, ITG *nactdof, double *dgdu,
+                           double *vold, char *objectset, ITG *nactdofinv,
+                           ITG *neq, double *g0));
 
-void FORTRAN(distributesens,(ITG *istartdesi,ITG *ialdesi,ITG *ipkon,
-            char *lakon,ITG *ipoface,ITG *ndesi,ITG *nodedesi,ITG *nodface,
-            ITG *kon,double *co,double *dgdx,ITG *nobject,
-            double *weightformgrad,ITG *nodedesiinv,ITG *noregion,
-            char *objectset,double *dgdxglob,ITG *nk,double *physcon,
-	    ITG* nobjectstart));
+void FORTRAN(distributesens, (ITG * istartdesi, ITG *ialdesi, ITG *ipkon,
+                              char *lakon, ITG *ipoface, ITG *ndesi, ITG *nodedesi, ITG *nodface,
+                              ITG *kon, double *co, double *dgdx, ITG *nobject,
+                              double *weightformgrad, ITG *nodedesiinv, ITG *noregion,
+                              char *objectset, double *dgdxglob, ITG *nk, double *physcon,
+                              ITG *nobjectstart));
 
-void divparll(double *var1,double *var2,ITG *size,ITG *num_cpus);
+void divparll(double *var1, double *var2, ITG *size, ITG *num_cpus);
 
 void *divparllmt(ITG *i);
 
-void FORTRAN(dmatrix,(double *ad,double *au,ITG *jqs,ITG *irows,ITG *icols,
-		      ITG *ndesi,ITG *nodedesi,double *add,double *aud,
-		      ITG *jqd,ITG *irowd,ITG *ndesibou,ITG *nodedesibou));
+void FORTRAN(dmatrix, (double *ad, double *au, ITG *jqs, ITG *irows, ITG *icols,
+                       ITG *ndesi, ITG *nodedesi, double *add, double *aud,
+                       ITG *jqd, ITG *irowd, ITG *ndesibou, ITG *nodedesibou));
 
-void FORTRAN(drfftf,(ITG *ndata,double *r,double *wsave,ITG *isave));
+void FORTRAN(drfftf, (ITG * ndata, double *r, double *wsave, ITG *isave));
 
-void FORTRAN(drffti,(ITG *ndata,double *wsave,ITG *isave));
+void FORTRAN(drffti, (ITG * ndata, double *wsave, ITG *isave));
 
-void FORTRAN(dnaupd,(ITG *ido,char *bmat,ITG *n,char *which,ITG *nev,
-             double *tol,double *resid,ITG *ncv,double *z,ITG *ldz,
-             ITG *iparam,ITG *ipntr,double *workd,double *workl,
-             ITG *lworkl,ITG *info));
+void FORTRAN(dnaupd, (ITG * ido, char *bmat, ITG *n, char *which, ITG *nev,
+                      double *tol, double *resid, ITG *ncv, double *z, ITG *ldz,
+                      ITG *iparam, ITG *ipntr, double *workd, double *workl,
+                      ITG *lworkl, ITG *info));
 
-void FORTRAN(dsaupd,(ITG *ido,char *bmat,ITG *n,char *which,ITG *nev,
-             double *tol,double *resid,ITG *ncv,double *z,ITG *ldz,
-             ITG *iparam,ITG *ipntr,double *workd,double *workl,
-             ITG *lworkl,ITG *info));
+void FORTRAN(dsaupd, (ITG * ido, char *bmat, ITG *n, char *which, ITG *nev,
+                      double *tol, double *resid, ITG *ncv, double *z, ITG *ldz,
+                      ITG *iparam, ITG *ipntr, double *workd, double *workl,
+                      ITG *lworkl, ITG *info));
 
-void FORTRAN(dneupd,(ITG *rvec,char *howmny,ITG *select,double *d,
-             double *di,double *z,ITG *ldz,double *sigma,double *sigmai,
-             double *workev,char *bmat,ITG *neq,char *which,
-             ITG *nev,double *tol,double *resid,ITG *ncv,double *v,
-             ITG *ldv,ITG *iparam,ITG *ipntr,double *workd,
-             double *workl,ITG *lworkl,ITG *info));
+void FORTRAN(dneupd, (ITG * rvec, char *howmny, ITG *select, double *d,
+                      double *di, double *z, ITG *ldz, double *sigma, double *sigmai,
+                      double *workev, char *bmat, ITG *neq, char *which,
+                      ITG *nev, double *tol, double *resid, ITG *ncv, double *v,
+                      ITG *ldv, ITG *iparam, ITG *ipntr, double *workd,
+                      double *workl, ITG *lworkl, ITG *info));
 
-void FORTRAN(dseupd,(ITG *rvec,char *howmny,ITG *select,double *d,double *z,
-             ITG *ldz,double *sigma,char *bmat,ITG *neq,char *which,
-             ITG *nev,double *tol,double *resid,ITG *ncv,double *v,
-             ITG *ldv,ITG *iparam,ITG *ipntr,double *workd,
-             double *workl,ITG *lworkl,ITG *info));
+void FORTRAN(dseupd, (ITG * rvec, char *howmny, ITG *select, double *d, double *z,
+                      ITG *ldz, double *sigma, char *bmat, ITG *neq, char *which,
+                      ITG *nev, double *tol, double *resid, ITG *ncv, double *v,
+                      ITG *ldv, ITG *iparam, ITG *ipntr, double *workd,
+                      double *workl, ITG *lworkl, ITG *info));
 
-void FORTRAN(dsort,(double *dx,ITG *iy,ITG *n,ITG *kflag));
+void FORTRAN(dsort, (double *dx, ITG *iy, ITG *n, ITG *kflag));
 
-void dudsmain(ITG *isolver,double *au,double *ad,double *aub,double*adb,
-	 ITG *icol,ITG *irow,ITG *jq,ITG *neq,ITG *nzs,double *df,ITG *jqs,
-	      ITG *irows,ITG *ndesi,double *duds);
+void dudsmain(ITG *isolver, double *au, double *ad, double *aub, double *adb,
+              ITG *icol, ITG *irow, ITG *jq, ITG *neq, ITG *nzs, double *df, ITG *jqs,
+              ITG *irows, ITG *ndesi, double *duds);
 
-void dyna(double **cop,ITG *nk,ITG **konp,ITG **ipkonp,char **lakonp,ITG *ne,
-               ITG **nodebounp,ITG **ndirbounp,double **xbounp,ITG *nboun,
-               ITG **ipompcp,ITG **nodempcp,double **coefmpcp,char **labmpcp,
-               ITG *nmpc,ITG *nodeforc,ITG *ndirforc,double *xforc,
-               ITG *nforc,ITG *nelemload,char *sideload,double *xload,
-               ITG *nload,
-               ITG **nactdofp,ITG *neq,ITG *nzl,ITG *icol,ITG *irow,
-               ITG *nmethod,ITG **ikmpcp,ITG **ilmpcp,ITG **ikbounp,
-               ITG **ilbounp,double *elcon,ITG *nelcon,double *rhcon,
-               ITG *nrhcon,double *cocon,ITG *ncocon,
-               double *alcon,ITG *nalcon,double *alzero,
-               ITG **ielmatp,ITG **ielorienp,ITG *norien,double *orab,
-               ITG *ntmat_,double **t0p,
-               double **t1p,ITG *ithermal,double *prestr,ITG *iprestr,
-               double **voldp,ITG *iperturb,double **stip,ITG *nzs,
-               double *timepar,double *xmodal,
-               double **veoldp,char *amname,double *amta,
-               ITG *namta,ITG *nam,ITG *iamforc,ITG *iamload,
-               ITG **iamt1p,ITG *jout,
-               ITG *kode,char *filab,double **emep,double *xforcold,
-               double *xloadold,
-               double **t1oldp,ITG **iambounp,double **xbounoldp,ITG *iexpl,
-               double *plicon,ITG *nplicon,double *plkcon,ITG *nplkcon,
-               double **xstatep,ITG *npmat_,char *matname,ITG *mi,
-               ITG *ncmat_,ITG *nstate_,double **enerp,char *jobnamec,
-               double *ttime,char *set,ITG *nset,ITG *istartset,
-               ITG *iendset,ITG **ialsetp,ITG *nprint,char *prlab,
-               char *prset,ITG *nener,double *trab,
-               ITG **inotrp,ITG *ntrans,double **fmpcp,ITG *ipobody,ITG *ibody,
-               double *xbody,ITG *nbody,double *xbodyold,ITG *istep,
-               ITG *isolver,ITG *jq,char *output,ITG *mcs,ITG *nkon,
-               ITG *mpcend,ITG *ics,double *cs,ITG *ntie,char *tieset,
-               ITG *idrct,ITG *jmax,
-               double *ctrl,ITG *itpamp,double *tietol,ITG *nalset,
-               ITG *ikforc,ITG *ilforc,double *thicke,
-               ITG *nslavs,ITG *nmat,char *typeboun,ITG *ielprop,double *prop,
-               char *orname,double *t0g,double *t1g);
+void dyna(double **cop, ITG *nk, ITG **konp, ITG **ipkonp, char **lakonp, ITG *ne,
+          ITG **nodebounp, ITG **ndirbounp, double **xbounp, ITG *nboun,
+          ITG **ipompcp, ITG **nodempcp, double **coefmpcp, char **labmpcp,
+          ITG *nmpc, ITG *nodeforc, ITG *ndirforc, double *xforc,
+          ITG *nforc, ITG *nelemload, char *sideload, double *xload,
+          ITG * nload,
+          ITG **nactdofp, ITG *neq, ITG *nzl, ITG *icol, ITG *irow,
+          ITG *nmethod, ITG **ikmpcp, ITG **ilmpcp, ITG **ikbounp,
+          ITG **ilbounp, double *elcon, ITG *nelcon, double *rhcon,
+          ITG *nrhcon, double *cocon, ITG *ncocon,
+          double *alcon, ITG *nalcon, double *alzero,
+          ITG **ielmatp, ITG **ielorienp, ITG *norien, double *orab,
+          ITG *ntmat_, double **t0p,
+          double **t1p, ITG *ithermal, double *prestr, ITG *iprestr,
+          double **voldp, ITG *iperturb, double **stip, ITG *nzs,
+          double *timepar, double *xmodal,
+          double **veoldp, char *amname, double *amta,
+          ITG *namta, ITG *nam, ITG *iamforc, ITG *iamload,
+          ITG **iamt1p, ITG *jout,
+          ITG *kode, char *filab, double **emep, double *xforcold,
+          double * xloadold,
+          double **t1oldp, ITG **iambounp, double **xbounoldp, ITG *iexpl,
+          double *plicon, ITG *nplicon, double *plkcon, ITG *nplkcon,
+          double **xstatep, ITG *npmat_, char *matname, ITG *mi,
+          ITG *ncmat_, ITG *nstate_, double **enerp, char *jobnamec,
+          double *ttime, char *set, ITG *nset, ITG *istartset,
+          ITG *iendset, ITG **ialsetp, ITG *nprint, char *prlab,
+          char *prset, ITG *nener, double *trab,
+          ITG **inotrp, ITG *ntrans, double **fmpcp, ITG *ipobody, ITG *ibody,
+          double *xbody, ITG *nbody, double *xbodyold, ITG *istep,
+          ITG *isolver, ITG *jq, char *output, ITG *mcs, ITG *nkon,
+          ITG *mpcend, ITG *ics, double *cs, ITG *ntie, char *tieset,
+          ITG *idrct, ITG *jmax,
+          double *ctrl, ITG *itpamp, double *tietol, ITG *nalset,
+          ITG *ikforc, ITG *ilforc, double *thicke,
+          ITG *nslavs, ITG *nmat, char *typeboun, ITG *ielprop, double *prop,
+          char *orname, double *t0g, double *t1g);
 
-void dynacont(double *co,ITG *nk,ITG *kon,ITG *ipkon,char *lakon,ITG *ne,
-              ITG *nodeboun,ITG *ndirboun,double *xboun,ITG *nboun,
-              ITG *ipompc,ITG *nodempc,double *coefmpc,char *labmpc,
-              ITG *nmpc,ITG *nodeforc,ITG *ndirforc,double *xforc,
-              ITG *nforc,ITG *nelemload,char *sideload,double *xload,
+void dynacont(double *co, ITG *nk, ITG *kon, ITG *ipkon, char *lakon, ITG *ne,
+              ITG *nodeboun, ITG *ndirboun, double *xboun, ITG *nboun,
+              ITG *ipompc, ITG *nodempc, double *coefmpc, char *labmpc,
+              ITG *nmpc, ITG *nodeforc, ITG *ndirforc, double *xforc,
+              ITG *nforc, ITG *nelemload, char *sideload, double *xload,
               ITG *nload,
-              ITG *nactdof,ITG *neq,ITG *nzl,ITG *icol,ITG *irow,
-              ITG *nmethod,ITG *ikmpc,ITG *ilmpc,ITG *ikboun,
-              ITG *ilboun,double *elcon,ITG *nelcon,double *rhcon,
-              ITG *nrhcon,double *cocon,ITG *ncocon,
-              double *alcon,ITG *nalcon,double *alzero,
-              ITG *ielmat,ITG *ielorien,ITG *norien,double *orab,
-              ITG *ntmat_,double *t0,
-              double *t1,ITG *ithermal,double *prestr,ITG *iprestr,
-              double *vold,ITG *iperturb,double *sti,ITG *nzs,
-              double *tinc,double *tper,double *xmodal,
-              double *veold,char *amname,double *amta,
-              ITG *namta,ITG *nam,ITG *iamforc,ITG *iamload,
-              ITG *iamt1,ITG *jout,char *filab,double *eme,double *xforcold,
+              ITG *nactdof, ITG *neq, ITG *nzl, ITG *icol, ITG *irow,
+              ITG *nmethod, ITG *ikmpc, ITG *ilmpc, ITG *ikboun,
+              ITG *ilboun, double *elcon, ITG *nelcon, double *rhcon,
+              ITG *nrhcon, double *cocon, ITG *ncocon,
+              double *alcon, ITG *nalcon, double *alzero,
+              ITG *ielmat, ITG *ielorien, ITG *norien, double *orab,
+              ITG *ntmat_, double *t0,
+              double *t1, ITG *ithermal, double *prestr, ITG *iprestr,
+              double *vold, ITG *iperturb, double *sti, ITG *nzs,
+              double *tinc, double *tper, double *xmodal,
+              double *veold, char *amname, double *amta,
+              ITG *namta, ITG *nam, ITG *iamforc, ITG *iamload,
+              ITG *iamt1, ITG *jout, char *filab, double *eme, double *xforcold,
               double *xloadold,
-              double *t1old,ITG *iamboun,double *xbounold,ITG *iexpl,
-              double *plicon,ITG *nplicon,double *plkcon,ITG *nplkcon,
-              double *xstate,ITG *npmat_,char *matname,ITG *mi,
-              ITG *ncmat_,ITG *nstate_,double *ener,char *jobnamec,
-              double *ttime,char *set,ITG *nset,ITG *istartset,
-              ITG *iendset,ITG *ialset,ITG *nprint,char *prlab,
-              char *prset,ITG *nener,double *trab,
-              ITG *inotr,ITG *ntrans,double *fmpc,char *cbody,ITG *ibody,
-              double *xbody,ITG *nbody,double *xbodyold,ITG *istep,
-              ITG *isolver,ITG *jq,char *output,ITG *mcs,ITG *nkon,
-              ITG *mpcend,ITG *ics,double *cs,ITG *ntie,char *tieset,
-              ITG *idrct,ITG *jmax,double *tmin,double *tmax,
-              double *ctrl,ITG *itpamp,double *tietol,ITG *iit,
-              ITG *ncont,ITG *ne0,double *reltime,double *dtime,
-              double *bcontini,double *bj,double *aux,ITG *iaux,
-              double *bcont,ITG *nev,double *v,
-              ITG *nkon0,double *deltmx,double *dtheta,double *theta,
-              ITG *iprescribedboundary,ITG *mpcfree,ITG *memmpc_,
-              ITG *itietri,ITG *koncont,double *cg,double *straight,
-              ITG *iinc,double *vini,
-              double *aa,double *bb,double *aanew,double *d,double *z,
-              double *zeta,double *b,double *time0,double *time1,
-              ITG *ipobody,
-              double *xforcact,double *xloadact,double *t1act,
-              double *xbounact,double *xbodyact,double *cd,double *cv,
-              double *ampli,double *dthetaref,double *bjp,double *bp,
-              double *cstr,ITG *imddof,
-              ITG *nmddof,ITG **ikactcontp,ITG *nactcont,ITG *nactcont_,
-              double *aamech,double *bprev,ITG *iprev,ITG *inonlinmpc,
-              ITG **ikactmechp,ITG *nactmech,ITG *imdnode,ITG *nmdnode,
-              ITG *imdboun,ITG *nmdboun,ITG *imdmpc,ITG *nmdmpc,
-              ITG *itp,ITG *inext,
-              ITG *imastop,ITG *nslavnode,ITG *islavnode,
+              double *t1old, ITG *iamboun, double *xbounold, ITG *iexpl,
+              double *plicon, ITG *nplicon, double *plkcon, ITG *nplkcon,
+              double *xstate, ITG *npmat_, char *matname, ITG *mi,
+              ITG *ncmat_, ITG *nstate_, double *ener, char *jobnamec,
+              double *ttime, char *set, ITG *nset, ITG *istartset,
+              ITG *iendset, ITG *ialset, ITG *nprint, char *prlab,
+              char *prset, ITG *nener, double *trab,
+              ITG *inotr, ITG *ntrans, double *fmpc, char *cbody, ITG *ibody,
+              double *xbody, ITG *nbody, double *xbodyold, ITG *istep,
+              ITG *isolver, ITG *jq, char *output, ITG *mcs, ITG *nkon,
+              ITG *mpcend, ITG *ics, double *cs, ITG *ntie, char *tieset,
+              ITG *idrct, ITG *jmax, double *tmin, double *tmax,
+              double *ctrl, ITG *itpamp, double *tietol, ITG *iit,
+              ITG *ncont, ITG *ne0, double *reltime, double *dtime,
+              double *bcontini, double *bj, double *aux, ITG *iaux,
+              double *bcont, ITG *nev, double *v,
+              ITG *nkon0, double *deltmx, double *dtheta, double *theta,
+              ITG *iprescribedboundary, ITG *mpcfree, ITG *memmpc_,
+              ITG *itietri, ITG *koncont, double *cg, double *straight,
+              ITG *iinc, double *vini,
+              double *aa, double *bb, double *aanew, double *d, double *z,
+              double *zeta, double *b, double *time0, double *time1,
+              ITG *   ipobody,
+              double *xforcact, double *xloadact, double *t1act,
+              double *xbounact, double *xbodyact, double *cd, double *cv,
+              double *ampli, double *dthetaref, double *bjp, double *bp,
+              double *cstr, ITG *imddof,
+              ITG *nmddof, ITG **ikactcontp, ITG *nactcont, ITG *nactcont_,
+              double *aamech, double *bprev, ITG *iprev, ITG *inonlinmpc,
+              ITG **ikactmechp, ITG *nactmech, ITG *imdnode, ITG *nmdnode,
+              ITG *imdboun, ITG *nmdboun, ITG *imdmpc, ITG *nmdmpc,
+              ITG *itp, ITG *inext,
+              ITG *imastop, ITG *nslavnode, ITG *islavnode,
               ITG *islavsurf,
-              ITG *itiefac,double *areaslav,ITG *iponoels,ITG *inoels,
-              double *springarea,ITG *izdof,ITG *nzdof,double *fn,
-              ITG *imastnode,ITG *nmastnode,double *xmastnor,
-              double *xstateini,ITG *nslavs,
-              ITG *cyclicsymmetry,double *xnoels,ITG *ielas,ITG *ielprop,
+              ITG *itiefac, double *areaslav, ITG *iponoels, ITG *inoels,
+              double *springarea, ITG *izdof, ITG *nzdof, double *fn,
+              ITG *imastnode, ITG *nmastnode, double *xmastnor,
+              double *xstateini, ITG *nslavs,
+              ITG *cyclicsymmetry, double *xnoels, ITG *ielas, ITG *ielprop,
               double *prop);
- 
-void dynboun(double *amta,ITG *namta,ITG *nam,double *ampli,double *time,
-             double *ttime,double *dtime,double *xbounold,double *xboun,
-             double *xbounact,ITG *iamboun,ITG *nboun,ITG *nodeboun,
-             ITG *ndirboun,double *ad,double *au,double *adb,
-             double *aub,ITG *icol,ITG *irow,ITG *neq,ITG *nzs,
-             double *sigma,double *b,ITG *isolver,
-             double *alpham,double *betam,ITG *nzl,
-             ITG *init,double *bact,double *bmin,ITG *jq,char *amname,
-             double *bv,double *bprev,double *bdiff,
-             ITG *nactmech,ITG *icorrect,ITG *iprev,double *reltime);
 
-void FORTRAN(dynresults,(ITG *nk,double *v,ITG *ithermal,ITG *nactdof,
-             double *vold,ITG *nodeboun,ITG *ndirboun,double *xboun,
-             ITG *nboun,ITG *ipompc,ITG *nodempc,double *coefmpc,
-             char *labmpc,ITG *nmpc,double *b,double *bp,double *veold,
-             double *dtime,ITG *mi,ITG *imdnode,ITG *nmdnode,ITG *imdboun,
-             ITG *nmdboun,ITG *imdmpc,ITG *nmdmpc,ITG *nmethod,double *time));
+void dynboun(double *amta, ITG *namta, ITG *nam, double *ampli, double *time,
+             double *ttime, double *dtime, double *xbounold, double *xboun,
+             double *xbounact, ITG *iamboun, ITG *nboun, ITG *nodeboun,
+             ITG *ndirboun, double *ad, double *au, double *adb,
+             double *aub, ITG *icol, ITG *irow, ITG *neq, ITG *nzs,
+             double *sigma, double *b, ITG *isolver,
+             double *alpham, double *betam, ITG *nzl,
+             ITG *init, double *bact, double *bmin, ITG *jq, char *amname,
+             double *bv, double *bprev, double *bdiff,
+             ITG *nactmech, ITG *icorrect, ITG *iprev, double *reltime);
 
-void FORTRAN(edgedivide,(ITG *nnewnodes,ITG *nktet_,ITG *ipoed,
-                         ITG *iexternedg,ITG *iedg,double *d,
-                         double *h,ITG *n,double *r,ITG *iext,
-			 ITG *jfix));
+void FORTRAN(dynresults, (ITG * nk, double *v, ITG *ithermal, ITG *nactdof,
+                          double *vold, ITG *nodeboun, ITG *ndirboun, double *xboun,
+                          ITG *nboun, ITG *ipompc, ITG *nodempc, double *coefmpc,
+                          char *labmpc, ITG *nmpc, double *b, double *bp, double *veold,
+                          double *dtime, ITG *mi, ITG *imdnode, ITG *nmdnode, ITG *imdboun,
+                          ITG *nmdboun, ITG *imdmpc, ITG *nmdmpc, ITG *nmethod, double *time));
 
-void FORTRAN(effectivemodalmass,(ITG *neq,ITG *nactdof,ITG *mi,double *adb,
-                        double *aub,ITG *jq,ITG *irow,ITG *nev,double *z,
-                        double *co,ITG *nk));
+void FORTRAN(edgedivide, (ITG * nnewnodes, ITG *nktet_, ITG *ipoed,
+                          ITG *iexternedg, ITG *iedg, double *d,
+                          double *h, ITG *n, double *r, ITG *iext,
+                          ITG *jfix));
 
-void electromagnetics(double **co,ITG *nk,ITG **konp,ITG **ipkonp,char **lakonp,
-             ITG *ne,ITG *nodeboun,ITG *ndirboun,double *xboun,ITG *nboun,
-             ITG **ipompcp,ITG **nodempcp,double **coefmpcp,char **labmpcp,
-             ITG *nmpc,ITG *nodeforc,ITG *ndirforc,double *xforc,ITG *nforc,
-             ITG **nelemloadp,char **sideloadp,double *xload,
-             ITG *nload,ITG *nactdof,ITG **icolp,ITG **jqp,ITG **irowp,
-             ITG *neq,ITG *nzl,ITG *nmethod,ITG **ikmpcp,ITG **ilmpcp,
-             ITG *ikboun,ITG *ilboun,double *elcon,ITG *nelcon,
-             double *rhcon,ITG *nrhcon,double *alcon,ITG *nalcon,
-             double *alzero,ITG **ielmatp,ITG **ielorienp,ITG *norien,
-             double *orab,ITG *ntmat_,double *t0,double *t1,double *t1old,
-             ITG *ithermal,double *prestr,ITG *iprestr,double **vold,
-             ITG *iperturb,double *sti,ITG *nzs,ITG *kode,char *filab,
-             ITG *idrct,ITG *jmax,ITG *jout,double *timepar,double *eme,
-             double *xbounold,double *xforcold,double *xloadold,
-             double *veold,double *accold,char *amname,double *amta,
-             ITG *namta,ITG *nam,ITG *iamforc,ITG **iamloadp,ITG *iamt1,
-             double *alpha,ITG *iexpl,ITG *iamboun,double *plicon,
-             ITG *nplicon,double *plkcon,ITG *nplkcon,
-             double **xstatep,ITG *npmat_,ITG *istep,double *ttime,
-             char *matname,double *qaold,ITG *mi,
-             ITG *isolver,ITG *ncmat_,ITG *nstate_,ITG *iumat,
-             double *cs,ITG *mcs,ITG *nkon,double **ener,ITG *mpcinfo,
-             char *output,double *shcon,ITG *nshcon,double *cocon,ITG *ncocon,
-             double *physcon,ITG *nflow,double *ctrl,
-             char **setp,ITG *nset,ITG **istartsetp,
-             ITG **iendsetp,ITG **ialsetp,ITG *nprint,char *prlab,
-             char *prset,ITG *nener,ITG *ikforc,ITG *ilforc,double *trab,
-             ITG *inotr,ITG *ntrans,double **fmpcp,ITG *ipobody,
-             ITG *ibody,double *xbody,ITG *nbody,double *xbodyold,
-             ITG *ielprop,double *prop,ITG *ntie,char **tiesetp,
-             ITG *itpamp,ITG *iviewfile,char *jobnamec,double **tietolp,
-             ITG *nslavs,double *thicke,ITG *ics,ITG *nalset,ITG *nmpc_,
-             ITG *nmat,char *typeboun,ITG *iaxial,ITG *nload_,ITG *nprop,
-             ITG *network,char *orname,double *t0g,double *t1g);
+void FORTRAN(effectivemodalmass, (ITG * neq, ITG *nactdof, ITG *mi, double *adb,
+                                  double *aub, ITG *jq, ITG *irow, ITG *nev, double *z,
+                                  double *co, ITG *nk));
 
-void elementcpuload(ITG *neapar,ITG *nebpar,ITG *ne,ITG *ipkon,
-                             ITG *num_cpus);
+void electromagnetics(double **co, ITG *nk, ITG **konp, ITG **ipkonp, char **lakonp,
+                      ITG *ne, ITG *nodeboun, ITG *ndirboun, double *xboun, ITG *nboun,
+                      ITG **ipompcp, ITG **nodempcp, double **coefmpcp, char **labmpcp,
+                      ITG *nmpc, ITG *nodeforc, ITG *ndirforc, double *xforc, ITG *nforc,
+                      ITG **nelemloadp, char **sideloadp, double *xload,
+                      ITG *nload, ITG *nactdof, ITG **icolp, ITG **jqp, ITG **irowp,
+                      ITG *neq, ITG *nzl, ITG *nmethod, ITG **ikmpcp, ITG **ilmpcp,
+                      ITG *ikboun, ITG *ilboun, double *elcon, ITG *nelcon,
+                      double *rhcon, ITG *nrhcon, double *alcon, ITG *nalcon,
+                      double *alzero, ITG **ielmatp, ITG **ielorienp, ITG *norien,
+                      double *orab, ITG *ntmat_, double *t0, double *t1, double *t1old,
+                      ITG *ithermal, double *prestr, ITG *iprestr, double **vold,
+                      ITG *iperturb, double *sti, ITG *nzs, ITG *kode, char *filab,
+                      ITG *idrct, ITG *jmax, ITG *jout, double *timepar, double *eme,
+                      double *xbounold, double *xforcold, double *xloadold,
+                      double *veold, double *accold, char *amname, double *amta,
+                      ITG *namta, ITG *nam, ITG *iamforc, ITG **iamloadp, ITG *iamt1,
+                      double *alpha, ITG *iexpl, ITG *iamboun, double *plicon,
+                      ITG *nplicon, double *plkcon, ITG *nplkcon,
+                      double **xstatep, ITG *npmat_, ITG *istep, double *ttime,
+                      char *matname, double *qaold, ITG *mi,
+                      ITG *isolver, ITG *ncmat_, ITG *nstate_, ITG *iumat,
+                      double *cs, ITG *mcs, ITG *nkon, double **ener, ITG *mpcinfo,
+                      char *output, double *shcon, ITG *nshcon, double *cocon, ITG *ncocon,
+                      double *physcon, ITG *nflow, double *ctrl,
+                      char **setp, ITG *nset, ITG **istartsetp,
+                      ITG **iendsetp, ITG **ialsetp, ITG *nprint, char *prlab,
+                      char *prset, ITG *nener, ITG *ikforc, ITG *ilforc, double *trab,
+                      ITG *inotr, ITG *ntrans, double **fmpcp, ITG *ipobody,
+                      ITG *ibody, double *xbody, ITG *nbody, double *xbodyold,
+                      ITG *ielprop, double *prop, ITG *ntie, char **tiesetp,
+                      ITG *itpamp, ITG *iviewfile, char *jobnamec, double **tietolp,
+                      ITG *nslavs, double *thicke, ITG *ics, ITG *nalset, ITG *nmpc_,
+                      ITG *nmat, char *typeboun, ITG *iaxial, ITG *nload_, ITG *nprop,
+                      ITG *network, char *orname, double *t0g, double *t1g);
 
-void FORTRAN(elementpernode,(ITG *iponoel,ITG *inoel,char *lakon,ITG *ipkon,
-                             ITG *kon,ITG *ne));
+void elementcpuload(ITG *neapar, ITG *nebpar, ITG *ne, ITG *ipkon,
+                    ITG *num_cpus);
 
-void FORTRAN(elementpernodef,(ITG *iponoel,ITG *inoel,char *lakonf,ITG *ipkonf,
-                             ITG *konf,ITG *nef));
+void FORTRAN(elementpernode, (ITG * iponoel, ITG *inoel, char *lakon, ITG *ipkon,
+                              ITG *kon, ITG *ne));
 
-void FORTRAN(elemperorien,(ITG *ipoorel,ITG *iorel,ITG *ielorien,
-                              ITG *ne,ITG *mi));
+void FORTRAN(elementpernodef, (ITG * iponoel, ITG *inoel, char *lakonf, ITG *ipkonf,
+                               ITG *konf, ITG *nef));
 
-void FORTRAN(elemperdesi,(ITG *ndesi,ITG *nodedesi,ITG *iponoel,
-                            ITG *inoel,ITG *istartdesi,ITG *ialdesi,
-                            char *lakon,ITG *ipkon,ITG *kon,ITG *nodedesiinv,
-                            ITG *icoordinate,ITG *noregion));
+void FORTRAN(elemperorien, (ITG * ipoorel, ITG *iorel, ITG *ielorien,
+                            ITG *ne, ITG *mi));
 
-void FORTRAN(envtemp,(ITG *itg,ITG *ieg,ITG *ntg,ITG *ntr,char *sideload,
-                      ITG *nelemload,ITG *ipkon,ITG *kon,char *lakon,
-                      ITG *ielmat,ITG *ne,ITG *nload,
-                      ITG *kontri,ITG *ntri,ITG *nloadtr,
-                      ITG *nflow,ITG *ndirboun,ITG *nactdog,
-                      ITG *nodeboun,ITG *nacteq,
-                      ITG *nboun,ITG *ielprop,double *prop,ITG *nteq,
-                      double *v,ITG *network,double *physcon,
-                      double *shcon,ITG *ntmat_,double *co,
-                      double *vold,char *set,ITG *nshcon,
-                      double *rhcon,ITG *nrhcon,ITG *mi,ITG *nmpc,
-                      ITG *nodempc,ITG *ipompc,char *labmpc,ITG *ikboun,
-                      ITG *nasym,double *ttime,double *time,ITG *iaxial));
+void FORTRAN(elemperdesi, (ITG * ndesi, ITG *nodedesi, ITG *iponoel,
+                           ITG *inoel, ITG *istartdesi, ITG *ialdesi,
+                           char *lakon, ITG *ipkon, ITG *kon, ITG *nodedesiinv,
+                           ITG *icoordinate, ITG *noregion));
 
-void FORTRAN(eqspacednodes,(double *co,ITG *istartfront,ITG *iendfront,
-			    ITG *nnfront,ITG *ifrontprop,
-			    ITG *nk,ITG *nfront,ITG *ifronteq,
-			    double *charlen,ITG *istartfronteq,
-			    ITG *iendfronteq,ITG *nfronteq,
-			    double *acrackglob,ITG *ier,ITG *iendcrackfro,
-			    ITG *iincglob,ITG *iinc,double *dnglob,
-			    ITG *ncyc));
+void FORTRAN(envtemp, (ITG * itg, ITG *ieg, ITG *ntg, ITG *ntr, char *sideload,
+                       ITG *nelemload, ITG *ipkon, ITG *kon, char *lakon,
+                       ITG *ielmat, ITG *ne, ITG *nload,
+                       ITG *kontri, ITG *ntri, ITG *nloadtr,
+                       ITG *nflow, ITG *ndirboun, ITG *nactdog,
+                       ITG *nodeboun, ITG *nacteq,
+                       ITG *nboun, ITG *ielprop, double *prop, ITG *nteq,
+                       double *v, ITG *network, double *physcon,
+                       double *shcon, ITG *ntmat_, double *co,
+                       double *vold, char *set, ITG *nshcon,
+                       double *rhcon, ITG *nrhcon, ITG *mi, ITG *nmpc,
+                       ITG *nodempc, ITG *ipompc, char *labmpc, ITG *ikboun,
+                       ITG *nasym, double *ttime, double *time, ITG *iaxial));
 
-void FORTRAN(equationcheck,(double *ac,ITG *nteq,ITG *nactdog,
-                            ITG *itg,ITG *ntg,ITG *nacteq,ITG *network));
+void FORTRAN(eqspacednodes, (double *co, ITG *istartfront, ITG *iendfront,
+                             ITG *nnfront, ITG *ifrontprop,
+                             ITG *nk, ITG *nfront, ITG *ifronteq,
+                             double *charlen, ITG *istartfronteq,
+                             ITG *iendfronteq, ITG *nfronteq,
+                             double *acrackglob, ITG *ier, ITG *iendcrackfro,
+                             ITG *iincglob, ITG *iinc, double *dnglob,
+                             ITG *ncyc));
 
-void FORTRAN(errorestimator,(double *yi,double *yn,ITG *ipkon,
-             ITG *kon,char *lakon,ITG *nk,ITG *ne,ITG *mi,ITG *ielmat,
-             ITG *nterms,ITG *inum,double *co,double *vold,char *cflag,
-             ITG *ielprop,double *prop));
+void FORTRAN(equationcheck, (double *ac, ITG *nteq, ITG *nactdog,
+                             ITG *itg, ITG *ntg, ITG *nacteq, ITG *network));
 
-void expand(double *co,ITG *nk,ITG *kon,ITG *ipkon,char *lakon,
-             ITG *ne,ITG *nodeboun,ITG *ndirboun,double *xboun,ITG *nboun,
-             ITG *ipompc,ITG *nodempc,double *coefmpc,char *labmpc,
-             ITG *nmpc,ITG *nodeforc,ITG *ndirforc,double *xforc,
-             ITG *nforc,ITG *nelemload,char *sideload,double *xload,
-             ITG *nload,ITG *nactdof,ITG *neq,
-             ITG *nmethod,ITG *ikmpc,ITG *ilmpc,ITG *ikboun,ITG *ilboun,
-             double *elcon,ITG *nelcon,double *rhcon,ITG *nrhcon,
-             double *alcon,ITG *nalcon,double *alzero,ITG *ielmat,
-             ITG *ielorien,ITG *norien,double *orab,ITG *ntmat_,
-             double *t0,ITG *ithermal,double *prestr,ITG *iprestr,
-             double *vold,ITG *iperturb,double *sti,ITG *nzs,
-             double *adb,double *aub,char *filab,double *eme,
-             double *plicon,ITG *nplicon,double *plkcon,ITG *nplkcon,
-             double *xstate,ITG *npmat_,char *matname,ITG *mi,
-             ITG *ics,double *cs,ITG *mpcend,ITG *ncmat_,
-             ITG *nstate_,ITG *mcs,ITG *nkon,double *ener,
-             char *jobnamec,char *output,char *set,ITG *nset,ITG *istartset,
-             ITG *iendset,ITG *ialset,ITG *nprint,char *prlab,
-             char *prset,ITG *nener,double *trab,
-             ITG *inotr,ITG *ntrans,double *ttime,double *fmpc,
-             ITG *nev,double **z,ITG *iamboun,double *xbounold,
-             ITG *nsectors,ITG *nm,ITG *icol,ITG *irow,ITG *nzl,ITG *nam,
-             ITG *ipompcold,ITG *nodempcold,double *coefmpcold,
-             char *labmpcold,ITG *nmpcold,double *xloadold,ITG *iamload,
-             double *t1old,double *t1,ITG *iamt1,double *xstiff,ITG **icolep,
-             ITG **jqep,ITG **irowep,ITG *isolver,
-             ITG *nzse,double **adbep,double **aubep,ITG *iexpl,ITG *ibody,
-             double *xbody,ITG *nbody,double *cocon,ITG *ncocon,
-             char* tieset,ITG* ntie,ITG *imddof,ITG *nmddof,
-             ITG *imdnode,ITG *nmdnode,ITG *imdboun,ITG *nmdboun,
-             ITG *imdmpc,ITG *nmdmpc,ITG **izdofp,ITG *nzdof,ITG *nherm,
-             double *xmr,double *xmi,char *typeboun,ITG *ielprop,double *prop,
-             char *orname,ITG *itiefac,double *t0g,double *t1g);
+void FORTRAN(errorestimator, (double *yi, double *yn, ITG *ipkon,
+                              ITG *kon, char *lakon, ITG *nk, ITG *ne, ITG *mi, ITG *ielmat,
+                              ITG *nterms, ITG *inum, double *co, double *vold, char *cflag,
+                              ITG *ielprop, double *prop));
 
-void FORTRAN(expand_auw,(double *auw,ITG *jqw,ITG *iroww,ITG *nslavs,
-			 double *auwnew,ITG *jqwnew,ITG *irowwnew,
-			 ITG *neqslav,ITG *nactdof,
-			 ITG *mi,ITG *ktot,ITG *neqtot,ITG *islavnode,
-			 ITG *imastnode));
+void expand(double *co, ITG *nk, ITG *kon, ITG *ipkon, char *lakon,
+            ITG *ne, ITG *nodeboun, ITG *ndirboun, double *xboun, ITG *nboun,
+            ITG *ipompc, ITG *nodempc, double *coefmpc, char *labmpc,
+            ITG *nmpc, ITG *nodeforc, ITG *ndirforc, double *xforc,
+            ITG *nforc, ITG *nelemload, char *sideload, double *xload,
+            ITG *nload, ITG *nactdof, ITG *neq,
+            ITG *nmethod, ITG *ikmpc, ITG *ilmpc, ITG *ikboun, ITG *ilboun,
+            double *elcon, ITG *nelcon, double *rhcon, ITG *nrhcon,
+            double *alcon, ITG *nalcon, double *alzero, ITG *ielmat,
+            ITG *ielorien, ITG *norien, double *orab, ITG *ntmat_,
+            double *t0, ITG *ithermal, double *prestr, ITG *iprestr,
+            double *vold, ITG *iperturb, double *sti, ITG *nzs,
+            double *adb, double *aub, char *filab, double *eme,
+            double *plicon, ITG *nplicon, double *plkcon, ITG *nplkcon,
+            double *xstate, ITG *npmat_, char *matname, ITG *mi,
+            ITG *ics, double *cs, ITG *mpcend, ITG *ncmat_,
+            ITG *nstate_, ITG *mcs, ITG *nkon, double *ener,
+            char *jobnamec, char *output, char *set, ITG *nset, ITG *istartset,
+            ITG *iendset, ITG *ialset, ITG *nprint, char *prlab,
+            char *prset, ITG *nener, double *trab,
+            ITG *inotr, ITG *ntrans, double *ttime, double *fmpc,
+            ITG *nev, double **z, ITG *iamboun, double *xbounold,
+            ITG *nsectors, ITG *nm, ITG *icol, ITG *irow, ITG *nzl, ITG *nam,
+            ITG *ipompcold, ITG *nodempcold, double *coefmpcold,
+            char *labmpcold, ITG *nmpcold, double *xloadold, ITG *iamload,
+            double *t1old, double *t1, ITG *iamt1, double *xstiff, ITG **icolep,
+            ITG **jqep, ITG **irowep, ITG *isolver,
+            ITG *nzse, double **adbep, double **aubep, ITG *iexpl, ITG *ibody,
+            double *xbody, ITG *nbody, double *cocon, ITG *ncocon,
+            char *tieset, ITG *ntie, ITG *imddof, ITG *nmddof,
+            ITG *imdnode, ITG *nmdnode, ITG *imdboun, ITG *nmdboun,
+            ITG *imdmpc, ITG *nmdmpc, ITG **izdofp, ITG *nzdof, ITG *nherm,
+            double *xmr, double *xmi, char *typeboun, ITG *ielprop, double *prop,
+            char *orname, ITG *itiefac, double *t0g, double *t1g);
 
-void FORTRAN(extendmesh,(ITG *nnfront,ITG *istartfront,ITG *iendfront,
-			 ITG *ifront,ITG *nkold,ITG *ne,ITG *nkon,char *lakon,
-			 ITG *ipkon,ITG *kon,ITG *isubsurffront,double *co,
-			 ITG *ifronteq,ITG *istartfronteq,ITG *iendfronteq,
-			 ITG *nfront,ITG *nfronteq));
+void FORTRAN(expand_auw, (double *auw, ITG *jqw, ITG *iroww, ITG *nslavs,
+                          double *auwnew, ITG *jqwnew, ITG *irowwnew,
+                          ITG *neqslav, ITG *nactdof,
+                          ITG *mi, ITG *ktot, ITG *neqtot, ITG *islavnode,
+                          ITG *imastnode));
 
-void FORTRAN(extern_crackprop,(ITG *ieled,ITG *nedg,ITG *iexternedg,
-			       ITG *nexternedg,ITG *iexternnod,
-			       ITG *nexternnod,ITG *iedg,ITG *iedno));
+void FORTRAN(extendmesh, (ITG * nnfront, ITG *istartfront, ITG *iendfront,
+                          ITG *ifront, ITG *nkold, ITG *ne, ITG *nkon, char *lakon,
+                          ITG *ipkon, ITG *kon, ITG *isubsurffront, double *co,
+                          ITG *ifronteq, ITG *istartfronteq, ITG *iendfronteq,
+                          ITG *nfront, ITG *nfronteq));
 
-void FORTRAN(extfacepernode,(ITG *iponoelfa,ITG *inoelfa,char *lakonfa,
-                          ITG *ipkonfa,ITG *konfa,ITG *nsurfs,ITG *inoelsize));
+void FORTRAN(extern_crackprop, (ITG * ieled, ITG *nedg, ITG *iexternedg,
+                                ITG *nexternedg, ITG *iexternnod,
+                                ITG *nexternnod, ITG *iedg, ITG *iedno));
 
-void FORTRAN(extract_matrices,(double *au,double *ad,ITG *jq,ITG *irow,
-			       ITG *neq,double *aubb,double *adbb,
-			       ITG *jqbb,ITG *irowbb,ITG *neqtot,ITG *nzsbb,
-			       double *aubi,ITG *jqbi,ITG *irowbi,
-			       ITG *nzsbi,double *auib,ITG *jqib,ITG *irowib,
-			       ITG *nzsib,ITG *ktot,ITG *icolbb));
+void FORTRAN(extfacepernode, (ITG * iponoelfa, ITG *inoelfa, char *lakonfa,
+                              ITG *ipkonfa, ITG *konfa, ITG *nsurfs, ITG *inoelsize));
 
-void FORTRAN(extrapol2dto3d,(double *dgdxglob,ITG *iponod2dto3d,ITG *ndesi,
-                             ITG *nodedesi,ITG *nobject,ITG *nk,
-                             double *xinterpol,ITG *nnodes,ITG *ipkon,
-                             char *lakon,ITG *kon,ITG *ne,ITG *iponoel,
-                             ITG *inoel));
+void FORTRAN(extract_matrices, (double *au, double *ad, ITG *jq, ITG *irow,
+                                ITG *neq, double *aubb, double *adbb,
+                                ITG *jqbb, ITG *irowbb, ITG *neqtot, ITG *nzsbb,
+                                double *aubi, ITG *jqbi, ITG *irowbi,
+                                ITG *nzsbi, double *auib, ITG *jqib, ITG *irowib,
+                                ITG *nzsib, ITG *ktot, ITG *icolbb));
 
-void FORTRAN(extrapolate,(double *yi,double *yn,ITG *ipkon,ITG *inum,
-             ITG *kon,char *lakon,ITG *nfield,ITG *nk,ITG *ne,ITG *mi,
-             ITG *ndim,double *orab,ITG *ielorien,double *co,ITG *iorienloc,
-             char *cflag,double *vold,ITG *force,
-             ITG *ielmat,double *thicke,ITG *ielprop,double *prop));
+void FORTRAN(extrapol2dto3d, (double *dgdxglob, ITG *iponod2dto3d, ITG *ndesi,
+                              ITG *nodedesi, ITG *nobject, ITG *nk,
+                              double *xinterpol, ITG *nnodes, ITG *ipkon,
+                              char *lakon, ITG *kon, ITG *ne, ITG *iponoel,
+                              ITG *inoel));
 
-void FORTRAN(extrapolatefem,(double *sti,double *stn,ITG *ipkon,ITG *inum,
-             ITG *kon,char *lakon,ITG *nfield,ITG *nk,ITG *ne,ITG *mi,
-             ITG *ndim,double *orab,ITG *ielorien,double *co,ITG *iorienglob));
+void FORTRAN(extrapolate, (double *yi, double *yn, ITG *ipkon, ITG *inum,
+                           ITG *kon, char *lakon, ITG *nfield, ITG *nk, ITG *ne, ITG *mi,
+                           ITG *ndim, double *orab, ITG *ielorien, double *co, ITG *iorienloc,
+                           char *cflag, double *vold, ITG *force,
+                           ITG *ielmat, double *thicke, ITG *ielprop, double *prop));
 
-void FORTRAN(extrapolateshell,(double *yi,double *yn,ITG *ipkon,ITG *inum,
-			       ITG *kon,char *lakon,ITG *nfield,ITG *nk,
-			       ITG *ne,ITG *mi,ITG *ndim,double *orab,
-			       ITG *ielorien,double *co,ITG *iorienloc,
-			       char *cflag,ITG *ielmat,double *thicke,
-			       ITG *ielprop,double *prop,ITG *iflag));
+void FORTRAN(extrapolatefem, (double *sti, double *stn, ITG *ipkon, ITG *inum,
+                              ITG *kon, char *lakon, ITG *nfield, ITG *nk, ITG *ne, ITG *mi,
+                              ITG *ndim, double *orab, ITG *ielorien, double *co, ITG *iorienglob));
 
-void FORTRAN(extrapolate_se,(double *yi,double *yn,ITG *ipkon,ITG *inum,
-             ITG *kon,char *lakon,ITG *nfield,ITG *nk,ITG *ne,ITG *mi,
-             ITG *ndim,double *orab,ITG *ielorien,double *co,ITG *iorienloc,
-             char *cflag,double *vold,ITG *force,
-             ITG *ielmat,double *thicke,ITG *ielprop,double *prop,
-             ITG *ialeneigh,ITG *neaneigh,ITG *nebneigh,ITG *ialnneigh,
-             ITG *naneigh,ITG *nbneigh));
+void FORTRAN(extrapolateshell, (double *yi, double *yn, ITG *ipkon, ITG *inum,
+                                ITG *kon, char *lakon, ITG *nfield, ITG *nk,
+                                ITG *ne, ITG *mi, ITG *ndim, double *orab,
+                                ITG *ielorien, double *co, ITG *iorienloc,
+                                char *cflag, ITG *ielmat, double *thicke,
+                                ITG *ielprop, double *prop, ITG *iflag));
 
-void FORTRAN(fcrit,(double *time,double *tend,double *aai,double *bbi,
-                      double *zetaj,double *dj,double *ddj,
-                      double *h1,double *h2,double *h3,double *h4,
-                      double *func,double *funcp));
+void FORTRAN(extrapolate_se, (double *yi, double *yn, ITG *ipkon, ITG *inum,
+                              ITG *kon, char *lakon, ITG *nfield, ITG *nk, ITG *ne, ITG *mi,
+                              ITG *ndim, double *orab, ITG *ielorien, double *co, ITG *iorienloc,
+                              char *cflag, double *vold, ITG *force,
+                              ITG *ielmat, double *thicke, ITG *ielprop, double *prop,
+                              ITG *ialeneigh, ITG *neaneigh, ITG *nebneigh, ITG *ialnneigh,
+                              ITG *naneigh, ITG *nbneigh));
 
-void feasibledirection(ITG *nobject,char **objectsetp,double **dgdxglobp,
-		       double *g0,ITG *ndesi,ITG *nodedesi,ITG *nk,ITG *isolver,
-		       ITG **ipkonp,ITG **konp,char **lakonp,ITG *ne,
-		       ITG *nelemload,ITG *nload,ITG *nodeboun,ITG *nboun,
-		       ITG *ndirboun,ITG *ithermal,double *co,double *vold,
-		       ITG *mi,ITG **ielmatp,ITG *ielprop,double *prop,
-		       ITG *kode,ITG *nmethod,char *filab,ITG *nstate_,
-		       ITG *istep,double *cs,char *set,ITG *nset,
-		       ITG *istartset,ITG *iendset,ITG *ialset,char *jobnamec,
-		       char *output,ITG *ntrans,ITG *inotr,double *trab,
-		       char *orname,double *xdesi);
+void FORTRAN(fcrit, (double *time, double *tend, double *aai, double *bbi,
+                     double *zetaj, double *dj, double *ddj,
+                     double *h1, double *h2, double *h3, double *h4,
+                     double *func, double *funcp));
 
-void FORTRAN(fill_neiel,(ITG *nef,ITG *ipnei,ITG *neiel,ITG *neielcp));
+void feasibledirection(ITG *nobject, char **objectsetp, double **dgdxglobp,
+                       double *g0, ITG *ndesi, ITG *nodedesi, ITG *nk, ITG *isolver,
+                       ITG **ipkonp, ITG **konp, char **lakonp, ITG *ne,
+                       ITG *nelemload, ITG *nload, ITG *nodeboun, ITG *nboun,
+                       ITG *ndirboun, ITG *ithermal, double *co, double *vold,
+                       ITG *mi, ITG **ielmatp, ITG *ielprop, double *prop,
+                       ITG *kode, ITG *nmethod, char *filab, ITG *nstate_,
+                       ITG *istep, double *cs, char *set, ITG *nset,
+                       ITG *istartset, ITG *iendset, ITG *ialset, char *jobnamec,
+                       char *output, ITG *ntrans, ITG *inotr, double *trab,
+                       char *orname, double *xdesi);
 
-void FORTRAN(filter,(double *dgdxglob,ITG *nobject,ITG *nk,ITG *nodedesi,
-                     ITG *ndesi,char *objectset,double *xo,double *yo,
-                     double *zo,double *x,double *y,double *z,ITG *nx,
-                     ITG *ny,ITG *nz,ITG *neighbor,double *r,ITG *ndesia,
-                     ITG *ndesib,double *xdesi,double *distmin));
+void FORTRAN(fill_neiel, (ITG * nef, ITG *ipnei, ITG *neiel, ITG *neielcp));
 
-void filtermain(double *co,double *dgdxglob,ITG *nobject,ITG *nk,
-                ITG *nodedesi,ITG *ndesi,char *objectset,double *xdesi,
+void FORTRAN(filter, (double *dgdxglob, ITG *nobject, ITG *nk, ITG *nodedesi,
+                      ITG *ndesi, char *objectset, double *xo, double *yo,
+                      double *zo, double *x, double *y, double *z, ITG *nx,
+                      ITG *ny, ITG *nz, ITG *neighbor, double *r, ITG *ndesia,
+                      ITG *ndesib, double *xdesi, double *distmin));
+
+void filtermain(double *co, double *dgdxglob, ITG *nobject, ITG *nk,
+                ITG *nodedesi, ITG *ndesi, char *objectset, double *xdesi,
                 double *distmin);
 
 void *filtermt(ITG *i);
 
-void FORTRAN(findextsurface,(ITG *nodface,ITG *ipoface,ITG *ne,ITG *ipkon,
-                             char *lakon,ITG *kon,ITG *konfa,ITG *ipkonfa,
-                             ITG *nk,char *lakonfa,ITG *nsurfs,ITG *ifreemax));
+void FORTRAN(findextsurface, (ITG * nodface, ITG *ipoface, ITG *ne, ITG *ipkon,
+                              char *lakon, ITG *kon, ITG *konfa, ITG *ipkonfa,
+                              ITG *nk, char *lakonfa, ITG *nsurfs, ITG *ifreemax));
 
-void FORTRAN(findslavcfd,(ITG *nmpc,char *labmpc,ITG *ipompc,ITG *nodempc,
-                          ITG *islav,ITG *nslav,ITG *inoslav,ITG *inomast,
-                          ITG *ics,double *cs,ITG *imast,ITG *nmast,double *co,
-                          ITG *inomat,ITG *nr,ITG *nz,double *rcs,double *zcs,
-                          double *rcs0,double *zcs0,ITG *ncs));
+void FORTRAN(findslavcfd, (ITG * nmpc, char *labmpc, ITG *ipompc, ITG *nodempc,
+                           ITG *islav, ITG *nslav, ITG *inoslav, ITG *inomast,
+                           ITG *ics, double *cs, ITG *imast, ITG *nmast, double *co,
+                           ITG *inomat, ITG *nr, ITG *nz, double *rcs, double *zcs,
+                           double *rcs0, double *zcs0, ITG *ncs));
 
-void FORTRAN(findsurface,(ITG *ipoface,ITG *nodface,ITG *ne,ITG *ipkon,ITG *kon,
-                     char *lakon,ITG *ntie,char *tieset));
+void FORTRAN(findsurface, (ITG * ipoface, ITG *nodface, ITG *ne, ITG *ipkon, ITG *kon,
+                           char *lakon, ITG *ntie, char *tieset));
 
-void FORTRAN(fixnode,(ITG *nobject,ITG *nk,char *set,ITG *nset,ITG *istartset,
-                      ITG *iendset,ITG *ialset,ITG *iobject,ITG *nodedesiinv,
-                      double *dgdxglob,char *objectset));                       
+void FORTRAN(fixnode, (ITG * nobject, ITG *nk, char *set, ITG *nset, ITG *istartset,
+                       ITG *iendset, ITG *ialset, ITG *iobject, ITG *nodedesiinv,
+                       double *dgdxglob, char *objectset));
 
-void FORTRAN (flowoutput,(ITG *itg,ITG *ieg,ITG *ntg,ITG *nteq,
-                          double *bc,char *lakon,
-                          ITG *ntmat_,double *v,double *shcon,ITG *nshcon,
-                          ITG *ipkon,ITG *kon,double *co,ITG *nflow,
-                          double *dtime,double *ttime,double *time,
-                          ITG *ielmat,double *prop,
-                          ITG *ielprop,ITG *nactdog,ITG *nacteq,ITG *iin,
-                          double *physcon,double *camt,double *camf,double *camp,
-                          double *rhcon,ITG *nrhcon,
-                          double *vold,char *jobnamef,char *set,ITG *istartset,
-                          ITG *iendset,ITG *ialset,ITG *nset,ITG *mi,
-                          ITG *iaxial,ITG *istep,ITG *iit));
+void FORTRAN(flowoutput, (ITG * itg, ITG *ieg, ITG *ntg, ITG *nteq,
+                          double *bc, char *lakon,
+                          ITG *ntmat_, double *v, double *shcon, ITG *nshcon,
+                          ITG *ipkon, ITG *kon, double *co, ITG *nflow,
+                          double *dtime, double *ttime, double *time,
+                          ITG *ielmat, double *prop,
+                          ITG *ielprop, ITG *nactdog, ITG *nacteq, ITG *iin,
+                          double *physcon, double *camt, double *camf, double *camp,
+                          double *rhcon, ITG *nrhcon,
+                          double *vold, char *jobnamef, char *set, ITG *istartset,
+                          ITG *iendset, ITG *ialset, ITG *nset, ITG *mi,
+                          ITG *iaxial, ITG *istep, ITG *iit));
 
-void FORTRAN(flowresult,(ITG *ntg,ITG *itg,double *cam,double *vold,
-              double *v,
-              ITG *nload,char *sideload,ITG *nelemload,
-              double *xloadact,ITG *nactdog,ITG *network,ITG *mi,
-              ITG *ne,ITG *ipkon,char *lakon,ITG *kon));
+void FORTRAN(flowresult, (ITG * ntg, ITG *itg, double *cam, double *vold,
+                          double *v,
+                          ITG *nload, char *sideload, ITG *nelemload,
+                          double *xloadact, ITG *nactdog, ITG *network, ITG *mi,
+                          ITG *ne, ITG *ipkon, char *lakon, ITG *kon));
 
-void FORTRAN(fluidnodes,(ITG *nef,ITG *ipkonf,char *lakonf,ITG *konf,ITG *ikf,
-			 ITG *nk,ITG *nkf));
+void FORTRAN(fluidnodes, (ITG * nef, ITG *ipkonf, char *lakonf, ITG *konf, ITG *ikf,
+                          ITG *nk, ITG *nkf));
 
-void FORTRAN(forcesolve,(double *zc,ITG *nev,double *aa,double *bb,
-             double *xx,double *eiga,double *eigb,double *eigxx,
-             ITG *iter,double *d,ITG *neq,double *z,ITG *istartnmd,
-             ITG *iendnmd,ITG *nmd,ITG *cyclicsymmetry,ITG *neqact,
-             ITG *igeneralizedforce));
+void FORTRAN(forcesolve, (double *zc, ITG *nev, double *aa, double *bb,
+                          double *xx, double *eiga, double *eigb, double *eigxx,
+                          ITG *iter, double *d, ITG *neq, double *z, ITG *istartnmd,
+                          ITG *iendnmd, ITG *nmd, ITG *cyclicsymmetry, ITG *neqact,
+                          ITG *igeneralizedforce));
 
-void forparll(ITG *mt,ITG *nactdof,double *aux2,double *veold,
-                    ITG *nk,ITG *num_cpus);
+void forparll(ITG *mt, ITG *nactdof, double *aux2, double *veold,
+              ITG *nk, ITG *num_cpus);
 
 void *forparllmt(ITG *i);
 
-void frd(double *co,ITG *nk,ITG *kon,ITG *ipkon,char *lakon,ITG *ne0,
-         double *v,double *stn,ITG *inum,ITG *nmethod,ITG *kode,
-         char *filab,double *een,double *t1,double *fn,double *time,
-         double *epn,ITG *ielmat,char *matname,double *enern,
-         double *xstaten,ITG *nstate_,ITG *istep,ITG *iinc,
-         ITG *ithermal,double *qfn,ITG *mode,ITG *noddiam,
-         double *trab,ITG *inotr,ITG *ntrans,double *orab,
-         ITG *ielorien,ITG *norien,char *description,ITG *ipneigh,
-         ITG *neigh,ITG *mi,double *stx,double *vr,double *vi,
-         double *stnr,double *stni,double *vmax,double *stnmax,
-         ITG *ngraph,double *veold,double *ener,ITG *ne,double *cs,
-         char *set,ITG *nset,ITG *istartset,ITG *iendset,ITG *ialset,
-         double *eenmax,double *fnr,double *fni,double *emn,
-         double *thicke,char *jobnamec,char *output,double *qfx,
-         double *cdn,ITG *mortar,double *cdnr,double *cdni,ITG *nmat,
-         ITG *ielprop,double *prop,double *sti);
+void frd(double *co, ITG *nk, ITG *kon, ITG *ipkon, char *lakon, ITG *ne0,
+         double *v, double *stn, ITG *inum, ITG *nmethod, ITG *kode,
+         char *filab, double *een, double *t1, double *fn, double *time,
+         double *epn, ITG *ielmat, char *matname, double *enern,
+         double *xstaten, ITG *nstate_, ITG *istep, ITG *iinc,
+         ITG *ithermal, double *qfn, ITG *mode, ITG *noddiam,
+         double *trab, ITG *inotr, ITG *ntrans, double *orab,
+         ITG *ielorien, ITG *norien, char *description, ITG *ipneigh,
+         ITG *neigh, ITG *mi, double *stx, double *vr, double *vi,
+         double *stnr, double *stni, double *vmax, double *stnmax,
+         ITG *ngraph, double *veold, double *ener, ITG *ne, double *cs,
+         char *set, ITG *nset, ITG *istartset, ITG *iendset, ITG *ialset,
+         double *eenmax, double *fnr, double *fni, double *emn,
+         double *thicke, char *jobnamec, char *output, double *qfx,
+         double *cdn, ITG *mortar, double *cdnr, double *cdni, ITG *nmat,
+         ITG *ielprop, double *prop, double *sti);
 
-void frdcyc(double *co,ITG *nk,ITG *kon,ITG *ipkon,char *lakon,ITG *ne,double *v,
-            double *stn,ITG *inum,ITG *nmethod,ITG *kode,char *filab,
-            double *een,double *t1,double *fn,double *time,double *epn,
-            ITG *ielmat,char *matname,double *cs,ITG *mcs,ITG *nkon,
-            double *enern,double *xstaten,ITG *nstate_,ITG *istep,
-            ITG *iinc,ITG *iperturb,double *ener,ITG *mi,char *output,
-            ITG *ithermal,double *qfn,ITG *ialset,ITG *istartset,
-            ITG *iendset,double *trab,ITG *inotr,ITG *ntrans,double *orab,
-            ITG *ielorien,ITG *norien,double *sti,double *veold,ITG *noddiam,
-            char *set,ITG *nset,double *emn,double *thicke,char *jobnamec,
-            ITG *ne0,double *cdn,ITG *mortar,ITG *nmat,double *qfx,
-            ITG *ielprop,double *prop);
+void frdcyc(double *co, ITG *nk, ITG *kon, ITG *ipkon, char *lakon, ITG *ne, double *v,
+            double *stn, ITG *inum, ITG *nmethod, ITG *kode, char *filab,
+            double *een, double *t1, double *fn, double *time, double *epn,
+            ITG *ielmat, char *matname, double *cs, ITG *mcs, ITG *nkon,
+            double *enern, double *xstaten, ITG *nstate_, ITG *istep,
+            ITG *iinc, ITG *iperturb, double *ener, ITG *mi, char *output,
+            ITG *ithermal, double *qfn, ITG *ialset, ITG *istartset,
+            ITG *iendset, double *trab, ITG *inotr, ITG *ntrans, double *orab,
+            ITG *ielorien, ITG *norien, double *sti, double *veold, ITG *noddiam,
+            char *set, ITG *nset, double *emn, double *thicke, char *jobnamec,
+            ITG *ne0, double *cdn, ITG *mortar, ITG *nmat, double *qfx,
+            ITG *ielprop, double *prop);
 
-void frd_norm_se(double *co,ITG *nk,double *stn,ITG *inum,ITG *nmethod,
-         ITG *kode,char *filab,double *fn,double *time,ITG *nstate_,
-         ITG *istep,ITG *iinc,ITG *mode,ITG *noddiam,char *description,
-         ITG *mi,ITG *ngraph,ITG *ne,double *cs,char *set,ITG *nset,
-         ITG *istartset,ITG *iendset,ITG *ialset,double *thicke,
-         char *jobnamec,char *output,double *dgdxtotglob,ITG *numobject,
-         char *objectset,double *extnor,ITG *ntrans,double *trab,
-         ITG *inotr);
+void frd_norm_se(double *co, ITG *nk, double *stn, ITG *inum, ITG *nmethod,
+                 ITG *kode, char *filab, double *fn, double *time, ITG *nstate_,
+                 ITG *istep, ITG *iinc, ITG *mode, ITG *noddiam, char *description,
+                 ITG *mi, ITG *ngraph, ITG *ne, double *cs, char *set, ITG *nset,
+                 ITG *istartset, ITG *iendset, ITG *ialset, double *thicke,
+                 char *jobnamec, char *output, double *dgdxtotglob, ITG *numobject,
+                 char *objectset, double *extnor, ITG *ntrans, double *trab,
+                 ITG *inotr);
 
-void frd_sen(double *co,ITG *nk,double *dstn,ITG *inum,ITG *nmethod,
-         ITG *kode,char *filab,double *time,ITG *nstate_,
-         ITG *istep,ITG *iinc,ITG *mode,ITG *noddiam,char *description,
-         ITG *mi,ITG *ngraph,ITG *ne,double *cs,char *set,ITG *nset,
-         ITG *istartset,ITG *iendset,ITG *ialset,
-         char *jobnamec,char *output,double *v,ITG *iobject,
-         char *objectset,ITG *ntrans,ITG *inotr,double *trab,
-         ITG *idesvar,char *orname,ITG *icoordinate,ITG *inorm,
-         ITG *irand,ITG *ishape);
+void frd_sen(double *co, ITG *nk, double *dstn, ITG *inum, ITG *nmethod,
+             ITG *kode, char *filab, double *time, ITG *nstate_,
+             ITG *istep, ITG *iinc, ITG *mode, ITG *noddiam, char *description,
+             ITG *mi, ITG *ngraph, ITG *ne, double *cs, char *set, ITG *nset,
+             ITG *istartset, ITG *iendset, ITG *ialset,
+             char *jobnamec, char *output, double *v, ITG *iobject,
+             char *objectset, ITG *ntrans, ITG *inotr, double *trab,
+             ITG *idesvar, char *orname, ITG *icoordinate, ITG *inorm,
+             ITG *irand, ITG *ishape);
 
-void frd_sen_se(double *co,ITG *nk,double *stn,ITG *inum,ITG *nmethod,
-         ITG *kode,char *filab,double *fn,double *time,ITG *nstate_,
-         ITG *istep,ITG *iinc,ITG *mode,ITG *noddiam,char *description,
-         ITG *mi,ITG *ngraph,ITG *ne,double *cs,char *set,ITG *nset,
-         ITG *istartset,ITG *iendset,ITG *ialset,double *thicke,
-         char *jobnamec,char *output,double *dgdxglob,ITG *iobject,
-         char *objectset);
+void frd_sen_se(double *co, ITG *nk, double *stn, ITG *inum, ITG *nmethod,
+                ITG *kode, char *filab, double *fn, double *time, ITG *nstate_,
+                ITG *istep, ITG *iinc, ITG *mode, ITG *noddiam, char *description,
+                ITG *mi, ITG *ngraph, ITG *ne, double *cs, char *set, ITG *nset,
+                ITG *istartset, ITG *iendset, ITG *ialset, double *thicke,
+                char *jobnamec, char *output, double *dgdxglob, ITG *iobject,
+                char *objectset);
 
-void frd_orien_se(double *co,ITG *nk,double *stn,ITG *inum,ITG *nmethod,
-         ITG *kode,char *filab,double *fn,double *time,ITG *nstate_,
-         ITG *istep,ITG *iinc,ITG *mode,ITG *noddiam,char *description,
-         ITG *mi,ITG *ngraph,ITG *ne,double *cs,char *set,ITG *nset,
-         ITG *istartset,ITG *iendset,ITG *ialset,double *thicke,
-         char *jobnamec,char *output,double *dgdxtotglob,ITG *numobject,
-         char *objectset,ITG *ntrans,ITG *inotr,double *trab,
-         ITG *idesvar,char *orname);
+void frd_orien_se(double *co, ITG *nk, double *stn, ITG *inum, ITG *nmethod,
+                  ITG *kode, char *filab, double *fn, double *time, ITG *nstate_,
+                  ITG *istep, ITG *iinc, ITG *mode, ITG *noddiam, char *description,
+                  ITG *mi, ITG *ngraph, ITG *ne, double *cs, char *set, ITG *nset,
+                  ITG *istartset, ITG *iendset, ITG *ialset, double *thicke,
+                  char *jobnamec, char *output, double *dgdxtotglob, ITG *numobject,
+                  char *objectset, ITG *ntrans, ITG *inotr, double *trab,
+                  ITG *idesvar, char *orname);
 
-void FORTRAN(frdfluidfem,(double *co,ITG *nk,ITG *kon,ITG *ipkon,char *lakon,
-			  ITG *ne,double *v,double *vold,ITG *kode,double *time,
-			  ITG *ielmat,char *matname,ITG *nnstep,
-			  double *physcon,char *filab,ITG *inomat,ITG *ntrans,
-			  ITG *inotr,double *trab,ITG *mi,double *stn,
-			  double *qfn,ITG *istep,double *sa,ITG *compressible,
-			  ITG *nactdoh,double *yy,ITG *jyy,ITG *ithermal,
-			  double *shcon,ITG *nshcon,double *rhcon,ITG *nrhcon,
-			  ITG *ntmat_,double *vcon,double *depth,double *xg,
-			  ITG *nodfreesurf,double *dt,double *shockcoef,
-			  ITG *iexplicit,ITG *nkold,ITG *nelold));
+void FORTRAN(frdfluidfem, (double *co, ITG *nk, ITG *kon, ITG *ipkon, char *lakon,
+                           ITG *ne, double *v, double *vold, ITG *kode, double *time,
+                           ITG *ielmat, char *matname, ITG *nnstep,
+                           double *physcon, char *filab, ITG *inomat, ITG *ntrans,
+                           ITG *inotr, double *trab, ITG *mi, double *stn,
+                           double *qfn, ITG *istep, double *sa, ITG *compressible,
+                           ITG *nactdoh, double *yy, ITG *jyy, ITG *ithermal,
+                           double *shcon, ITG *nshcon, double *rhcon, ITG *nrhcon,
+                           ITG *ntmat_, double *vcon, double *depth, double *xg,
+                           ITG *nodfreesurf, double *dt, double *shockcoef,
+                           ITG *iexplicit, ITG *nkold, ITG *nelold));
 
-void frdgeneralvector(double *v,ITG *iset,ITG *ntrans,char * filabl,
-               ITG *nkcoords,
-               ITG *inum,char *m1,ITG *inotr,double *trab,double *co,
-               ITG *istartset,ITG *iendset,ITG *ialset,ITG *mi,ITG *ngraph,
-               FILE *f1,char *output,char *m3);
+void frdgeneralvector(double *v, ITG *iset, ITG *ntrans, char *filabl,
+                      ITG *nkcoords,
+                      ITG *inum, char *m1, ITG *inotr, double *trab, double *co,
+                      ITG *istartset, ITG *iendset, ITG *ialset, ITG *mi, ITG *ngraph,
+                      FILE *f1, char *output, char *m3);
 
-void frdheader(ITG *icounter,double *oner,double *time,double *pi,
-               ITG *noddiam,double *cs,ITG *null,ITG *mode,
-               ITG *noutloc,char *description,ITG *kode,ITG *nmethod,
-               FILE *f1,char *output,ITG *istep,ITG *iinc);
+void frdheader(ITG *icounter, double *oner, double *time, double *pi,
+               ITG *noddiam, double *cs, ITG *null, ITG *mode,
+               ITG *noutloc, char *description, ITG *kode, ITG *nmethod,
+               FILE *f1, char *output, ITG *istep, ITG *iinc);
 
-void FORTRAN(frditeration,(double *co,ITG *nk,ITG *kon,ITG *ipkon,char *lakon,
-             ITG *ne,double *v,double *time,ITG *ielmat,char *matname,
-             ITG *mi,ITG *istep,ITG *iinc,ITG *ithermal));
+void FORTRAN(frditeration, (double *co, ITG *nk, ITG *kon, ITG *ipkon, char *lakon,
+                            ITG *ne, double *v, double *time, ITG *ielmat, char *matname,
+                            ITG *mi, ITG *istep, ITG *iinc, ITG *ithermal));
 
-void frdselect(double *field1,double *field2,ITG *iset,ITG *nkcoords,ITG *inum,
-     char *m1,ITG *istartset,ITG *iendset,ITG *ialset,ITG *ngraph,ITG *ncomp,
-     ITG *ifield,ITG *icomp,ITG *nfield,ITG *iselect,char *m2,FILE *f1,
-     char *output,char *m3);
+void frdselect(double *field1, double *field2, ITG *iset, ITG *nkcoords, ITG *inum,
+               char *m1, ITG *istartset, ITG *iendset, ITG *ialset, ITG *ngraph, ITG *ncomp,
+               ITG *ifield, ITG *icomp, ITG *nfield, ITG *iselect, char *m2, FILE *f1,
+               char *output, char *m3);
 
-void frdset(char *filabl,char *set,ITG *iset,ITG *istartset,ITG *iendset,
-            ITG *ialset,ITG *inum,ITG *noutloc,ITG *nout,ITG *nset,
-            ITG *noutmin,ITG *noutplus,ITG *iselect,ITG *ngraph);
+void frdset(char *filabl, char *set, ITG *iset, ITG *istartset, ITG *iendset,
+            ITG *ialset, ITG *inum, ITG *noutloc, ITG *nout, ITG *nset,
+            ITG *noutmin, ITG *noutplus, ITG *iselect, ITG *ngraph);
 
-void frdvector(double *v,ITG *iset,ITG *ntrans,char * filabl,ITG *nkcoords,
-               ITG *inum,char *m1,ITG *inotr,double *trab,double *co,
-               ITG *istartset,ITG *iendset,ITG *ialset,ITG *mi,ITG *ngraph,
-               FILE *f1,char *output,char *m3);
+void frdvector(double *v, ITG *iset, ITG *ntrans, char *filabl, ITG *nkcoords,
+               ITG *inum, char *m1, ITG *inotr, double *trab, double *co,
+               ITG *istartset, ITG *iendset, ITG *ialset, ITG *mi, ITG *ngraph,
+               FILE *f1, char *output, char *m3);
 
-void FORTRAN(frictionheating,(ITG *ne0,ITG *ne,ITG *ipkon,char *lakon,ITG *ielmat,
-                     ITG *mi,double *elcon,ITG *ncmat_,ITG *ntmat_,
-                     ITG *kon,ITG *islavsurf,double *pmastsurf,
-                     double *springarea,double *co,double *vold,
-                     double *veold,double *pslavsurf,double *xload,
-                     ITG *nload,ITG *nload_,ITG *nelemload,ITG *iamload,
-                     ITG *idefload,char *sideload,double *stx,ITG *nam,
-                     double *time,double *ttime,char *matname,ITG *istep,
-                     ITG *iinc));
+void FORTRAN(frictionheating, (ITG * ne0, ITG *ne, ITG *ipkon, char *lakon, ITG *ielmat,
+                               ITG *mi, double *elcon, ITG *ncmat_, ITG *ntmat_,
+                               ITG *kon, ITG *islavsurf, double *pmastsurf,
+                               double *springarea, double *co, double *vold,
+                               double *veold, double *pslavsurf, double *xload,
+                               ITG *nload, ITG *nload_, ITG *nelemload, ITG *iamload,
+                               ITG *idefload, char *sideload, double *stx, ITG *nam,
+                               double *time, double *ttime, char *matname, ITG *istep,
+                               ITG *iinc));
 
-void FORTRAN(fsub,(double *time,double *tend,double *aai,double *bbi,
-                   double *ddj,double *h1,double *h2,double *h3,double *h4,
-                   double *func,double *funcp));
+void FORTRAN(fsub, (double *time, double *tend, double *aai, double *bbi,
+                    double *ddj, double *h1, double *h2, double *h3, double *h4,
+                    double *func, double *funcp));
 
-void FORTRAN(fsuper,(double *time,double *tend,double *aai,double *bbi,
-                       double *h1,double *h2,double *h3,double *h4,
-                       double *h5,double *h6,double *func,double *funcp));
+void FORTRAN(fsuper, (double *time, double *tend, double *aai, double *bbi,
+                      double *h1, double *h2, double *h3, double *h4,
+                      double *h5, double *h6, double *func, double *funcp));
 
-void FORTRAN(gasmechbc,(double *vold,ITG *nload,char *sideload,
-                        ITG *nelemload,double *xload,ITG *mi));
+void FORTRAN(gasmechbc, (double *vold, ITG *nload, char *sideload,
+                         ITG *nelemload, double *xload, ITG *mi));
 
-void FORTRAN(genadvecelem,(ITG *inodesd,ITG *ipkon,ITG *ne,char *lakon,
-             ITG *kon,ITG *nload,char *sideload,ITG *nelemload,ITG *nkon,
-             ITG *network));
+void FORTRAN(genadvecelem, (ITG * inodesd, ITG *ipkon, ITG *ne, char *lakon,
+                            ITG *kon, ITG *nload, char *sideload, ITG *nelemload, ITG *nkon,
+                            ITG *network));
 
-void FORTRAN(gencontelem_f2f,(char *tieset,ITG *ntie,ITG *itietri,ITG *ne,
-             ITG *ipkon,ITG *kon,char *lakon,double *cg,double *straight,
-             ITG *ifree,ITG *koncont,double *co,double *vold,double *xo,
-             double *yo,double *zo,double *x,double *y,double *z,ITG *nx,
-             ITG *ny,ITG *nz,ITG *ielmat,double *elcon,ITG *istep,ITG *iinc,
-             ITG *iit,ITG *ncmat_,ITG *ntmat_,ITG *mi,ITG *imastop,
-             ITG *islavsurf,ITG *itiefac,double *springarea,double *tietol,
-             double *reltime,char *filab,ITG *nasym,
-             double *pslavsurf,double *pmastsurf,double *clearini,
-             double *theta,double *xstateini,double *xstate,ITG *nstate_,
-             ITG *ne0,ITG *icutb,ITG *ialeatoric,ITG *nmethod,
-             char *jobnamef,double *alea));
+void FORTRAN(gencontelem_f2f, (char *tieset, ITG *ntie, ITG *itietri, ITG *ne,
+                               ITG *ipkon, ITG *kon, char *lakon, double *cg, double *straight,
+                               ITG *ifree, ITG *koncont, double *co, double *vold, double *xo,
+                               double *yo, double *zo, double *x, double *y, double *z, ITG *nx,
+                               ITG *ny, ITG *nz, ITG *ielmat, double *elcon, ITG *istep, ITG *iinc,
+                               ITG *iit, ITG *ncmat_, ITG *ntmat_, ITG *mi, ITG *imastop,
+                               ITG *islavsurf, ITG *itiefac, double *springarea, double *tietol,
+                               double *reltime, char *filab, ITG *nasym,
+                               double *pslavsurf, double *pmastsurf, double *clearini,
+                               double *theta, double *xstateini, double *xstate, ITG *nstate_,
+                               ITG *ne0, ITG *icutb, ITG *ialeatoric, ITG *nmethod,
+                               char *jobnamef, double *alea));
 
-void FORTRAN(gencontelem_n2f,(char *tieset,ITG *ntie,ITG *itietri,ITG *ne,
-     ITG *ipkon,ITG *kon,char *lakon,
-     double *cg,double *straight,ITG *ifree,ITG *koncont,
-     double *co,double *vold,double *xo,double *yo,double *zo,
-     double *x,double *y,double *z,ITG *nx,ITG *ny,ITG *nz,
-     ITG *ielmat,double *elcon,ITG *istep,ITG *iinc,ITG *iit,
-     ITG *ncmat_,ITG *ntmat_,
-     ITG *nmethod,ITG *mi,ITG *imastop,ITG *nslavnode,
-     ITG *islavnode,ITG *islavsurf,ITG *itiefac,double *areaslav,
-     ITG *iponoels,ITG *inoels,double *springarea,
-     char *set,ITG *nset,ITG *istartset,ITG *iendset,ITG *ialset,
-     double *tietol,double *reltime,
-     char* filab,ITG *nasym,double *xnoels,ITG *icutb,ITG *ne0,
-     char *jobnamef,ITG *mortar,double *auw,ITG *jqw,ITG *iroww,ITG *nzsw,
-     ITG *imastnode,ITG *nmastnode));
+void FORTRAN(gencontelem_n2f, (char *tieset, ITG *ntie, ITG *itietri, ITG *ne,
+                               ITG *ipkon, ITG *kon, char *lakon,
+                               double *cg, double *straight, ITG *ifree, ITG *koncont,
+                               double *co, double *vold, double *xo, double *yo, double *zo,
+                               double *x, double *y, double *z, ITG *nx, ITG *ny, ITG *nz,
+                               ITG *ielmat, double *elcon, ITG *istep, ITG *iinc, ITG *iit,
+                               ITG *ncmat_, ITG *ntmat_,
+                               ITG *nmethod, ITG *mi, ITG *imastop, ITG *nslavnode,
+                               ITG *islavnode, ITG *islavsurf, ITG *itiefac, double *areaslav,
+                               ITG *iponoels, ITG *inoels, double *springarea,
+                               char *set, ITG *nset, ITG *istartset, ITG *iendset, ITG *ialset,
+                               double *tietol, double *reltime,
+                               char *filab, ITG *nasym, double *xnoels, ITG *icutb, ITG *ne0,
+                               char *jobnamef, ITG *mortar, double *auw, ITG *jqw, ITG *iroww, ITG *nzsw,
+                               ITG *imastnode, ITG *nmastnode));
 
-void FORTRAN(gencycsymelemcfd,(double *cs,ITG *islav,ITG *nslav,
-         ITG *imast,ITG *nmast,ITG *inomat,ITG *nk,double *co,ITG *ne,
-         ITG *ipkon,char *lakon,ITG *kon,ITG *nkon,ITG *mi,ITG *ielmat,
-         double *vold,ITG *ielslav,ITG *ielmast,ITG *inoslav,ITG *inomast,
-         ITG *iponoel,ITG *inoel));
+void FORTRAN(gencycsymelemcfd, (double *cs, ITG *islav, ITG *nslav,
+                                ITG *imast, ITG *nmast, ITG *inomat, ITG *nk, double *co, ITG *ne,
+                                ITG *ipkon, char *lakon, ITG *kon, ITG *nkon, ITG *mi, ITG *ielmat,
+                                double *vold, ITG *ielslav, ITG *ielmast, ITG *inoslav, ITG *inomast,
+                                ITG *iponoel, ITG *inoel));
 
-void FORTRAN(generateeminterfaces,(ITG *istartset,ITG *iendset,
-             ITG *ialset,ITG *iactive,ITG *ipkon,char *lakon,ITG *kon,
-             ITG *ikmpc,ITG *nmpc,ITG *nafaces));
+void FORTRAN(generateeminterfaces, (ITG * istartset, ITG *iendset,
+                                    ITG *ialset, ITG *iactive, ITG *ipkon, char *lakon, ITG *kon,
+                                    ITG *ikmpc, ITG *nmpc, ITG *nafaces));
 
-void FORTRAN(generateglob,(ITG *kontet,ITG *ifatet,ITG *ifreetet,
-			   double *bc,ITG *ifac,ITG *itetfa,ITG *ifreefa,
-			   double *planfa,ITG *ipofa,ITG *nodes,double *cotet,
-			   ITG *nktet,ITG *ipocatt,ITG *ncat_,double *xmin,
-			   double *ymin,double *zmin,double *charlen,
-			   ITG *iexternalfa));
+void FORTRAN(generateglob, (ITG * kontet, ITG *ifatet, ITG *ifreetet,
+                            double *bc, ITG *ifac, ITG *itetfa, ITG *ifreefa,
+                            double *planfa, ITG *ipofa, ITG *nodes, double *cotet,
+                            ITG *nktet, ITG *ipocatt, ITG *ncat_, double *xmin,
+                            double *ymin, double *zmin, double *charlen,
+                            ITG *iexternalfa));
 
-void FORTRAN(genmidnodes,(ITG *nktet_,ITG *ipoed,ITG *iedgmid,ITG *iexternedg,
-			  ITG *iedgext,double *cotet,ITG *nktet,ITG *iedg,
-			  ITG *jfix,ITG *ipoeled,ITG *ieled,ITG *kontet,
-			  ITG *iedtet,ITG *iwrite));
+void FORTRAN(genmidnodes, (ITG * nktet_, ITG *ipoed, ITG *iedgmid, ITG *iexternedg,
+                           ITG *iedgext, double *cotet, ITG *nktet, ITG *iedg,
+                           ITG *jfix, ITG *ipoeled, ITG *ieled, ITG *kontet,
+                           ITG *iedtet, ITG *iwrite));
 
-void FORTRAN(genmpc,(ITG *inodestet,ITG *nnodestet,double *co,
-		     double *doubleglob,ITG *integerglob,ITG *ipompc,
-		     ITG *nodempc,double *coefmpc,ITG *nmpc,ITG *nmpc_,
-		     char *labmpc,ITG *mpcfree,ITG *ikmpc,ITG *ilmpc));
+void FORTRAN(genmpc, (ITG * inodestet, ITG *nnodestet, double *co,
+                      double *doubleglob, ITG *integerglob, ITG *ipompc,
+                      ITG *nodempc, double *coefmpc, ITG *nmpc, ITG *nmpc_,
+                      char *labmpc, ITG *mpcfree, ITG *ikmpc, ITG *ilmpc));
 
-void FORTRAN(gennactdofinv,(ITG *nactdof,ITG *nactdofinv,ITG *nk,
-       ITG *mi,ITG *nodorig,ITG *ipkon,char *lakon,ITG *kon,ITG *ne));
+void FORTRAN(gennactdofinv, (ITG * nactdof, ITG *nactdofinv, ITG *nk,
+                             ITG *mi, ITG *nodorig, ITG *ipkon, char *lakon, ITG *kon, ITG *ne));
 
 unsigned long genrand();
 
-void FORTRAN(genratio,(double *co,double *doubleglob,ITG *integerglob,
-		       ITG *nkold,ITG *nk,ITG *iprfn,ITG *konrfn,
-		       double *ratiorfn));
+void FORTRAN(genratio, (double *co, double *doubleglob, ITG *integerglob,
+                        ITG *nkold, ITG *nk, ITG *iprfn, ITG *konrfn,
+                        double *ratiorfn));
 
-void FORTRAN(gentiedmpc,(char *tieset,ITG *ntie,ITG *itietri,
-          ITG *ipkon,ITG *kon,char *lakon,char *set,ITG *istartset,
-          ITG *iendset,ITG *ialset,double *cg,double *straight,
-          ITG *koncont,double *co,double *xo,double *yo,double *zo,
-          double *x,double *y,double *z,ITG *nx,ITG *ny,ITG *nz,ITG *nset,
-          ITG *ifaceslave,ITG *istartfield,ITG *iendfield,ITG *ifield,
-          ITG *ipompc,ITG *nodempc,double *coefmpc,ITG *nmpc,ITG *nmpc_,
-          ITG *mpcfree,ITG *ikmpc,ITG *ilmpc,char *labmpc,ITG *ithermal,
-          double *tietol,ITG *icfd,ITG *ncont,ITG *imastop,ITG *ikboun,
-          ITG *nboun,char *kind));
+void FORTRAN(gentiedmpc, (char *tieset, ITG *ntie, ITG *itietri,
+                          ITG *ipkon, ITG *kon, char *lakon, char *set, ITG *istartset,
+                          ITG *iendset, ITG *ialset, double *cg, double *straight,
+                          ITG *koncont, double *co, double *xo, double *yo, double *zo,
+                          double *x, double *y, double *z, ITG *nx, ITG *ny, ITG *nz, ITG *nset,
+                          ITG *ifaceslave, ITG *istartfield, ITG *iendfield, ITG *ifield,
+                          ITG *ipompc, ITG *nodempc, double *coefmpc, ITG *nmpc, ITG *nmpc_,
+                          ITG *mpcfree, ITG *ikmpc, ITG *ilmpc, char *labmpc, ITG *ithermal,
+                          double *tietol, ITG *icfd, ITG *ncont, ITG *imastop, ITG *ikboun,
+                          ITG *nboun, char *kind));
 
-void FORTRAN(geomview,(double *vold,double *co,double *pmid,double *e1,
-             double *e2,double *e3,ITG *kontri,double *area,double *cs,
-             ITG *mcs,ITG *inocs,ITG *ntrit,ITG *nk,ITG *mi,double *sidemean));
+void FORTRAN(geomview, (double *vold, double *co, double *pmid, double *e1,
+                        double *e2, double *e3, ITG *kontri, double *area, double *cs,
+                        ITG *mcs, ITG *inocs, ITG *ntrit, ITG *nk, ITG *mi, double *sidemean));
 
-void FORTRAN(getbasis,(double *xmin,double *ymin,double *zmin,double *charlen,
-		       ITG *node,double *cotet,ITG *ifatet,ITG *itetfa,
-		       ITG *ibase,ITG *istock,ITG *ipocatt,ITG *ncat_,
-		       double *planfa));
+void FORTRAN(getbasis, (double *xmin, double *ymin, double *zmin, double *charlen,
+                        ITG *node, double *cotet, ITG *ifatet, ITG *itetfa,
+                        ITG *ibase, ITG *istock, ITG *ipocatt, ITG *ncat_,
+                        double *planfa));
 
-void getuncrackedresults(char *masterfile,ITG **integerglobp,
-			 double **doubleglobp,ITG *iglob,ITG *nstep);
+void getuncrackedresults(char *masterfile, ITG **integerglobp,
+                         double **doubleglobp, ITG *iglob, ITG *nstep);
 
-void FORTRAN(getdesiinfo2d,(char *set,ITG *istartset,ITG *iendset,ITG *ialset,
-            ITG *nset,ITG *mi,ITG *nactdof,ITG *ndesi,
-            ITG *nodedesi,ITG *ntie,char *tieset,ITG *nodedesiinv,
-            char *lakon,ITG *ipkon,ITG *kon,ITG *iponoelfa,ITG *iponod2dto3d,
-            ITG *iponor2d,ITG *knor2d,ITG *iponoel2d,ITG *inoel2d,ITG *nobject,
-            char *objectset,ITG *iponk2dto3d,ITG *ne));  
+void FORTRAN(getdesiinfo2d, (char *set, ITG *istartset, ITG *iendset, ITG *ialset,
+                             ITG *nset, ITG *mi, ITG *nactdof, ITG *ndesi,
+                             ITG *nodedesi, ITG *ntie, char *tieset, ITG *nodedesiinv,
+                             char *lakon, ITG *ipkon, ITG *kon, ITG *iponoelfa, ITG *iponod2dto3d,
+                             ITG *iponor2d, ITG *knor2d, ITG *iponoel2d, ITG *inoel2d, ITG *nobject,
+                             char *objectset, ITG *iponk2dto3d, ITG *ne));
 
-void FORTRAN(getdesiinfo3d,(char *set,ITG *istartset,ITG *iendset,ITG *ialset,
-            ITG *nset,ITG *mi,ITG *nactdof,ITG *ndesi,
-            ITG *nodedesi,ITG *ntie,char *tieset,ITG *itmp,ITG *nmpc,
-            ITG *nodempc,ITG *ipompc,ITG *nodedesiinv,ITG *iponoel,
-            ITG *inoel,char *lakon,ITG *ipkon,ITG *kon,ITG *noregion,
-            ITG *ipoface,ITG *nodface,ITG *nk));
+void FORTRAN(getdesiinfo3d, (char *set, ITG *istartset, ITG *iendset, ITG *ialset,
+                             ITG *nset, ITG *mi, ITG *nactdof, ITG *ndesi,
+                             ITG *nodedesi, ITG *ntie, char *tieset, ITG *itmp, ITG *nmpc,
+                             ITG *nodempc, ITG *ipompc, ITG *nodedesiinv, ITG *iponoel,
+                             ITG *inoel, char *lakon, ITG *ipkon, ITG *kon, ITG *noregion,
+                             ITG *ipoface, ITG *nodface, ITG *nk));
 
-void FORTRAN(getdesiinfo3d_robust,(char *set,ITG *istartset,ITG *iendset,
-				   ITG *ialset,ITG *nset,ITG *mi,ITG *nactdof,
-				   ITG *ndesi,ITG *nodedesi,ITG *ntie,
-				   char *tieset,ITG *itmp,ITG *nmpc,
-				   ITG *nodempc,ITG *ipompc,ITG *nodedesiinv,
-				   ITG *iponoel,ITG *inoel,char *lakon,
-				   ITG *ipkon,ITG *kon,ITG *noregion,
-				   ITG *ipoface,ITG *nodface,ITG *nk,
-				   ITG *irandomtype));
+void FORTRAN(getdesiinfo3d_robust, (char *set, ITG *istartset, ITG *iendset,
+                                    ITG *ialset, ITG *nset, ITG *mi, ITG *nactdof,
+                                    ITG *ndesi, ITG *nodedesi, ITG *ntie,
+                                    char *tieset, ITG *itmp, ITG *nmpc,
+                                    ITG *nodempc, ITG *ipompc, ITG *nodedesiinv,
+                                    ITG *iponoel, ITG *inoel, char *lakon,
+                                    ITG *ipkon, ITG *kon, ITG *noregion,
+                                    ITG *ipoface, ITG *nodface, ITG *nk,
+                                    ITG *irandomtype));
 
-void FORTRAN(getdesiinfobou,(ITG *ndesibou,ITG *nodedesibou,ITG *nodedesiinv,
-			     char *lakon,ITG *ipkon,ITG *kon,ITG *ipoface,
-			     ITG *nodface,ITG *nodedesiinvbou,ITG *ndesi,
-			     ITG *nodedesi,ITG *nk));
+void FORTRAN(getdesiinfobou, (ITG * ndesibou, ITG *nodedesibou, ITG *nodedesiinv,
+                              char *lakon, ITG *ipkon, ITG *kon, ITG *ipoface,
+                              ITG *nodface, ITG *nodedesiinvbou, ITG *ndesi,
+                              ITG *nodedesi, ITG *nk));
 
-void getglobalresults (char *masterfile,ITG **integerglobp,double **doubleglobp,
-                       ITG *nboun,ITG *iamboun,double *xboun,ITG *nload,
-                       char *sideload,ITG *iamload,ITG *iglob,ITG *nforc,
-                       ITG *iamforc,double *xforc,ITG *ithermal,ITG *nk,
-                       double *t1,ITG *iamt1,double *sigma,ITG *irefine);
+void getglobalresults(char *masterfile, ITG **integerglobp, double **doubleglobp,
+                      ITG *nboun, ITG *iamboun, double *xboun, ITG *nload,
+                      char *sideload, ITG *iamload, ITG *iglob, ITG *nforc,
+                      ITG *iamforc, double *xforc, ITG *ithermal, ITG *nk,
+                      double *t1, ITG *iamt1, double *sigma, ITG *irefine);
 
-void getlocalresults(ITG **integerglobp,double **doubleglobp,ITG *nktet,
-                     double *cotet,double *h,ITG *netet_,ITG *kontet,
-                     ITG *ifatet,double *planfa,ITG *kontetor);
+void getlocalresults(ITG **integerglobp, double **doubleglobp, ITG *nktet,
+                     double *cotet, double *h, ITG *netet_, ITG *kontet,
+                     ITG *ifatet, double *planfa, ITG *kontetor);
 
-void FORTRAN(getnodesinitetmesh,(ITG *ne,char *lakon,ITG *ipkon,ITG *kon,
-				 ITG *istartset,ITG *iendset,ITG *ialset,
-				 char *set,ITG *nset,char *filab,
-				 ITG *inodestet,ITG *nnodestet,ITG *nodface,
-				 ITG *ipoface,ITG *nk));
+void FORTRAN(getnodesinitetmesh, (ITG * ne, char *lakon, ITG *ipkon, ITG *kon,
+                                  ITG *istartset, ITG *iendset, ITG *ialset,
+                                  char *set, ITG *nset, char *filab,
+                                  ITG *inodestet, ITG *nnodestet, ITG *nodface,
+                                  ITG *ipoface, ITG *nk));
 
-ITG getSystemCPUs();;
-    
-void FORTRAN(globalcrackresults,(ITG *nfront,ITG *ifront,double *wk1,
-				 double *wk2,double *wk3,double *dkeq,
-				 double *domphi,double *dadn,ITG *ncyc,
-				 double *dk1glob,double *dk2glob,
-				 double *dk3glob,double *dkeqglob,
-				 double *phiglob,double *dadnglob,
-				 double *dnglob,double *acrack,
-				 double *acrackglob,ITG *nstep,
-				 double *xkeqmin,double *xkeqmax,
-				 double *xkeqminglob,double *xkeqmaxglob,
-				 ITG *iinc,ITG *iincglob,double *domstep,
-				 double *domstepglob,double *r,double *rglob));
+ITG getSystemCPUs();
+;
 
-void FORTRAN(gradcoefficients,(ITG *nef,char *lakonf,ITG *ipkonf,ITG *konf,
-			       double *gradelsh,ITG *ipogradfa,double *gradfash,
-			       ITG *ngradfash,ITG *ipnei,double *co));
+void FORTRAN(globalcrackresults, (ITG * nfront, ITG *ifront, double *wk1,
+                                  double *wk2, double *wk3, double *dkeq,
+                                  double *domphi, double *dadn, ITG *ncyc,
+                                  double *dk1glob, double *dk2glob,
+                                  double *dk3glob, double *dkeqglob,
+                                  double *phiglob, double *dadnglob,
+                                  double *dnglob, double *acrack,
+                                  double *acrackglob, ITG *nstep,
+                                  double *xkeqmin, double *xkeqmax,
+                                  double *xkeqminglob, double *xkeqmaxglob,
+                                  ITG *iinc, ITG *iincglob, double *domstep,
+                                  double *domstepglob, double *r, double *rglob));
 
-void FORTRAN(identamta,(double *amta,double *reftime,ITG *istart,ITG *iend,
-               ITG *id));
+void FORTRAN(gradcoefficients, (ITG * nef, char *lakonf, ITG *ipkonf, ITG *konf,
+                                double *gradelsh, ITG *ipogradfa, double *gradfash,
+                                ITG *ngradfash, ITG *ipnei, double *co));
 
-void FORTRAN(identifytiedface,(char *tieset,ITG *ntie,char *set,ITG *nset,
-                               ITG *faceslave,char *kind));
+void FORTRAN(identamta, (double *amta, double *reftime, ITG *istart, ITG *iend,
+                         ITG *id));
 
-void FORTRAN(includefilename,(char *buff,char *includefn,ITG *lincludefn));
+void FORTRAN(identifytiedface, (char *tieset, ITG *ntie, char *set, ITG *nset,
+                                ITG *faceslave, char *kind));
 
-void inicont(ITG* nk,ITG *ncont,ITG *ntie,char *tieset,ITG *nset,char *set,
-             ITG *istartset,ITG *iendset,ITG *ialset,ITG **itietrip,
-             char *lakon,ITG *ipkon,ITG *kon,ITG **koncontp,
-             ITG *ncone,double *tietol,ITG *ismallsliding,ITG **itiefacp,
-             ITG **islavsurfp,ITG **islavnodep,ITG **imastnodep,
-             ITG **nslavnodep,ITG **nmastnodep,ITG *mortar,
-             ITG **imastopp,ITG *nkon,ITG **iponoels,ITG **inoelsp,
-             ITG **ipep,ITG **imep,ITG *ne,ITG *ifacecount,
-             ITG *iperturb,ITG *ikboun,ITG *nboun,double *co,ITG *istep,
+void FORTRAN(includefilename, (char *buff, char *includefn, ITG *lincludefn));
+
+void inicont(ITG *nk, ITG *ncont, ITG *ntie, char *tieset, ITG *nset, char *set,
+             ITG *istartset, ITG *iendset, ITG *ialset, ITG **itietrip,
+             char *lakon, ITG *ipkon, ITG *kon, ITG **koncontp,
+             ITG *ncone, double *tietol, ITG *ismallsliding, ITG **itiefacp,
+             ITG **islavsurfp, ITG **islavnodep, ITG **imastnodep,
+             ITG **nslavnodep, ITG **nmastnodep, ITG *mortar,
+             ITG **imastopp, ITG *nkon, ITG **iponoels, ITG **inoelsp,
+             ITG **ipep, ITG **imep, ITG *ne, ITG *ifacecount,
+             ITG *iperturb, ITG *ikboun, ITG *nboun, double *co, ITG *istep,
              double **xnoelsp);
 
-void iniparll(ITG *mt,ITG *nactdof,double *b,double *v,
-              double *veold,double *accold,double *bet,
-              double *gam,double *dtime,double *cam,
-              ITG *nk,ITG *num_cpus,ITG *mortar);
+void iniparll(ITG *mt, ITG *nactdof, double *b, double *v,
+              double *veold, double *accold, double *bet,
+              double *gam, double *dtime, double *cam,
+              ITG *nk, ITG *num_cpus, ITG *mortar);
 
 void *iniparllmt(ITG *i);
 
 void *iniparllmt_massless(ITG *i);
 
-void FORTRAN(init_mesh,(double *cotet,ITG *nktet,double *xmin,double *ymin,
-			double *zmin,double *charlen,ITG *ndx,ITG *ndy,
-			ITG *ndz,ITG *ncat_,ITG *kontet,ITG *ifac,
-			ITG *nktet_,ITG *netet_));
+void FORTRAN(init_mesh, (double *cotet, ITG *nktet, double *xmin, double *ymin,
+                         double *zmin, double *charlen, ITG *ndx, ITG *ndy,
+                         ITG *ndz, ITG *ncat_, ITG *kontet, ITG *ifac,
+                         ITG *nktet_, ITG *netet_));
 
-void FORTRAN(init_submodel,(ITG *nktet,ITG *inodfa,ITG *ipofa,ITG *netet_));
-  
-void FORTRAN(initialcfdfem,(double *yy,ITG *nk,double *co,ITG *ne,ITG *ipkon,
-			    ITG *kon,char *lakon,double *x,double *y,double *z,
-			    double *xo,double *yo,double *zo,ITG *nx,ITG *ny,
-			    ITG *nz,ITG *isolidsurf,ITG *neighsolidsurf,
-			    double *xsolidsurf,double *dh,ITG *nshcon,
-			    double *shcon,ITG *nrhcon,double *rhcon,
-			    double *vold,double *vcon,ITG *ntmat_,ITG *iponoel,
-			    ITG *inoel,ITG *nsolidsurf,
-			    ITG *iturbulent,double *physcon,ITG *compressible,
-			    char *matname,ITG *inomat,ITG *mi,
-			    ITG *ithermal,double *dhel,ITG *jyy,
-			    ITG *ifreesurface,ITG *nbody,ITG *ipobody,
-			    ITG *ibody,double *xbody,double *depth,
-			    ITG *nodfreesurf,double *dgravity,double *xg));
+void FORTRAN(init_submodel, (ITG * nktet, ITG *inodfa, ITG *ipofa, ITG *netet_));
 
-void FORTRAN(initialchannel,(ITG *itg,ITG *ieg,ITG *ntg,double *ac,double *bc,
-                         char *lakon,double *v,ITG * ipkon,ITG *kon,
-                         ITG *nflow,ITG *ikboun,ITG *nboun,double *prop,
-                         ITG *ielprop,ITG *nactdog,ITG *ndirboun,
-                         ITG *nodeboun,double *xbounact,ITG *ielmat,
-                         ITG *ntmat_,double *shcon,ITG *nshcon,
-                         double *physcon,ITG *ipiv,ITG *nteq,
-                         double *rhcon,ITG *nrhcon,ITG *ipobody,ITG *ibody,
-                         double *xbody,double *co,ITG *nbody,ITG *network,
-                         ITG *iin_abs,double *vold,char *set,ITG *istep,
-                         ITG *iit,ITG *mi,ITG *ineighe,ITG *ilboun,
-                         double *ttime,double *time,ITG *iaxial));
+void FORTRAN(initialcfdfem, (double *yy, ITG *nk, double *co, ITG *ne, ITG *ipkon,
+                             ITG *kon, char *lakon, double *x, double *y, double *z,
+                             double *xo, double *yo, double *zo, ITG *nx, ITG *ny,
+                             ITG *nz, ITG *isolidsurf, ITG *neighsolidsurf,
+                             double *xsolidsurf, double *dh, ITG *nshcon,
+                             double *shcon, ITG *nrhcon, double *rhcon,
+                             double *vold, double *vcon, ITG *ntmat_, ITG *iponoel,
+                             ITG *inoel, ITG *nsolidsurf,
+                             ITG *iturbulent, double *physcon, ITG *compressible,
+                             char *matname, ITG *inomat, ITG *mi,
+                             ITG *ithermal, double *dhel, ITG *jyy,
+                             ITG *ifreesurface, ITG *nbody, ITG *ipobody,
+                             ITG *ibody, double *xbody, double *depth,
+                             ITG *nodfreesurf, double *dgravity, double *xg));
 
-void FORTRAN(initialnet,(ITG *itg,ITG *ieg,ITG *ntg,double *ac,double *bc,
-                         char *lakon,double *v,ITG * ipkon,ITG *kon,
-                         ITG *nflow,ITG *ikboun,ITG *nboun,double *prop,
-                         ITG *ielprop,ITG *nactdog,ITG *ndirboun,
-                         ITG *nodeboun,double *xbounact,ITG *ielmat,
-                         ITG *ntmat_,double *shcon,ITG *nshcon,
-                         double *physcon,ITG *ipiv,ITG *nteq,
-                         double *rhcon,ITG *nrhcon,ITG *ipobody,ITG *ibody,
-                         double *xbody,double *co,ITG *nbody,ITG *network,
-                         ITG *iin_abs,double *vold,char *set,ITG *istep,
-                         ITG *iit,ITG *mi,ITG *ineighe,ITG *ilboun,
-                         ITG *channel,ITG *iaxial,ITG *nmpc,char *labmpc,
-                         ITG *ipompc,ITG *nodempc,double *coefmpc,
-                         double *ttime,double *time,ITG *iponoel,ITG *inoel));
+void FORTRAN(initialchannel, (ITG * itg, ITG *ieg, ITG *ntg, double *ac, double *bc,
+                              char *lakon, double *v, ITG *ipkon, ITG *kon,
+                              ITG *nflow, ITG *ikboun, ITG *nboun, double *prop,
+                              ITG *ielprop, ITG *nactdog, ITG *ndirboun,
+                              ITG *nodeboun, double *xbounact, ITG *ielmat,
+                              ITG *ntmat_, double *shcon, ITG *nshcon,
+                              double *physcon, ITG *ipiv, ITG *nteq,
+                              double *rhcon, ITG *nrhcon, ITG *ipobody, ITG *ibody,
+                              double *xbody, double *co, ITG *nbody, ITG *network,
+                              ITG *iin_abs, double *vold, char *set, ITG *istep,
+                              ITG *iit, ITG *mi, ITG *ineighe, ITG *ilboun,
+                              double *ttime, double *time, ITG *iaxial));
 
-void ini_cal(char *jobnamec,char *output,char *fneig,char *kind1,char *kind2,
-	     ITG *itempuser,ITG *irobustdesign,ITG *nprint,
-	     ITG *neq,ITG *mpcfree,ITG *nbounold,ITG *nforcold,ITG *nloadold,
-	     ITG *nbody_,ITG *nbodyold,ITG *network,ITG *nheading_,ITG *nmpc_,
-	     ITG *nload_,ITG *nforc_,ITG *nboun_,ITG *nintpoint,ITG *iperturb,
-	     ITG *ntmat_,ITG *ithermal,ITG *isolver,ITG *nslavs,ITG *nkon_,
-	     ITG *mortar,ITG *jout,ITG *nkon,ITG *nevtot,ITG *ifacecount,
-	     ITG *iplas,ITG *npmat_,ITG *mi,ITG *mpcend,ITG *namtot_,ITG *iumat,
-	     ITG *icascade,ITG *ne1d,ITG *ne2d,ITG *infree,ITG *nflow,
-	     ITG *irstrt,ITG *nener,ITG *jrstrt,ITG *ntie_,ITG *mcs,ITG *nprop_,
-	     ITG *nprop,ITG *itpamp,ITG *nevdamp_,ITG *npt_,ITG *iaxial,
-	     ITG *inext,ITG *icontact,ITG *nobject,ITG *nobject_,ITG *iit,
-	     ITG *mpcfreeref,ITG *isens,ITG *namtot,ITG *nstam,ITG *ndamp,
-	     ITG *nef,ITG *nk_,ITG *ne_,ITG *nalset_,
-	     ITG *nmat_,ITG *norien_,ITG *nam_,ITG *ntrans_,ITG *ncs_,
-	     ITG *nstate_,ITG *ncmat_,ITG *memmpc_,ITG *nprint_,double *energy,
-	     double *ctrl,double *alpha,double *qaold,double *physcon,
-	     ITG *istep,ITG *istat,ITG *iprestr,ITG *kode,ITG *nload,
-	     ITG *nbody,ITG *nforc,ITG *nboun,ITG *nk,ITG *nmpc,ITG *nam,
-	     ITG *nzs_,ITG *nlabel,double *ttime,ITG *iheading,ITG *nfc,
-	     ITG *nfc_,ITG *ndc,ITG *ndc_);
+void FORTRAN(initialnet, (ITG * itg, ITG *ieg, ITG *ntg, double *ac, double *bc,
+                          char *lakon, double *v, ITG *ipkon, ITG *kon,
+                          ITG *nflow, ITG *ikboun, ITG *nboun, double *prop,
+                          ITG *ielprop, ITG *nactdog, ITG *ndirboun,
+                          ITG *nodeboun, double *xbounact, ITG *ielmat,
+                          ITG *ntmat_, double *shcon, ITG *nshcon,
+                          double *physcon, ITG *ipiv, ITG *nteq,
+                          double *rhcon, ITG *nrhcon, ITG *ipobody, ITG *ibody,
+                          double *xbody, double *co, ITG *nbody, ITG *network,
+                          ITG *iin_abs, double *vold, char *set, ITG *istep,
+                          ITG *iit, ITG *mi, ITG *ineighe, ITG *ilboun,
+                          ITG *channel, ITG *iaxial, ITG *nmpc, char *labmpc,
+                          ITG *ipompc, ITG *nodempc, double *coefmpc,
+                          double *ttime, double *time, ITG *iponoel, ITG *inoel));
 
-void insert_cmatrix(ITG *ipointer,ITG **mast1p,ITG **nextp,ITG *i1,
-		    ITG *i2,ITG *ifree,ITG *nzs_);
+void ini_cal(char *jobnamec, char *output, char *fneig, char *kind1, char *kind2,
+             ITG *itempuser, ITG *irobustdesign, ITG *nprint,
+             ITG *neq, ITG *mpcfree, ITG *nbounold, ITG *nforcold, ITG *nloadold,
+             ITG *nbody_, ITG *nbodyold, ITG *network, ITG *nheading_, ITG *nmpc_,
+             ITG *nload_, ITG *nforc_, ITG *nboun_, ITG *nintpoint, ITG *iperturb,
+             ITG *ntmat_, ITG *ithermal, ITG *isolver, ITG *nslavs, ITG *nkon_,
+             ITG *mortar, ITG *jout, ITG *nkon, ITG *nevtot, ITG *ifacecount,
+             ITG *iplas, ITG *npmat_, ITG *mi, ITG *mpcend, ITG *namtot_, ITG *iumat,
+             ITG *icascade, ITG *ne1d, ITG *ne2d, ITG *infree, ITG *nflow,
+             ITG *irstrt, ITG *nener, ITG *jrstrt, ITG *ntie_, ITG *mcs, ITG *nprop_,
+             ITG *nprop, ITG *itpamp, ITG *nevdamp_, ITG *npt_, ITG *iaxial,
+             ITG *inext, ITG *icontact, ITG *nobject, ITG *nobject_, ITG *iit,
+             ITG *mpcfreeref, ITG *isens, ITG *namtot, ITG *nstam, ITG *ndamp,
+             ITG *nef, ITG *nk_, ITG *ne_, ITG *nalset_,
+             ITG *nmat_, ITG *norien_, ITG *nam_, ITG *ntrans_, ITG *ncs_,
+             ITG *nstate_, ITG *ncmat_, ITG *memmpc_, ITG *nprint_, double *energy,
+             double *ctrl, double *alpha, double *qaold, double *physcon,
+             ITG *istep, ITG *istat, ITG *iprestr, ITG *kode, ITG *nload,
+             ITG *nbody, ITG *nforc, ITG *nboun, ITG *nk, ITG *nmpc, ITG *nam,
+             ITG *nzs_, ITG *nlabel, double *ttime, ITG *iheading, ITG *nfc,
+             ITG *nfc_, ITG *ndc, ITG *ndc_);
 
-void insert(ITG *ipointer,ITG **mast1p,ITG **mast2p,ITG *i1,
-            ITG *i2,ITG *ifree,ITG *nzs_);
+void insert_cmatrix(ITG *ipointer, ITG **mast1p, ITG **nextp, ITG *i1,
+                    ITG *i2, ITG *ifree, ITG *nzs_);
+
+void insert(ITG *ipointer, ITG **mast1p, ITG **mast2p, ITG *i1,
+            ITG *i2, ITG *ifree, ITG *nzs_);
 
 void insertcbs(ITG *ipointer, ITG **irowp, ITG **nextp, ITG *i1,
-	    ITG *i2, ITG *ifree, ITG *nzs_);
+               ITG *i2, ITG *ifree, ITG *nzs_);
 
-void insertfem(ITG *ipointer,ITG **mast1p,ITG **mast2p,ITG *i1,
-	       ITG *i2,ITG *ifree,ITG *nzs_);
+void insertfem(ITG *ipointer, ITG **mast1p, ITG **mast2p, ITG *i1,
+               ITG *i2, ITG *ifree, ITG *nzs_);
 
-void insertfreq(ITG *ipointer,ITG **mast1p,ITG **nextp,ITG *i1,
-                ITG *i2,ITG *ifree,ITG *nzs_);
+void insertfreq(ITG *ipointer, ITG **mast1p, ITG **nextp, ITG *i1,
+                ITG *i2, ITG *ifree, ITG *nzs_);
 
-void insertrad(ITG *ipointer,ITG **mast1p,ITG **mast2p,ITG *i1,
-	       ITG *i2,ITG *ifree,ITG *nzs_);
+void insertrad(ITG *ipointer, ITG **mast1p, ITG **mast2p, ITG *i1,
+               ITG *i2, ITG *ifree, ITG *nzs_);
 
-void FORTRAN(integral_boundary,(double *sumfix,double *sumfree,ITG *ifaext,
-                                ITG *nfaext,ITG *ielfa,ITG *ifabou,double *vfa,
-				ITG *ipnei,double *xxn));
-				
-void FORTRAN(interpolateinface,(ITG *kk,double *xstate1,double *xstateini1,
-				ITG *numpts,ITG *nstate1_,ITG *mi1,
-				ITG *islavsurf1,double *pslavsurf1,ITG *ne01,
-				ITG *islavsurfold1,double *pslavsurfold1));
+void FORTRAN(integral_boundary, (double *sumfix, double *sumfree, ITG *ifaext,
+                                 ITG *nfaext, ITG *ielfa, ITG *ifabou, double *vfa,
+                                 ITG *ipnei, double *xxn));
 
-void FORTRAN(interpolatestate,(ITG *ne,ITG *ipkon,ITG *kon,char *lakon,
-             ITG *ne0,ITG *mi,double *xstate,
-             double *pslavsurf,ITG *nstate_,double *xstateini,
-             ITG *islavsurf,ITG *islavsurfold,
-             double *pslavsurfold,char *tieset,ITG *ntie,ITG *itiefac));
+void FORTRAN(interpolateinface, (ITG * kk, double *xstate1, double *xstateini1,
+                                 ITG *numpts, ITG *nstate1_, ITG *mi1,
+                                 ITG *islavsurf1, double *pslavsurf1, ITG *ne01,
+                                 ITG *islavsurfold1, double *pslavsurfold1));
 
-void interpolatestatemain(ITG *ne,ITG *ipkon,ITG *kon,char *lakon,ITG *ne0,
-			  ITG *mi,double *xstate,double *pslavsurf,
-			  ITG *nstate_,double *xstateini,ITG *islavsurf,
-			  ITG *islavsurfold,double *pslavsurfold,char *tieset,
-			  ITG *ntie,ITG *itiefac);
+void FORTRAN(interpolatestate, (ITG * ne, ITG *ipkon, ITG *kon, char *lakon,
+                                ITG *ne0, ITG *mi, double *xstate,
+                                double *pslavsurf, ITG *nstate_, double *xstateini,
+                                ITG *islavsurf, ITG *islavsurfold,
+                                double *pslavsurfold, char *tieset, ITG *ntie, ITG *itiefac));
+
+void interpolatestatemain(ITG *ne, ITG *ipkon, ITG *kon, char *lakon, ITG *ne0,
+                          ITG *mi, double *xstate, double *pslavsurf,
+                          ITG *nstate_, double *xstateini, ITG *islavsurf,
+                          ITG *islavsurfold, double *pslavsurfold, char *tieset,
+                          ITG *ntie, ITG *itiefac);
 
 void *interpolatestatemainmt(ITG *i);
 
-void interpolcycsymcfd(ITG *nkold,double *cotet,ITG *neold,ITG *ipkon,
-     ITG *kon,ITG **nodempcp,ITG *ipompc,ITG *nmpc,
-     ITG *ikmpc,ITG *ilmpc,double **coefmpcp,char *labmpc,
-     ITG *mpcfree,ITG *memmpc_,char *lakon,ITG *ncs,ITG *nslav,
-     ITG *ithermal,double *cs,ITG *inoslav,ITG *inomast,ITG *ics,ITG *islav);
+void interpolcycsymcfd(ITG *nkold, double *cotet, ITG *neold, ITG *ipkon,
+                       ITG *kon, ITG **nodempcp, ITG *ipompc, ITG *nmpc,
+                       ITG *ikmpc, ITG *ilmpc, double **coefmpcp, char *labmpc,
+                       ITG *mpcfree, ITG *memmpc_, char *lakon, ITG *ncs, ITG *nslav,
+                       ITG *ithermal, double *cs, ITG *inoslav, ITG *inomast, ITG *ics, ITG *islav);
 
-void FORTRAN(interpolextnodes,(ITG *iexternnod,ITG *nexternnod,double *co,
-			       double *doubleglob,ITG *integerglob,
-			       double *stress,ITG *ifront,ITG *nfront,
-			       ITG *ifrontrel,double *costruc,double *temp,
-			       ITG *nstep));
+void FORTRAN(interpolextnodes, (ITG * iexternnod, ITG *nexternnod, double *co,
+                                double *doubleglob, ITG *integerglob,
+                                double *stress, ITG *ifront, ITG *nfront,
+                                ITG *ifrontrel, double *costruc, double *temp,
+                                ITG *nstep));
 
-void FORTRAN(interpolextnodesf,(ITG *iexternnod,ITG *nexternnod,double *co,
-			       double *doubleglobf,ITG *integerglobf,
-			       double *stressf,double *tempf,ITG *nstepf,
-			       ITG *mode));
+void FORTRAN(interpolextnodesf, (ITG * iexternnod, ITG *nexternnod, double *co,
+                                 double *doubleglobf, ITG *integerglobf,
+                                 double *stressf, double *tempf, ITG *nstepf,
+                                 ITG *mode));
 
-void FORTRAN(interpoltet,(double *x,double *y,double *z,double *xo,double *yo,
-			  double *zo,ITG *nx,ITG *ny,ITG *nz,double *planfa,
-			  ITG *ifatet,ITG *netet,ITG *kontet,double *cotet,
-			  ITG *iparent,double *co,ITG *nkfa,ITG *nkfb,
-			  ITG *konl,double *ratio,ITG *ikf));
+void FORTRAN(interpoltet, (double *x, double *y, double *z, double *xo, double *yo,
+                           double *zo, ITG *nx, ITG *ny, ITG *nz, double *planfa,
+                           ITG *ifatet, ITG *netet, ITG *kontet, double *cotet,
+                           ITG *iparent, double *co, ITG *nkfa, ITG *nkfb,
+                           ITG *konl, double *ratio, ITG *ikf));
 
-void interpoltetmain(double *plafa,ITG *ifatet,ITG *netet_,ITG *kontet,
-		     double *cotet,ITG *iparent,double *bc,double *co,
-		     ITG *nkf,ITG *ikf,ITG *konl,double *ratio);
+void interpoltetmain(double *plafa, ITG *ifatet, ITG *netet_, ITG *kontet,
+                     double *cotet, ITG *iparent, double *bc, double *co,
+                     ITG *nkf, ITG *ikf, ITG *konl, double *ratio);
 
 void *interpoltetmt(ITG *i);
 
-void FORTRAN(islavactive,(char *tieset,ITG *ntie,ITG *itietri,double *cg,
-              double *straight,double *co,double *vold,double *xo,
-              double *yo,double *zo,double *x,double *y,double *z,
-              ITG *nx,ITG *ny,ITG *nz,ITG *mi,ITG *imastop,ITG *nslavnode,
-              ITG *islavnode,ITG *islavact));
+void FORTRAN(islavactive, (char *tieset, ITG *ntie, ITG *itietri, double *cg,
+                           double *straight, double *co, double *vold, double *xo,
+                           double *yo, double *zo, double *x, double *y, double *z,
+                           ITG *nx, ITG *ny, ITG *nz, ITG *mi, ITG *imastop, ITG *nslavnode,
+                           ITG *islavnode, ITG *islavact));
 
-void FORTRAN(isortid,(ITG *ix,double *dy,ITG *n,ITG *kflag));
+void FORTRAN(isortid, (ITG * ix, double *dy, ITG *n, ITG *kflag));
 
-void FORTRAN(isortii,(ITG *ix,ITG *iy,ITG *n,ITG *kflag));
+void FORTRAN(isortii, (ITG * ix, ITG *iy, ITG *n, ITG *kflag));
 
-void FORTRAN(isortiid,(ITG *ix,ITG *iy,double *dy,ITG *n,ITG *kflag));
+void FORTRAN(isortiid, (ITG * ix, ITG *iy, double *dy, ITG *n, ITG *kflag));
 
-void FORTRAN(isortiddc,(ITG *ix,double *dy1,double *dy2,char *cy,ITG *n,
+void FORTRAN(isortiddc, (ITG * ix, double *dy1, double *dy2, char *cy, ITG *n,
                          ITG *kflag));
 
-void FORTRAN(isortiiddc,(ITG *ix1,ITG *ix2,double *dy1,double *dy2,
-                         char *cy,ITG *n,ITG *kflag));
+void FORTRAN(isortiiddc, (ITG * ix1, ITG *ix2, double *dy1, double *dy2,
+                          char *cy, ITG *n, ITG *kflag));
 
-void FORTRAN(jouleheating,(ITG *ipkon,char *lakon,ITG *kon,double *co,
-			   double *elcon,ITG *nelcon,ITG *mi,ITG *ne,
-			   double *sti,ITG *ielmat,ITG *nelemload,
-			   char *sideload,double *xload,ITG *nload,ITG *nload_,
-			   ITG *iamload,ITG *nam,ITG *idefload,ITG *ncmat_,
-			   ITG *ntmat_,double *alcon,ITG *nalcon,ITG *ithermal,
-			   double *vold,double *t1,ITG *nmethod));
+void FORTRAN(jouleheating, (ITG * ipkon, char *lakon, ITG *kon, double *co,
+                            double *elcon, ITG *nelcon, ITG *mi, ITG *ne,
+                            double *sti, ITG *ielmat, ITG *nelemload,
+                            char *sideload, double *xload, ITG *nload, ITG *nload_,
+                            ITG *iamload, ITG *nam, ITG *idefload, ITG *ncmat_,
+                            ITG *ntmat_, double *alcon, ITG *nalcon, ITG *ithermal,
+                            double *vold, double *t1, ITG *nmethod));
 
-void FORTRAN(keystart,(ITG *ifreeinp,ITG *ipoinp,ITG *inp,char *name,
-           ITG *iline,ITG *ikey));
-  
-void linstatic(double *co,ITG *nk,ITG **konp,ITG **ipkonp,char **lakonp,
-             ITG *ne,
-             ITG *nodeboun,ITG *ndirboun,double *xboun,ITG *nboun,
-             ITG *ipompc,ITG *nodempc,double *coefmpc,char *labmpc,
-             ITG *nmpc,
-             ITG *nodeforc,ITG *ndirforc,double *xforc,ITG *nforc,
-             ITG *nelemload,char *sideload,double *xload,
-             ITG *nload,ITG *nactdof,
-             ITG **icolp,ITG *jq,ITG **irowp,ITG *neq,ITG *nzl,
-             ITG *nmethod,ITG *ikmpc,ITG *ilmpc,ITG *ikboun,
-             ITG *ilboun,
-             double *elcon,ITG *nelcon,double *rhcon,ITG *nrhcon,
-             double *alcon,ITG *nalcon,double *alzero,ITG **ielmatp,
-             ITG **ielorienp,ITG *norien,double *orab,ITG *ntmat_,
-             double *t0,double *t1,double *t1old,
-             ITG *ithermal,double *prestr,ITG *iprestr,
-             double *vold,ITG *iperturb,double *sti,ITG *nzs,
-             ITG *kode,char *filab,double *eme,
-             ITG *iexpl,double *plicon,ITG *nplicon,double *plkcon,
-             ITG *nplkcon,
-             double **xstatep,ITG *npmat_,char *matname,ITG *isolver,
-             ITG *mi,ITG *ncmat_,ITG *nstate_,double *cs,ITG *mcs,
-             ITG *nkon,double **enerp,double *xbounold,
-             double *xforcold,double *xloadold,
-             char *amname,double *amta,ITG *namta,
-             ITG *nam,ITG *iamforc,ITG *iamload,
-             ITG *iamt1,ITG *iamboun,double *ttime,char *output,
-             char *set,ITG *nset,ITG *istartset,
-             ITG *iendset,ITG *ialset,ITG *nprint,char *prlab,
-             char *prset,ITG *nener,double *trab,
-             ITG *inotr,ITG *ntrans,double *fmpc,ITG *ipobody,ITG *ibody,
-             double *xbody,ITG *nbody,double *xbodyold,double *timepar,
-             double *thicke,char *jobnamec,char *tieset,ITG *ntie,
-             ITG *istep,ITG *nmat,ITG *ielprop,double *prop,char *typeboun,
-             ITG *mortar,ITG *mpcinfo,double *tietol,ITG *ics,
-             char *orname,ITG *itempuser,double *t0g,double *t1g);
+void FORTRAN(keystart, (ITG * ifreeinp, ITG *ipoinp, ITG *inp, char *name,
+                        ITG *iline, ITG *ikey));
 
-void FORTRAN(localaxes,(ITG *ibody,ITG *nbody,double *xbody,double *e1,
-                        double *e2,double *xn));
-
-void FORTRAN(localaxescs,(double *cs,ITG *mcs,double *e1,
-                        double *e2,double *xn));
-
-void FORTRAN(lump,(double *adb,double *aub,double *adl,ITG *irow,ITG *jq,
-                   ITG *neq));
-
-void FORTRAN(mafillcorio,(double *co,ITG *nk,ITG *kon,ITG *ipkon,
-               char *lakon,
-               ITG *ne,ITG *nodeboun,ITG *ndirboun,double *xboun,
-               ITG *nboun,ITG *ipompc,ITG *nodempc,double *coefmpc,
-               ITG *nmpc,ITG *nodeforc,ITG *ndirforc,
-               double *xforc,ITG *nforc,ITG *nelemload,char *sideload,
-               double *xload,ITG *nload,double *xbody,ITG *ipobody,
-               ITG *nbody,double *cgr,
-               double *ad,double *au,ITG *nactdof,
-               ITG *icol,ITG *jq,ITG *irow,ITG *neq,ITG *nzl,
-               ITG *nmethod,ITG *ikmpc,ITG *ilmpc,ITG *ikboun,
-               ITG *ilboun,
-               double *elcon,ITG *nelcon,double *rhcon,ITG *nrhcon,
-               double *alcon,ITG *nalcon,double *alzero,ITG *ielmat,
-               ITG *ielorien,ITG *norien,double *orab,ITG *ntmat_,
-               double *t0,double *t1,ITG *ithermal,
-               double *prestr,ITG *iprestr,double *vold,
-               ITG *iperturb,double *sti,ITG *nzs,double *stx,
-               double *adb,double *aub,ITG *iexpl,
-               double *plicon,ITG *nplicon,double *plkcon,ITG *nplkcon,
-               double *xstiff,
-               ITG *npmat_,double *dtime,char *matname,ITG *mi,
-               ITG *ncmat_,double *ttime,double *time,
-               ITG *istep,ITG *kinc,ITG *ibody,ITG *ielprop,double *prop));
-
-void FORTRAN(mafilldm,(double *co,ITG *nk,ITG *kon,ITG *ipkon,char *lakon,
-               ITG *ne,ITG *nodeboun,ITG *ndirboun,double *xboun,
-               ITG *nboun,ITG *ipompc,ITG *nodempc,double *coefmpc,
-               ITG *nmpc,ITG *nodeforc,ITG *ndirforc,
-               double *xforc,ITG *nforc,ITG *nelemload,char *sideload,
-               double *xload,ITG *nload,double *xbody,ITG *ipobody,
-               ITG *nbody,double *cgr,
-               double *ad,double *au,ITG *nactdof,
-               ITG *icol,ITG *jq,ITG *irow,ITG *neq,ITG *nzl,
-               ITG *nmethod,ITG *ikmpc,ITG *ilmpc,ITG *ikboun,
-               ITG *ilboun,
-               double *elcon,ITG *nelcon,double *rhcon,ITG *nrhcon,
-               double *alcon,ITG *nalcon,double *alzero,ITG *ielmat,
-               ITG *ielorien,ITG *norien,double *orab,ITG *ntmat_,
-               double *t0,double *t1,ITG *ithermal,
-               double *prestr,ITG *iprestr,double *vold,
-               ITG *iperturb,double *sti,ITG *nzs,double *stx,
-               double *adb,double *aub,ITG *iexpl,
-               double *plicon,ITG *nplicon,double *plkcon,ITG *nplkcon,
-               double *xstiff,
-               ITG *npmat_,double *dtime,char *matname,ITG *mi,
-               ITG *ncmat_,double *ttime,double *time,
-               ITG *istep,ITG *kinc,ITG *ibody,double *clearini,
-               ITG *mortar,double *springarea,double *pslavsurf,
-               double *pmastsurf,double *reltime,ITG *nasym));
-
-void FORTRAN(mafilldmss,(double *co,ITG *nk,ITG *kon,ITG *ipkon,char *lakon,
+void linstatic(double *co, ITG *nk, ITG **konp, ITG **ipkonp, char **lakonp,
                ITG *ne,
-               ITG *ipompc,ITG *nodempc,double *coefmpc,
-               ITG *nmpc,ITG *nelemload,char *sideload,
-               double *xload,ITG *nload,double *xbody,ITG *ipobody,
-               ITG *nbody,double *cgr,
-               double *ad,double *au,ITG *nactdof,
-               ITG *jq,ITG *irow,ITG *neq,
-               ITG *nmethod,ITG *ikmpc,ITG *ilmpc,
-               double *elcon,ITG *nelcon,double *rhcon,ITG *nrhcon,
-               double *alcon,ITG *nalcon,double *alzero,ITG *ielmat,
-               ITG *ielorien,ITG *norien,double *orab,ITG *ntmat_,
-               double *t0,double *t1,ITG *ithermal,double *vold,
-               ITG *iperturb,double *sti,double *stx,
-               ITG *iexpl,
-               double *plicon,ITG *nplicon,double *plkcon,ITG *nplkcon,
-               double *xstiff,
-               ITG *npmat_,double *dtime,char *matname,ITG *mi,
-               ITG *ncmat_,double *physcon,
-               double *ttime,double *time,
-               ITG *istep,ITG *kinc,ITG *ibody,
-               double *xloadold,double *reltime,double *veold,
-               double *springarea,ITG *nstate_,double *xstateini,
-               double *xstate,double *thicke,
-               ITG *integerglob,double *doubleglob,char *tieset,
-               ITG *istartset,ITG *iendset,ITG *ialset,ITG *ntie,
-               ITG *nasym,double *pslavsurf,double *pmastsurf,ITG *mortar,
-               double *clearini,ITG *ielprop,double *prop,ITG *ne0,
-               ITG *nea,ITG *neb,
-	       double *freq,ITG *ndamp,double *dacon,char *set,ITG *nset));
+               ITG *nodeboun, ITG *ndirboun, double *xboun, ITG *nboun,
+               ITG *ipompc, ITG *nodempc, double *coefmpc, char *labmpc,
+               ITG *nmpc,
+               ITG *nodeforc, ITG *ndirforc, double *xforc, ITG *nforc,
+               ITG *nelemload, char *sideload, double *xload,
+               ITG *nload, ITG *nactdof,
+               ITG **icolp, ITG *jq, ITG **irowp, ITG *neq, ITG *nzl,
+               ITG *nmethod, ITG *ikmpc, ITG *ilmpc, ITG *ikboun,
+               ITG *   ilboun,
+               double *elcon, ITG *nelcon, double *rhcon, ITG *nrhcon,
+               double *alcon, ITG *nalcon, double *alzero, ITG **ielmatp,
+               ITG **ielorienp, ITG *norien, double *orab, ITG *ntmat_,
+               double *t0, double *t1, double *t1old,
+               ITG *ithermal, double *prestr, ITG *iprestr,
+               double *vold, ITG *iperturb, double *sti, ITG *nzs,
+               ITG *kode, char *filab, double *eme,
+               ITG *iexpl, double *plicon, ITG *nplicon, double *plkcon,
+               ITG *    nplkcon,
+               double **xstatep, ITG *npmat_, char *matname, ITG *isolver,
+               ITG *mi, ITG *ncmat_, ITG *nstate_, double *cs, ITG *mcs,
+               ITG *nkon, double **enerp, double *xbounold,
+               double *xforcold, double *xloadold,
+               char *amname, double *amta, ITG *namta,
+               ITG *nam, ITG *iamforc, ITG *iamload,
+               ITG *iamt1, ITG *iamboun, double *ttime, char *output,
+               char *set, ITG *nset, ITG *istartset,
+               ITG *iendset, ITG *ialset, ITG *nprint, char *prlab,
+               char *prset, ITG *nener, double *trab,
+               ITG *inotr, ITG *ntrans, double *fmpc, ITG *ipobody, ITG *ibody,
+               double *xbody, ITG *nbody, double *xbodyold, double *timepar,
+               double *thicke, char *jobnamec, char *tieset, ITG *ntie,
+               ITG *istep, ITG *nmat, ITG *ielprop, double *prop, char *typeboun,
+               ITG *mortar, ITG *mpcinfo, double *tietol, ITG *ics,
+               char *orname, ITG *itempuser, double *t0g, double *t1g);
 
-void mafilldmssmain(double *co,ITG *nk,ITG *kon,ITG *ipkon,char *lakon,
-               ITG *ne,ITG *ipompc,ITG *nodempc,double *coefmpc,
-               ITG *nmpc,ITG *nelemload,char *sideload,
-               double *xload,ITG *nload,double *xbody,ITG *ipobody,
-               ITG *nbody,double *cgr,
-               double *ad,double *au,ITG *nactdof,
-               ITG *jq,ITG *irow,ITG *neq,
-               ITG *nmethod,ITG *ikmpc,ITG *ilmpc,
-               double *elcon,ITG *nelcon,double *rhcon,ITG *nrhcon,
-               double *alcon,ITG *nalcon,double *alzero,ITG *ielmat,
-               ITG *ielorien,ITG *norien,double *orab,ITG *ntmat_,
-               double *t0,double *t1,ITG *ithermal,double *vold,
-               ITG *iperturb,double *sti,ITG *nzs,double *stx,
-               ITG *iexpl,
-               double *plicon,ITG *nplicon,double *plkcon,ITG *nplkcon,
-               double *xstiff,
-               ITG *npmat_,double *dtime,char *matname,ITG *mi,
-               ITG *ncmat_,double *physcon,double *ttime,double *time,
-               ITG *istep,ITG *kinc,ITG *ibody,
-               double *xloadold,double *reltime,double *veold,
-               double *springarea,ITG *nstate_,double *xstateini,
-               double *xstate,double *thicke,
-               ITG *integerglob,double *doubleglob,char *tieset,
-               ITG *istartset,ITG *iendset,ITG *ialset,ITG *ntie,
-               ITG *nasym,double *pslavsurf,double *pmastsurf,ITG *mortar,
-               double *clearini,ITG *ielprop,double *prop,ITG *ne0,
-	       double *freq,ITG *ndamp,double *dacon,char *set,ITG *nset);
+void FORTRAN(localaxes, (ITG * ibody, ITG *nbody, double *xbody, double *e1,
+                         double *e2, double *xn));
+
+void FORTRAN(localaxescs, (double *cs, ITG *mcs, double *e1,
+                           double *e2, double *xn));
+
+void FORTRAN(lump, (double *adb, double *aub, double *adl, ITG *irow, ITG *jq,
+                    ITG *neq));
+
+void FORTRAN(mafillcorio, (double *co, ITG *nk, ITG *kon, ITG *ipkon,
+                           char *lakon,
+                           ITG *ne, ITG *nodeboun, ITG *ndirboun, double *xboun,
+                           ITG *nboun, ITG *ipompc, ITG *nodempc, double *coefmpc,
+                           ITG *nmpc, ITG *nodeforc, ITG *ndirforc,
+                           double *xforc, ITG *nforc, ITG *nelemload, char *sideload,
+                           double *xload, ITG *nload, double *xbody, ITG *ipobody,
+                           ITG *nbody, double *cgr,
+                           double *ad, double *au, ITG *nactdof,
+                           ITG *icol, ITG *jq, ITG *irow, ITG *neq, ITG *nzl,
+                           ITG *nmethod, ITG *ikmpc, ITG *ilmpc, ITG *ikboun,
+                           ITG *   ilboun,
+                           double *elcon, ITG *nelcon, double *rhcon, ITG *nrhcon,
+                           double *alcon, ITG *nalcon, double *alzero, ITG *ielmat,
+                           ITG *ielorien, ITG *norien, double *orab, ITG *ntmat_,
+                           double *t0, double *t1, ITG *ithermal,
+                           double *prestr, ITG *iprestr, double *vold,
+                           ITG *iperturb, double *sti, ITG *nzs, double *stx,
+                           double *adb, double *aub, ITG *iexpl,
+                           double *plicon, ITG *nplicon, double *plkcon, ITG *nplkcon,
+                           double *xstiff,
+                           ITG *npmat_, double *dtime, char *matname, ITG *mi,
+                           ITG *ncmat_, double *ttime, double *time,
+                           ITG *istep, ITG *kinc, ITG *ibody, ITG *ielprop, double *prop));
+
+void FORTRAN(mafilldm, (double *co, ITG *nk, ITG *kon, ITG *ipkon, char *lakon,
+                        ITG *ne, ITG *nodeboun, ITG *ndirboun, double *xboun,
+                        ITG *nboun, ITG *ipompc, ITG *nodempc, double *coefmpc,
+                        ITG *nmpc, ITG *nodeforc, ITG *ndirforc,
+                        double *xforc, ITG *nforc, ITG *nelemload, char *sideload,
+                        double *xload, ITG *nload, double *xbody, ITG *ipobody,
+                        ITG *nbody, double *cgr,
+                        double *ad, double *au, ITG *nactdof,
+                        ITG *icol, ITG *jq, ITG *irow, ITG *neq, ITG *nzl,
+                        ITG *nmethod, ITG *ikmpc, ITG *ilmpc, ITG *ikboun,
+                        ITG *   ilboun,
+                        double *elcon, ITG *nelcon, double *rhcon, ITG *nrhcon,
+                        double *alcon, ITG *nalcon, double *alzero, ITG *ielmat,
+                        ITG *ielorien, ITG *norien, double *orab, ITG *ntmat_,
+                        double *t0, double *t1, ITG *ithermal,
+                        double *prestr, ITG *iprestr, double *vold,
+                        ITG *iperturb, double *sti, ITG *nzs, double *stx,
+                        double *adb, double *aub, ITG *iexpl,
+                        double *plicon, ITG *nplicon, double *plkcon, ITG *nplkcon,
+                        double *xstiff,
+                        ITG *npmat_, double *dtime, char *matname, ITG *mi,
+                        ITG *ncmat_, double *ttime, double *time,
+                        ITG *istep, ITG *kinc, ITG *ibody, double *clearini,
+                        ITG *mortar, double *springarea, double *pslavsurf,
+                        double *pmastsurf, double *reltime, ITG *nasym));
+
+void FORTRAN(mafilldmss, (double *co, ITG *nk, ITG *kon, ITG *ipkon, char *lakon,
+                          ITG *ne,
+                          ITG *ipompc, ITG *nodempc, double *coefmpc,
+                          ITG *nmpc, ITG *nelemload, char *sideload,
+                          double *xload, ITG *nload, double *xbody, ITG *ipobody,
+                          ITG *nbody, double *cgr,
+                          double *ad, double *au, ITG *nactdof,
+                          ITG *jq, ITG *irow, ITG *neq,
+                          ITG *nmethod, ITG *ikmpc, ITG *ilmpc,
+                          double *elcon, ITG *nelcon, double *rhcon, ITG *nrhcon,
+                          double *alcon, ITG *nalcon, double *alzero, ITG *ielmat,
+                          ITG *ielorien, ITG *norien, double *orab, ITG *ntmat_,
+                          double *t0, double *t1, ITG *ithermal, double *vold,
+                          ITG *iperturb, double *sti, double *stx,
+                          ITG *   iexpl,
+                          double *plicon, ITG *nplicon, double *plkcon, ITG *nplkcon,
+                          double *xstiff,
+                          ITG *npmat_, double *dtime, char *matname, ITG *mi,
+                          ITG *ncmat_, double *physcon,
+                          double *ttime, double *time,
+                          ITG *istep, ITG *kinc, ITG *ibody,
+                          double *xloadold, double *reltime, double *veold,
+                          double *springarea, ITG *nstate_, double *xstateini,
+                          double *xstate, double *thicke,
+                          ITG *integerglob, double *doubleglob, char *tieset,
+                          ITG *istartset, ITG *iendset, ITG *ialset, ITG *ntie,
+                          ITG *nasym, double *pslavsurf, double *pmastsurf, ITG *mortar,
+                          double *clearini, ITG *ielprop, double *prop, ITG *ne0,
+                          ITG *nea, ITG *neb,
+                          double *freq, ITG *ndamp, double *dacon, char *set, ITG *nset));
+
+void mafilldmssmain(double *co, ITG *nk, ITG *kon, ITG *ipkon, char *lakon,
+                    ITG *ne, ITG *ipompc, ITG *nodempc, double *coefmpc,
+                    ITG *nmpc, ITG *nelemload, char *sideload,
+                    double *xload, ITG *nload, double *xbody, ITG *ipobody,
+                    ITG *nbody, double *cgr,
+                    double *ad, double *au, ITG *nactdof,
+                    ITG *jq, ITG *irow, ITG *neq,
+                    ITG *nmethod, ITG *ikmpc, ITG *ilmpc,
+                    double *elcon, ITG *nelcon, double *rhcon, ITG *nrhcon,
+                    double *alcon, ITG *nalcon, double *alzero, ITG *ielmat,
+                    ITG *ielorien, ITG *norien, double *orab, ITG *ntmat_,
+                    double *t0, double *t1, ITG *ithermal, double *vold,
+                    ITG *iperturb, double *sti, ITG *nzs, double *stx,
+                    ITG *   iexpl,
+                    double *plicon, ITG *nplicon, double *plkcon, ITG *nplkcon,
+                    double *xstiff,
+                    ITG *npmat_, double *dtime, char *matname, ITG *mi,
+                    ITG *ncmat_, double *physcon, double *ttime, double *time,
+                    ITG *istep, ITG *kinc, ITG *ibody,
+                    double *xloadold, double *reltime, double *veold,
+                    double *springarea, ITG *nstate_, double *xstateini,
+                    double *xstate, double *thicke,
+                    ITG *integerglob, double *doubleglob, char *tieset,
+                    ITG *istartset, ITG *iendset, ITG *ialset, ITG *ntie,
+                    ITG *nasym, double *pslavsurf, double *pmastsurf, ITG *mortar,
+                    double *clearini, ITG *ielprop, double *prop, ITG *ne0,
+                    double *freq, ITG *ndamp, double *dacon, char *set, ITG *nset);
 
 void *mafilldmssmt(ITG *i);
 
-void FORTRAN(mafillem,(double *co,ITG *nk,ITG *kon,ITG *ipkon,char *lakon,
-               ITG *ne,ITG *nodeboun,ITG *ndirboun,double *xboun,
-               ITG *nboun,ITG *ipompc,ITG *nodempc,double *coefmpc,
-               ITG *nmpc,ITG *nodeforc,ITG *ndirforc,
-               double *xforc,ITG *nforc,ITG *nelemload,char *sideload,
-               double *xload,ITG *nload,double *xbody,ITG *ipobody,
-               ITG *nbody,double *cgr,
-               double *ad,double *au,double *bb,ITG *nactdof,
-               ITG *icol,ITG *jq,ITG *irow,ITG *neq,ITG *nzl,
-               ITG *nmethod,ITG *ikmpc,ITG *ilmpc,ITG *ikboun,
-               ITG *ilboun,
-               double *elcon,ITG *nelcon,double *rhcon,ITG *nrhcon,
-               double *alcon,ITG *nalcon,double *alzero,ITG *ielmat,
-               ITG *ielorien,ITG *norien,double *orab,ITG *ntmat_,
-               double *t0,double *t1,ITG *ithermal,
-               double *prestr,ITG *iprestr,double *vold,
-               ITG *iperturb,double *sti,ITG *nzs,double *stx,
-               double *adb,double *aub,ITG *iexpl,
-               double *plicon,ITG *nplicon,double *plkcon,ITG *nplkcon,
-               double *xstiff,
-               ITG *npmat_,double *dtime,char *matname,ITG *mi,
-               ITG *ncmat_,ITG *mass,ITG *stiffness,ITG *buckling,ITG *rhs,
-               ITG *intscheme,double *physcon,double *shcon,ITG *nshcon,
-               double *cocon,ITG *ncocon,double *ttime,double *time,
-               ITG *istep,ITG *kinc,ITG *coriolis,ITG *ibody,
-               double *xloadold,double *reltime,double *veold,
-               double *springarea,ITG *nstate_,double *xstateini,
-               double *xstate,double *thicke,
-               ITG *integerglob,double *doubleglob,char *tieset,
-               ITG *istartset,ITG *iendset,ITG *ialset,ITG *ntie,
-               ITG *nasym,ITG *iactive,double *h0,double *pslavsurf,
-               double *pmastsurf,ITG *mortar,double *clearini,
-               ITG *ielprop,double *prop,ITG *iponoel,ITG *inoel,
-               ITG *network));
+void FORTRAN(mafillem, (double *co, ITG *nk, ITG *kon, ITG *ipkon, char *lakon,
+                        ITG *ne, ITG *nodeboun, ITG *ndirboun, double *xboun,
+                        ITG *nboun, ITG *ipompc, ITG *nodempc, double *coefmpc,
+                        ITG *nmpc, ITG *nodeforc, ITG *ndirforc,
+                        double *xforc, ITG *nforc, ITG *nelemload, char *sideload,
+                        double *xload, ITG *nload, double *xbody, ITG *ipobody,
+                        ITG *nbody, double *cgr,
+                        double *ad, double *au, double *bb, ITG *nactdof,
+                        ITG *icol, ITG *jq, ITG *irow, ITG *neq, ITG *nzl,
+                        ITG *nmethod, ITG *ikmpc, ITG *ilmpc, ITG *ikboun,
+                        ITG *   ilboun,
+                        double *elcon, ITG *nelcon, double *rhcon, ITG *nrhcon,
+                        double *alcon, ITG *nalcon, double *alzero, ITG *ielmat,
+                        ITG *ielorien, ITG *norien, double *orab, ITG *ntmat_,
+                        double *t0, double *t1, ITG *ithermal,
+                        double *prestr, ITG *iprestr, double *vold,
+                        ITG *iperturb, double *sti, ITG *nzs, double *stx,
+                        double *adb, double *aub, ITG *iexpl,
+                        double *plicon, ITG *nplicon, double *plkcon, ITG *nplkcon,
+                        double *xstiff,
+                        ITG *npmat_, double *dtime, char *matname, ITG *mi,
+                        ITG *ncmat_, ITG *mass, ITG *stiffness, ITG *buckling, ITG *rhs,
+                        ITG *intscheme, double *physcon, double *shcon, ITG *nshcon,
+                        double *cocon, ITG *ncocon, double *ttime, double *time,
+                        ITG *istep, ITG *kinc, ITG *coriolis, ITG *ibody,
+                        double *xloadold, double *reltime, double *veold,
+                        double *springarea, ITG *nstate_, double *xstateini,
+                        double *xstate, double *thicke,
+                        ITG *integerglob, double *doubleglob, char *tieset,
+                        ITG *istartset, ITG *iendset, ITG *ialset, ITG *ntie,
+                        ITG *nasym, ITG *iactive, double *h0, double *pslavsurf,
+                        double *pmastsurf, ITG *mortar, double *clearini,
+                        ITG *ielprop, double *prop, ITG *iponoel, ITG *inoel,
+                        ITG *network));
 
-void FORTRAN(mafillfreq_em,(double *ad,double *au,double *adb,double *aub,
-             ITG *irow,ITG *jq,ITG *neq,double *adfreq,double *aubfreq,
-             ITG *irowfreq,ITG *iaux,ITG *jqfreq,ITG *icolfreq,ITG *neqfreq,
-             ITG *nzsfreq,double *om,ITG *symmetryflag,ITG *inputformat,
-             double *b,double *bfreq));
+void FORTRAN(mafillfreq_em, (double *ad, double *au, double *adb, double *aub,
+                             ITG *irow, ITG *jq, ITG *neq, double *adfreq, double *aubfreq,
+                             ITG *irowfreq, ITG *iaux, ITG *jqfreq, ITG *icolfreq, ITG *neqfreq,
+                             ITG *nzsfreq, double *om, ITG *symmetryflag, ITG *inputformat,
+                             double *b, double *bfreq));
 
-void FORTRAN(mafillklhs,(double *co,ITG *nk,ITG *kon,ITG *ipkon,char *lakon,
-			 ITG *ne,ITG *nodeboun,ITG *ndirboun,double *xboun,
-			 ITG *nboun,ITG *ipompc,ITG *nodempc,double *coefmpc,
-			 ITG *nmpc,ITG *nactdok,ITG *icolk,ITG *jqk,ITG *irowk,
-			 ITG *neqk,ITG *nzlk,ITG *ikmpc,ITG *ilmpc,ITG *ikboun,
-			 ITG *ilboun,ITG *nzsk,double *adbk,double *aubk,
-			 ITG *ipvar,double *var));
+void FORTRAN(mafillklhs, (double *co, ITG *nk, ITG *kon, ITG *ipkon, char *lakon,
+                          ITG *ne, ITG *nodeboun, ITG *ndirboun, double *xboun,
+                          ITG *nboun, ITG *ipompc, ITG *nodempc, double *coefmpc,
+                          ITG *nmpc, ITG *nactdok, ITG *icolk, ITG *jqk, ITG *irowk,
+                          ITG *neqk, ITG *nzlk, ITG *ikmpc, ITG *ilmpc, ITG *ikboun,
+                          ITG *ilboun, ITG *nzsk, double *adbk, double *aubk,
+                          ITG *ipvar, double *var));
 
-void FORTRAN(mafillkrhs,(double *co,ITG *nk,ITG *kon,ITG *ipkon,char *lakon,
-        ITG *ne,ITG *nodeboun,ITG *ndirboun,double *xboun,ITG *nboun,
-        ITG *ipompc,ITG *nodempc,double *coefmpc,ITG *nmpc,ITG *nelemface,
-        char *sideface,ITG *nface,ITG *nactdok,ITG *neqk,ITG *nmethod,
-        ITG *ikmpc,ITG *ilmpc,ITG *ikboun,ITG *ilboun,double *rhcon,
-        ITG *nrhcon,ITG *ielmat,ITG *ntmat_,double *vold,double *voldaux,
-        ITG *nzsk,double *dtimef,char *matname,ITG *mi,ITG *ncmat_,
-        double *shcon,ITG *nshcon,double *theta1,double *bk,
-        double *bt,ITG *isolidsurf,ITG *nsolidsurf,
-        ITG *ifreestream,ITG *nfreestream,double *xsolidsurf,double *yy,
-	ITG *compressible,ITG *turbulent,ITG *ithermal,ITG *ipvar,
-	double *var,ITG *ipvarf,double *varf,ITG *nea,ITG *neb,
-	double *dt,double *ck,double *ct,double *physcon,ITG *ipface));
+void FORTRAN(mafillkrhs, (double *co, ITG *nk, ITG *kon, ITG *ipkon, char *lakon,
+                          ITG *ne, ITG *nodeboun, ITG *ndirboun, double *xboun, ITG *nboun,
+                          ITG *ipompc, ITG *nodempc, double *coefmpc, ITG *nmpc, ITG *nelemface,
+                          char *sideface, ITG *nface, ITG *nactdok, ITG *neqk, ITG *nmethod,
+                          ITG *ikmpc, ITG *ilmpc, ITG *ikboun, ITG *ilboun, double *rhcon,
+                          ITG *nrhcon, ITG *ielmat, ITG *ntmat_, double *vold, double *voldaux,
+                          ITG *nzsk, double *dtimef, char *matname, ITG *mi, ITG *ncmat_,
+                          double *shcon, ITG *nshcon, double *theta1, double *bk,
+                          double *bt, ITG *isolidsurf, ITG *nsolidsurf,
+                          ITG *ifreestream, ITG *nfreestream, double *xsolidsurf, double *yy,
+                          ITG *compressible, ITG *turbulent, ITG *ithermal, ITG *ipvar,
+                          double *var, ITG *ipvarf, double *varf, ITG *nea, ITG *neb,
+                          double *dt, double *ck, double *ct, double *physcon, ITG *ipface));
 
 void *mafillkrhsmt(ITG *i);
 
-void FORTRAN(mafillnet,(ITG *itg,ITG *ieg,ITG *ntg,
-                        double *ac,ITG *nload,char *sideload,
-                        ITG *nelemload,double *xloadact,char *lakon,
-                        ITG *ntmat_,double *v,double *shcon,ITG *nshcon,
-                        ITG *ipkon,ITG *kon,double *co,ITG *nflow,
-                        ITG *iinc,ITG *istep,
-                        double *dtime,double *ttime,double *time,
-                        ITG *ielmat,ITG *nteq,double *prop,
-                        ITG *ielprop,ITG *nactdog,ITG *nacteq,
-                        double *physcon,double *rhcon,ITG *nrhcon,
-                        ITG *ipobody,ITG *ibody,double *xbody,ITG *nbody,
-                        double *vold,double *xloadold,double *reltime,
-                        ITG *nmethod,char *set,ITG *mi,ITG *nmpc,
-                        ITG *nodempc,ITG *ipompc,double *coefmpc,
-                        char *labmpc,ITG *iaxial,double *cocon,ITG *ncocon,
-                        ITG *iponoel,ITG *inoel));
+void FORTRAN(mafillnet, (ITG * itg, ITG *ieg, ITG *ntg,
+                         double *ac, ITG *nload, char *sideload,
+                         ITG *nelemload, double *xloadact, char *lakon,
+                         ITG *ntmat_, double *v, double *shcon, ITG *nshcon,
+                         ITG *ipkon, ITG *kon, double *co, ITG *nflow,
+                         ITG *iinc, ITG *istep,
+                         double *dtime, double *ttime, double *time,
+                         ITG *ielmat, ITG *nteq, double *prop,
+                         ITG *ielprop, ITG *nactdog, ITG *nacteq,
+                         double *physcon, double *rhcon, ITG *nrhcon,
+                         ITG *ipobody, ITG *ibody, double *xbody, ITG *nbody,
+                         double *vold, double *xloadold, double *reltime,
+                         ITG *nmethod, char *set, ITG *mi, ITG *nmpc,
+                         ITG *nodempc, ITG *ipompc, double *coefmpc,
+                         char *labmpc, ITG *iaxial, double *cocon, ITG *ncocon,
+                         ITG *iponoel, ITG *inoel));
 
-void FORTRAN(mafillplhs,(ITG *kon,ITG *ipkon,char *lakon,ITG *ne,ITG *ipompc,
-			 ITG *nodempc,double *coefmpc,ITG *nmpc,ITG *nactdoh,
-			 ITG *icolp,ITG *jqp,ITG *irowp,ITG *neqp,ITG *nzlp,
-			 ITG *nzsp,double *adbp,double *aubp,ITG *ipvar,
-			 double *var));
+void FORTRAN(mafillplhs, (ITG * kon, ITG *ipkon, char *lakon, ITG *ne, ITG *ipompc,
+                          ITG *nodempc, double *coefmpc, ITG *nmpc, ITG *nactdoh,
+                          ITG *icolp, ITG *jqp, ITG *irowp, ITG *neqp, ITG *nzlp,
+                          ITG *nzsp, double *adbp, double *aubp, ITG *ipvar,
+                          double *var));
 
-void FORTRAN(mafillprhs,(ITG *nk,ITG *kon,ITG *ipkon,char *lakon,
-			 ITG *ipompc,ITG *nodempc,double *coefmpc,ITG *nmpc,
-			 double *b,ITG *nactdoh,ITG *mi,double *v,
-			 double *theta1,ITG *nea,ITG *neb,double *dtimef,
-			 ITG *ipvar,double *var,ITG *compressible));
+void FORTRAN(mafillprhs, (ITG * nk, ITG *kon, ITG *ipkon, char *lakon,
+                          ITG *ipompc, ITG *nodempc, double *coefmpc, ITG *nmpc,
+                          double *b, ITG *nactdoh, ITG *mi, double *v,
+                          double *theta1, ITG *nea, ITG *neb, double *dtimef,
+                          ITG *ipvar, double *var, ITG *compressible));
 
 void *mafillprhsmt(ITG *i);
 
-void FORTRAN(mafillsm,(double *co,ITG *nk,ITG *kon,ITG *ipkon,char *lakon,
-               ITG *ne,ITG *nodeboun,ITG *ndirboun,double *xboun,
-               ITG *nboun,ITG *ipompc,ITG *nodempc,double *coefmpc,
-               ITG *nmpc,ITG *nodeforc,ITG *ndirforc,
-               double *xforc,ITG *nforc,ITG *nelemload,char *sideload,
-               double *xload,ITG *nload,double *xbody,ITG *ipobody,
-               ITG *nbody,double *cgr,
-               double *ad,double *au,double *bb,ITG *nactdof,
-               ITG *icol,ITG *jq,ITG *irow,ITG *neq,ITG *nzl,
-               ITG *nmethod,ITG *ikmpc,ITG *ilmpc,ITG *ikboun,
-               ITG *ilboun,
-               double *elcon,ITG *nelcon,double *rhcon,ITG *nrhcon,
-               double *alcon,ITG *nalcon,double *alzero,ITG *ielmat,
-               ITG *ielorien,ITG *norien,double *orab,ITG *ntmat_,
-               double *t0,double *t1,ITG *ithermal,
-               double *prestr,ITG *iprestr,double *vold,
-               ITG *iperturb,double *sti,ITG *nzs,double *stx,
-               double *adb,double *aub,ITG *iexpl,
-               double *plicon,ITG *nplicon,double *plkcon,ITG *nplkcon,
-               double *xstiff,
-               ITG *npmat_,double *dtime,char *matname,ITG *mi,
-               ITG *ncmat_,ITG *mass,ITG *stiffness,ITG *buckling,ITG *rhs,
-               ITG *intscheme,double *physcon,double *shcon,ITG *nshcon,
-               double *cocon,ITG *ncocon,double *ttime,double *time,
-               ITG *istep,ITG *kinc,ITG *coriolis,ITG *ibody,
-               double *xloadold,double *reltime,double *veold,
-               double *springarea,ITG *nstate_,double *xstateini,
-               double *xstate,double *thicke,
-               ITG *integerglob,double *doubleglob,char *tieset,
-               ITG *istartset,ITG *iendset,ITG *ialset,ITG *ntie,
-               ITG *nasym,double *pslavsurf,double *pmastsurf,ITG *mortar,
-               double *clearini,ITG *ielprop,double *prop,ITG *ne0,
-               double *fnext,ITG *nea,ITG *neb,ITG *kscale,ITG *iponoel,
-               ITG *inoel,ITG *network,double *smscale,ITG *mscalmethod,
-	       char *set,ITG *nset,ITG *islavelinv,
-	       double *autloc,ITG *irowtloc,ITG *jqtloc,ITG *mortartrafoflag));
+void FORTRAN(mafillsm, (double *co, ITG *nk, ITG *kon, ITG *ipkon, char *lakon,
+                        ITG *ne, ITG *nodeboun, ITG *ndirboun, double *xboun,
+                        ITG *nboun, ITG *ipompc, ITG *nodempc, double *coefmpc,
+                        ITG *nmpc, ITG *nodeforc, ITG *ndirforc,
+                        double *xforc, ITG *nforc, ITG *nelemload, char *sideload,
+                        double *xload, ITG *nload, double *xbody, ITG *ipobody,
+                        ITG *nbody, double *cgr,
+                        double *ad, double *au, double *bb, ITG *nactdof,
+                        ITG *icol, ITG *jq, ITG *irow, ITG *neq, ITG *nzl,
+                        ITG *nmethod, ITG *ikmpc, ITG *ilmpc, ITG *ikboun,
+                        ITG *   ilboun,
+                        double *elcon, ITG *nelcon, double *rhcon, ITG *nrhcon,
+                        double *alcon, ITG *nalcon, double *alzero, ITG *ielmat,
+                        ITG *ielorien, ITG *norien, double *orab, ITG *ntmat_,
+                        double *t0, double *t1, ITG *ithermal,
+                        double *prestr, ITG *iprestr, double *vold,
+                        ITG *iperturb, double *sti, ITG *nzs, double *stx,
+                        double *adb, double *aub, ITG *iexpl,
+                        double *plicon, ITG *nplicon, double *plkcon, ITG *nplkcon,
+                        double *xstiff,
+                        ITG *npmat_, double *dtime, char *matname, ITG *mi,
+                        ITG *ncmat_, ITG *mass, ITG *stiffness, ITG *buckling, ITG *rhs,
+                        ITG *intscheme, double *physcon, double *shcon, ITG *nshcon,
+                        double *cocon, ITG *ncocon, double *ttime, double *time,
+                        ITG *istep, ITG *kinc, ITG *coriolis, ITG *ibody,
+                        double *xloadold, double *reltime, double *veold,
+                        double *springarea, ITG *nstate_, double *xstateini,
+                        double *xstate, double *thicke,
+                        ITG *integerglob, double *doubleglob, char *tieset,
+                        ITG *istartset, ITG *iendset, ITG *ialset, ITG *ntie,
+                        ITG *nasym, double *pslavsurf, double *pmastsurf, ITG *mortar,
+                        double *clearini, ITG *ielprop, double *prop, ITG *ne0,
+                        double *fnext, ITG *nea, ITG *neb, ITG *kscale, ITG *iponoel,
+                        ITG *inoel, ITG *network, double *smscale, ITG *mscalmethod,
+                        char *set, ITG *nset, ITG *islavelinv,
+                        double *autloc, ITG *irowtloc, ITG *jqtloc, ITG *mortartrafoflag));
 
-void FORTRAN(mafillsmcsse,(double *co,ITG *kon,ITG *ipkon,char *lakon,
-               ITG *ne,ITG *ipompc,ITG *nodempc,double *coefmpc,
-               ITG *nmpc,ITG *nelemload,char *sideload,double *xload,
-               ITG *nload,double *xbody,ITG *ipobody,ITG *nbody,
-               double *cgr,ITG *nactdof,ITG *neq,ITG *nmethod,ITG *ikmpc,
-               ITG *ilmpc,double *elcon,ITG *nelcon,double *rhcon,
-               ITG *nrhcon,double *alcon,ITG *nalcon,double *alzero,
-               ITG *ielmat,ITG *ielorien,ITG *norien,double *orab,
-               ITG *ntmat_,double *t0,double *t1,ITG *ithermal,
-               ITG *iprestr,double *vold,ITG *iperturb,double *sti,
-               double *stx,ITG *iexpl,double *plicon,ITG *nplicon,
-               double *plkcon,ITG *nplkcon,double *xstiff,ITG *npmat_,
-               double *dtime,char *matname,ITG *mi,ITG *ncmat_,ITG *mass,
-               ITG *stiffness,ITG *buckling,ITG *rhs,
-               ITG *intscheme,double *physcon,double *ttime,double *time,
-               ITG *istep,ITG *iinc,ITG *coriolis,ITG *ibody,
-               double *xloadold,double *reltime,double *veold,
-               double *springarea,ITG *nstate_,double *xstateini,
-               double *xstate,double *thicke,
-               ITG *integerglob,double *doubleglob,char *tieset,
-               ITG *istartset,ITG *iendset,ITG *ialset,ITG *ntie,
-               ITG *nasym,double *pslavsurf,double *pmastsurf,ITG *mortar,
-               double *clearini,ITG *ielprop,double *prop,ITG *ne0,
-               ITG *nea,ITG *neb,double *distmin,ITG *ndesi,
-               ITG *nodedesi,double *df,ITG *jqs,
-               ITG *irows,double *dfminds,ITG *icoordinate,
-               double *dxstiff,double *xdesi,ITG *istartelem,ITG *ialelem,
-               double *v,double *sigma,char *labmpc,ITG *ics,double *cs,
-               ITG *mcs,ITG *nk,ITG *nzss,char *set,ITG *nset));
+void FORTRAN(mafillsmcsse, (double *co, ITG *kon, ITG *ipkon, char *lakon,
+                            ITG *ne, ITG *ipompc, ITG *nodempc, double *coefmpc,
+                            ITG *nmpc, ITG *nelemload, char *sideload, double *xload,
+                            ITG *nload, double *xbody, ITG *ipobody, ITG *nbody,
+                            double *cgr, ITG *nactdof, ITG *neq, ITG *nmethod, ITG *ikmpc,
+                            ITG *ilmpc, double *elcon, ITG *nelcon, double *rhcon,
+                            ITG *nrhcon, double *alcon, ITG *nalcon, double *alzero,
+                            ITG *ielmat, ITG *ielorien, ITG *norien, double *orab,
+                            ITG *ntmat_, double *t0, double *t1, ITG *ithermal,
+                            ITG *iprestr, double *vold, ITG *iperturb, double *sti,
+                            double *stx, ITG *iexpl, double *plicon, ITG *nplicon,
+                            double *plkcon, ITG *nplkcon, double *xstiff, ITG *npmat_,
+                            double *dtime, char *matname, ITG *mi, ITG *ncmat_, ITG *mass,
+                            ITG *stiffness, ITG *buckling, ITG *rhs,
+                            ITG *intscheme, double *physcon, double *ttime, double *time,
+                            ITG *istep, ITG *iinc, ITG *coriolis, ITG *ibody,
+                            double *xloadold, double *reltime, double *veold,
+                            double *springarea, ITG *nstate_, double *xstateini,
+                            double *xstate, double *thicke,
+                            ITG *integerglob, double *doubleglob, char *tieset,
+                            ITG *istartset, ITG *iendset, ITG *ialset, ITG *ntie,
+                            ITG *nasym, double *pslavsurf, double *pmastsurf, ITG *mortar,
+                            double *clearini, ITG *ielprop, double *prop, ITG *ne0,
+                            ITG *nea, ITG *neb, double *distmin, ITG *ndesi,
+                            ITG *nodedesi, double *df, ITG *jqs,
+                            ITG *irows, double *dfminds, ITG *icoordinate,
+                            double *dxstiff, double *xdesi, ITG *istartelem, ITG *ialelem,
+                            double *v, double *sigma, char *labmpc, ITG *ics, double *cs,
+                            ITG *mcs, ITG *nk, ITG *nzss, char *set, ITG *nset));
 
 void *mafillsmdudsmt(ITG *i);
 
-void FORTRAN(mafillsmse,(double *co,ITG *kon,ITG *ipkon,char *lakon,
-               ITG *ne,ITG *ipompc,ITG *nodempc,double *coefmpc,
-               ITG *nmpc,ITG *nelemload,char *sideload,double *xload,
-               ITG *nload,double *xbody,ITG *ipobody,ITG *nbody,
-               double *cgr,ITG *nactdof,ITG *neq,ITG *nmethod,ITG *ikmpc,
-               ITG *ilmpc,double *elcon,ITG *nelcon,double *rhcon,
-               ITG *nrhcon,double *alcon,ITG *nalcon,double *alzero,
-               ITG *ielmat,ITG *ielorien,ITG *norien,double *orab,
-               ITG *ntmat_,double *t0,double *t1,ITG *ithermal,
-               ITG *iprestr,double *vold,ITG *iperturb,double *sti,
-               double *stx,ITG *iexpl,double *plicon,ITG *nplicon,
-               double *plkcon,ITG *nplkcon,double *xstiff,ITG *npmat_,
-               double *dtime,char *matname,ITG *mi,ITG *ncmat_,ITG *mass,
-               ITG *stiffness,ITG *buckling,ITG *rhs,
-               ITG *intscheme,double *physcon,double *ttime,double *time,
-               ITG *istep,ITG *iinc,ITG *coriolis,ITG *ibody,
-               double *xloadold,double *reltime,double *veold,
-               double *springarea,ITG *nstate_,double *xstateini,
-               double *xstate,double *thicke,
-               ITG *integerglob,double *doubleglob,char *tieset,
-               ITG *istartset,ITG *iendset,ITG *ialset,ITG *ntie,
-               ITG *nasym,double *pslavsurf,double *pmastsurf,ITG *mortar,
-               double *clearini,ITG *ielprop,double *prop,ITG *ne0,
-               ITG *nea,ITG *neb,double *distmin,ITG *ndesi,
-               ITG *nodedesi,double *df,ITG *jqs,
-               ITG *irows,double *dfl,ITG *icoordinate,
-               double *dxstiff,double *xdesi,ITG *istartelem,ITG *ialelem,
-               double *v,double *sigma,ITG *ieigenfrequency,char *set,
-	       ITG *nset,double *sigmak));
+void FORTRAN(mafillsmse, (double *co, ITG *kon, ITG *ipkon, char *lakon,
+                          ITG *ne, ITG *ipompc, ITG *nodempc, double *coefmpc,
+                          ITG *nmpc, ITG *nelemload, char *sideload, double *xload,
+                          ITG *nload, double *xbody, ITG *ipobody, ITG *nbody,
+                          double *cgr, ITG *nactdof, ITG *neq, ITG *nmethod, ITG *ikmpc,
+                          ITG *ilmpc, double *elcon, ITG *nelcon, double *rhcon,
+                          ITG *nrhcon, double *alcon, ITG *nalcon, double *alzero,
+                          ITG *ielmat, ITG *ielorien, ITG *norien, double *orab,
+                          ITG *ntmat_, double *t0, double *t1, ITG *ithermal,
+                          ITG *iprestr, double *vold, ITG *iperturb, double *sti,
+                          double *stx, ITG *iexpl, double *plicon, ITG *nplicon,
+                          double *plkcon, ITG *nplkcon, double *xstiff, ITG *npmat_,
+                          double *dtime, char *matname, ITG *mi, ITG *ncmat_, ITG *mass,
+                          ITG *stiffness, ITG *buckling, ITG *rhs,
+                          ITG *intscheme, double *physcon, double *ttime, double *time,
+                          ITG *istep, ITG *iinc, ITG *coriolis, ITG *ibody,
+                          double *xloadold, double *reltime, double *veold,
+                          double *springarea, ITG *nstate_, double *xstateini,
+                          double *xstate, double *thicke,
+                          ITG *integerglob, double *doubleglob, char *tieset,
+                          ITG *istartset, ITG *iendset, ITG *ialset, ITG *ntie,
+                          ITG *nasym, double *pslavsurf, double *pmastsurf, ITG *mortar,
+                          double *clearini, ITG *ielprop, double *prop, ITG *ne0,
+                          ITG *nea, ITG *neb, double *distmin, ITG *ndesi,
+                          ITG *nodedesi, double *df, ITG *jqs,
+                          ITG *irows, double *dfl, ITG *icoordinate,
+                          double *dxstiff, double *xdesi, ITG *istartelem, ITG *ialelem,
+                          double *v, double *sigma, ITG *ieigenfrequency, char *set,
+                          ITG *nset, double *sigmak));
 
 void *mafillsmmt(ITG *i);
 
@@ -2446,1532 +2455,1532 @@ void *mafillsmse2mt(ITG *i);
 
 void *mafillsmsemt(ITG *i);
 
-void mafillsmmain(double *co,ITG *nk,ITG *kon,ITG *ipkon,char *lakon,
-               ITG *ne,ITG *nodeboun,ITG *ndirboun,double *xboun,
-               ITG *nboun,ITG *ipompc,ITG *nodempc,double *coefmpc,
-               ITG *nmpc,ITG *nodeforc,ITG *ndirforc,
-               double *xforc,ITG *nforc,ITG *nelemload,char *sideload,
-               double *xload,ITG *nload,double *xbody,ITG *ipobody,
-               ITG *nbody,double *cgr,
-               double *ad,double *au,double *bb,ITG *nactdof,
-               ITG *icol,ITG *jq,ITG *irow,ITG *neq,ITG *nzl,
-               ITG *nmethod,ITG *ikmpc,ITG *ilmpc,ITG *ikboun,
-               ITG *ilboun,
-               double *elcon,ITG *nelcon,double *rhcon,ITG *nrhcon,
-               double *alcon,ITG *nalcon,double *alzero,ITG *ielmat,
-               ITG *ielorien,ITG *norien,double *orab,ITG *ntmat_,
-               double *t0,double *t1,ITG *ithermal,
-               double *prestr,ITG *iprestr,double *vold,
-               ITG *iperturb,double *sti,ITG *nzs,double *stx,
-               double *adb,double *aub,ITG *iexpl,
-               double *plicon,ITG *nplicon,double *plkcon,ITG *nplkcon,
-               double *xstiff,
-               ITG *npmat_,double *dtime,char *matname,ITG *mi,
-               ITG *ncmat_,ITG *mass,ITG *stiffness,ITG *buckling,ITG *rhs,
-               ITG *intscheme,double *physcon,double *shcon,ITG *nshcon,
-               double *cocon,ITG *ncocon,double *ttime,double *time,
-               ITG *istep,ITG *kinc,ITG *coriolis,ITG *ibody,
-               double *xloadold,double *reltime,double *veold,
-               double *springarea,ITG *nstate_,double *xstateini,
-               double *xstate,double *thicke,
-               ITG *integerglob,double *doubleglob,char *tieset,
-               ITG *istartset,ITG *iendset,ITG *ialset,ITG *ntie,
-               ITG *nasym,double *pslavsurf,double *pmastsurf,ITG *mortar,
-               double *clearini,ITG *ielprop,double *prop,ITG *ne0,
-               double *fnext,ITG *kscale,ITG *iponoel,ITG *inoel,
-               ITG *network,ITG *ntrans,ITG *inotr,double *trab,
-	       double *smscale,ITG *mscalmethod,char *set,ITG *nset,
-	       ITG *islavelinv,
-	       double *autloc,ITG *irowtloc,ITG *jqtloc,ITG *mortartrafoflag);
+void mafillsmmain(double *co, ITG *nk, ITG *kon, ITG *ipkon, char *lakon,
+                  ITG *ne, ITG *nodeboun, ITG *ndirboun, double *xboun,
+                  ITG *nboun, ITG *ipompc, ITG *nodempc, double *coefmpc,
+                  ITG *nmpc, ITG *nodeforc, ITG *ndirforc,
+                  double *xforc, ITG *nforc, ITG *nelemload, char *sideload,
+                  double *xload, ITG *nload, double *xbody, ITG *ipobody,
+                  ITG *nbody, double *cgr,
+                  double *ad, double *au, double *bb, ITG *nactdof,
+                  ITG *icol, ITG *jq, ITG *irow, ITG *neq, ITG *nzl,
+                  ITG *nmethod, ITG *ikmpc, ITG *ilmpc, ITG *ikboun,
+                  ITG *   ilboun,
+                  double *elcon, ITG *nelcon, double *rhcon, ITG *nrhcon,
+                  double *alcon, ITG *nalcon, double *alzero, ITG *ielmat,
+                  ITG *ielorien, ITG *norien, double *orab, ITG *ntmat_,
+                  double *t0, double *t1, ITG *ithermal,
+                  double *prestr, ITG *iprestr, double *vold,
+                  ITG *iperturb, double *sti, ITG *nzs, double *stx,
+                  double *adb, double *aub, ITG *iexpl,
+                  double *plicon, ITG *nplicon, double *plkcon, ITG *nplkcon,
+                  double *xstiff,
+                  ITG *npmat_, double *dtime, char *matname, ITG *mi,
+                  ITG *ncmat_, ITG *mass, ITG *stiffness, ITG *buckling, ITG *rhs,
+                  ITG *intscheme, double *physcon, double *shcon, ITG *nshcon,
+                  double *cocon, ITG *ncocon, double *ttime, double *time,
+                  ITG *istep, ITG *kinc, ITG *coriolis, ITG *ibody,
+                  double *xloadold, double *reltime, double *veold,
+                  double *springarea, ITG *nstate_, double *xstateini,
+                  double *xstate, double *thicke,
+                  ITG *integerglob, double *doubleglob, char *tieset,
+                  ITG *istartset, ITG *iendset, ITG *ialset, ITG *ntie,
+                  ITG *nasym, double *pslavsurf, double *pmastsurf, ITG *mortar,
+                  double *clearini, ITG *ielprop, double *prop, ITG *ne0,
+                  double *fnext, ITG *kscale, ITG *iponoel, ITG *inoel,
+                  ITG *network, ITG *ntrans, ITG *inotr, double *trab,
+                  double *smscale, ITG *mscalmethod, char *set, ITG *nset,
+                  ITG *   islavelinv,
+                  double *autloc, ITG *irowtloc, ITG *jqtloc, ITG *mortartrafoflag);
 
-void mafillsmmain_duds(double *co,ITG *nk,ITG *kon,ITG *ipkon,char *lakon,
-	       ITG *ne,ITG *nodeboun,ITG *ndirboun,double *xboun,
-	       ITG *nboun,ITG *ipompc,ITG *nodempc,double *coefmpc,
-	       ITG *nmpc,ITG *nodeforc,ITG *ndirforc,
-	       double *xforc,ITG *nforc,ITG *nelemload,char *sideload,
-	       double *xload,ITG *nload,double *xbody,ITG *ipobody,
-	       ITG *nbody,double *cgr,ITG *nactdof,
-	       ITG *neq,ITG *nmethod,ITG *ikmpc,ITG *ilmpc,
-               ITG *ikboun,ITG *ilboun,
-	       double *elcon,ITG *nelcon,double *rhcon,ITG *nrhcon,
-	       double *alcon,ITG *nalcon,double *alzero,ITG *ielmat,
-	       ITG *ielorien,ITG *norien,double *orab,ITG *ntmat_,
-	       double *t0,double *t1,ITG *ithermal,
-	       double *prestr,ITG *iprestr,double *vold,
-	       ITG *iperturb,double *sti,double *stx,
-	       ITG *iexpl,
-               double *plicon,ITG *nplicon,double *plkcon,ITG *nplkcon,
-               double *xstiff,
-	       ITG *npmat_,double *dtime,char *matname,ITG *mi,
-               ITG *ncmat_,ITG *mass,ITG *stiffness,ITG *buckling,ITG *rhsi,
-               ITG *intscheme,double *physcon,double *shcon,ITG *nshcon,
-               double *cocon,ITG *ncocon,double *ttime,double *time,
-               ITG *istep,ITG *iinc,ITG *coriolis,ITG *ibody,
-	       double *xloadold,double *reltime,double *veold,
-               double *springarea,ITG *nstate_,double *xstateini,
-	       double *xstate,double *thicke,
-               ITG *integerglob,double *doubleglob,char *tieset,
-	       ITG *istartset,ITG *iendset,ITG *ialset,ITG *ntie,
-	       ITG *nasym,double *pslavsurf,double *pmastsurf,ITG *mortar,
-	       double *clearini,ITG *ielprop,double *prop,ITG *ne0,
-               double *fnext,double *distmin,ITG *ndesi,ITG *nodedesi,
-	       double *df2,ITG *nzss2,ITG *jqs2,ITG *irows2,
-	       ITG *icoordinate,double *dxstiff,double *xdesi,
-	       ITG *istartelem,ITG *ialelem,double *v,double *sigma,
-	       ITG *cyclicsymmetry,char *labmpc,ITG *ics,double *cs,
-	       ITG *mcs,ITG *ieigenfrequency,double *duds,char *set,ITG *nset);
+void mafillsmmain_duds(double *co, ITG *nk, ITG *kon, ITG *ipkon, char *lakon,
+                       ITG *ne, ITG *nodeboun, ITG *ndirboun, double *xboun,
+                       ITG *nboun, ITG *ipompc, ITG *nodempc, double *coefmpc,
+                       ITG *nmpc, ITG *nodeforc, ITG *ndirforc,
+                       double *xforc, ITG *nforc, ITG *nelemload, char *sideload,
+                       double *xload, ITG *nload, double *xbody, ITG *ipobody,
+                       ITG *nbody, double *cgr, ITG *nactdof,
+                       ITG *neq, ITG *nmethod, ITG *ikmpc, ITG *ilmpc,
+                       ITG *ikboun, ITG *ilboun,
+                       double *elcon, ITG *nelcon, double *rhcon, ITG *nrhcon,
+                       double *alcon, ITG *nalcon, double *alzero, ITG *ielmat,
+                       ITG *ielorien, ITG *norien, double *orab, ITG *ntmat_,
+                       double *t0, double *t1, ITG *ithermal,
+                       double *prestr, ITG *iprestr, double *vold,
+                       ITG *iperturb, double *sti, double *stx,
+                       ITG *   iexpl,
+                       double *plicon, ITG *nplicon, double *plkcon, ITG *nplkcon,
+                       double *xstiff,
+                       ITG *npmat_, double *dtime, char *matname, ITG *mi,
+                       ITG *ncmat_, ITG *mass, ITG *stiffness, ITG *buckling, ITG *rhsi,
+                       ITG *intscheme, double *physcon, double *shcon, ITG *nshcon,
+                       double *cocon, ITG *ncocon, double *ttime, double *time,
+                       ITG *istep, ITG *iinc, ITG *coriolis, ITG *ibody,
+                       double *xloadold, double *reltime, double *veold,
+                       double *springarea, ITG *nstate_, double *xstateini,
+                       double *xstate, double *thicke,
+                       ITG *integerglob, double *doubleglob, char *tieset,
+                       ITG *istartset, ITG *iendset, ITG *ialset, ITG *ntie,
+                       ITG *nasym, double *pslavsurf, double *pmastsurf, ITG *mortar,
+                       double *clearini, ITG *ielprop, double *prop, ITG *ne0,
+                       double *fnext, double *distmin, ITG *ndesi, ITG *nodedesi,
+                       double *df2, ITG *nzss2, ITG *jqs2, ITG *irows2,
+                       ITG *icoordinate, double *dxstiff, double *xdesi,
+                       ITG *istartelem, ITG *ialelem, double *v, double *sigma,
+                       ITG *cyclicsymmetry, char *labmpc, ITG *ics, double *cs,
+                       ITG *mcs, ITG *ieigenfrequency, double *duds, char *set, ITG *nset);
 
-void mafillsmmain_se(double *co,ITG *nk,ITG *kon,ITG *ipkon,char *lakon,
-               ITG *ne,ITG *nodeboun,ITG *ndirboun,double *xboun,
-               ITG *nboun,ITG *ipompc,ITG *nodempc,double *coefmpc,
-               ITG *nmpc,ITG *nodeforc,ITG *ndirforc,
-               double *xforc,ITG *nforc,ITG *nelemload,char *sideload,
-               double *xload,ITG *nload,double *xbody,ITG *ipobody,
-               ITG *nbody,double *cgr,ITG *nactdof,ITG *neq,
-               ITG *nmethod,ITG *ikmpc,ITG *ilmpc,ITG *ikboun,
-               ITG *ilboun,
-               double *elcon,ITG *nelcon,double *rhcon,ITG *nrhcon,
-               double *alcon,ITG *nalcon,double *alzero,ITG *ielmat,
-               ITG *ielorien,ITG *norien,double *orab,ITG *ntmat_,
-               double *t0,double *t1,ITG *ithermal,
-               double *prestr,ITG *iprestr,double *vold,
-               ITG *iperturb,double *sti,double *stx,
-               ITG *iexpl,
-               double *plicon,ITG *nplicon,double *plkcon,ITG *nplkcon,
-               double *xstiff,
-               ITG *npmat_,double *dtime,char *matname,ITG *mi,
-               ITG *ncmat_,ITG *mass,ITG *stiffness,ITG *buckling,ITG *rhs,
-               ITG *intscheme,double *physcon,double *shcon,ITG *nshcon,
-               double *cocon,ITG *ncocon,double *ttime,double *time,
-               ITG *istep,ITG *kinc,ITG *coriolis,ITG *ibody,
-               double *xloadold,double *reltime,double *veold,
-               double *springarea,ITG *nstate_,double *xstateini,
-               double *xstate,double *thicke,
-               ITG *integerglob,double *doubleglob,char *tieset,
-               ITG *istartset,ITG *iendset,ITG *ialset,ITG *ntie,
-               ITG *nasym,double *pslavsurf,double *pmastsurf,ITG *mortar,
-               double *clearini,ITG *ielprop,double *prop,ITG *ne0,
-               double *fnext,double *distmin,ITG *ndesi,ITG *nodedesi,
-               double *df,ITG *nzss,ITG *jqs,ITG *irows,
-               ITG *icoordinate,double *dxstiff,double *xdesi,
-               ITG *istartelem,ITG *ialelem,double *v,double *sigma,
-               ITG *cyclicsymmetry,char *labmpc,ITG *ics,double *cs,
-	       ITG *mcs,ITG *ieigenfrequency,char *set,ITG *nset,
-	       double *sigmak);
+void mafillsmmain_se(double *co, ITG *nk, ITG *kon, ITG *ipkon, char *lakon,
+                     ITG *ne, ITG *nodeboun, ITG *ndirboun, double *xboun,
+                     ITG *nboun, ITG *ipompc, ITG *nodempc, double *coefmpc,
+                     ITG *nmpc, ITG *nodeforc, ITG *ndirforc,
+                     double *xforc, ITG *nforc, ITG *nelemload, char *sideload,
+                     double *xload, ITG *nload, double *xbody, ITG *ipobody,
+                     ITG *nbody, double *cgr, ITG *nactdof, ITG *neq,
+                     ITG *nmethod, ITG *ikmpc, ITG *ilmpc, ITG *ikboun,
+                     ITG *   ilboun,
+                     double *elcon, ITG *nelcon, double *rhcon, ITG *nrhcon,
+                     double *alcon, ITG *nalcon, double *alzero, ITG *ielmat,
+                     ITG *ielorien, ITG *norien, double *orab, ITG *ntmat_,
+                     double *t0, double *t1, ITG *ithermal,
+                     double *prestr, ITG *iprestr, double *vold,
+                     ITG *iperturb, double *sti, double *stx,
+                     ITG *   iexpl,
+                     double *plicon, ITG *nplicon, double *plkcon, ITG *nplkcon,
+                     double *xstiff,
+                     ITG *npmat_, double *dtime, char *matname, ITG *mi,
+                     ITG *ncmat_, ITG *mass, ITG *stiffness, ITG *buckling, ITG *rhs,
+                     ITG *intscheme, double *physcon, double *shcon, ITG *nshcon,
+                     double *cocon, ITG *ncocon, double *ttime, double *time,
+                     ITG *istep, ITG *kinc, ITG *coriolis, ITG *ibody,
+                     double *xloadold, double *reltime, double *veold,
+                     double *springarea, ITG *nstate_, double *xstateini,
+                     double *xstate, double *thicke,
+                     ITG *integerglob, double *doubleglob, char *tieset,
+                     ITG *istartset, ITG *iendset, ITG *ialset, ITG *ntie,
+                     ITG *nasym, double *pslavsurf, double *pmastsurf, ITG *mortar,
+                     double *clearini, ITG *ielprop, double *prop, ITG *ne0,
+                     double *fnext, double *distmin, ITG *ndesi, ITG *nodedesi,
+                     double *df, ITG *nzss, ITG *jqs, ITG *irows,
+                     ITG *icoordinate, double *dxstiff, double *xdesi,
+                     ITG *istartelem, ITG *ialelem, double *v, double *sigma,
+                     ITG *cyclicsymmetry, char *labmpc, ITG *ics, double *cs,
+                     ITG *mcs, ITG *ieigenfrequency, char *set, ITG *nset,
+                     double *sigmak);
 
-void FORTRAN(mafillsmas,(double *co,ITG *nk,ITG *kon,ITG *ipkon,char *lakon,
-               ITG *ne,ITG *nodeboun,ITG *ndirboun,double *xboun,
-               ITG *nboun,ITG *ipompc,ITG *nodempc,double *coefmpc,
-               ITG *nmpc,ITG *nodeforc,ITG *ndirforc,
-               double *xforc,ITG *nforc,ITG *nelemload,char *sideload,
-               double *xload,ITG *nload,double *xbody,ITG *ipobody,
-               ITG *nbody,double *cgr,
-               double *ad,double *au,double *bb,ITG *nactdof,
-               ITG *icol,ITG *jq,ITG *irow,ITG *neq,ITG *nzl,
-               ITG *nmethod,ITG *ikmpc,ITG *ilmpc,ITG *ikboun,
-               ITG *ilboun,
-               double *elcon,ITG *nelcon,double *rhcon,ITG *nrhcon,
-               double *alcon,ITG *nalcon,double *alzero,ITG *ielmat,
-               ITG *ielorien,ITG *norien,double *orab,ITG *ntmat_,
-               double *t0,double *t1,ITG *ithermal,
-               double *prestr,ITG *iprestr,double *vold,
-               ITG *iperturb,double *sti,ITG *nzs,double *stx,
-               double *adb,double *aub,ITG *iexpl,
-               double *plicon,ITG *nplicon,double *plkcon,ITG *nplkcon,
-               double *xstiff,
-               ITG *npmat_,double *dtime,char *matname,ITG *mi,
-               ITG *ncmat_,ITG *mass,ITG *stiffness,ITG *buckling,ITG *rhs,
-               ITG *intscheme,double *physcon,double *shcon,ITG *nshcon,
-               double *cocon,ITG *ncocon,double *ttime,double *time,
-               ITG *istep,ITG *kinc,ITG *coriolis,ITG *ibody,
-               double *xloadold,double *reltime,double *veold,
-               double *springarea,ITG *nstate_,double *xstateini,
-               double *xstate,double *thicke,
-               ITG *integerglob,double *doubleglob,char *tieset,
-               ITG *istartset,ITG *iendset,ITG *ialset,ITG *ntie,
-               ITG *nasym,double *pslavsurf,double *pmastsurf,ITG *mortar,
-               double *clearini,ITG *ielprop,double *prop,ITG *ne0,
-	       ITG *kscale,ITG *iponoel,ITG *inoel,ITG *network,
-	       ITG *neam,ITG *nebm,ITG *neat,ITG *nebt,char *set,ITG *nset));
-  
-void mafillsmasmain(double *co,ITG *nk,ITG *kon,ITG *ipkon,char *lakon,ITG *ne,
-		ITG *nodeboun,ITG *ndirboun,double *xboun,ITG *nboun,
-		ITG *ipompc,ITG *nodempc,double *coefmpc,ITG *nmpc,
-		ITG *nodeforc,ITG *ndirforc,double *xforc,ITG *nforc,
-		ITG *nelemload,char *sideload,double *xload,ITG *nload,
-		double *xbody,ITG *ipobody,ITG *nbody,double *cgr,double *ad,
-		double *au,double *bb,ITG *nactdof,ITG *icol,ITG *jq,
-		ITG *irow,ITG *neq,ITG *nzl,ITG *nmethod,ITG *ikmpc,
-		ITG *ilmpc,ITG *ikboun,ITG *ilboun,double *elcon,ITG *nelcon,
-		double *rhcon,ITG *nrhcon,double *alcon,ITG *nalcon,
-		double *alzero,ITG *ielmat,ITG *ielorien,ITG *norien,
-		double *orab,ITG *ntmat_,double *t0,double *t1,ITG *ithermal,
-		double *prestr,ITG *iprestr,double *vold,ITG *iperturb,
-		double *sti,ITG *nzs,double *stx,double *adb,double *aub,
-		ITG *iexpl,double *plicon,ITG *nplicon,double *plkcon,
-		ITG *nplkcon,double *xstiff,ITG *npmat_,double *dtime,
-		char *matname,ITG *mi,ITG *ncmat_,ITG *mass,ITG *stiffness,
-		ITG *buckling,ITG *rhsi,ITG *intscheme,double *physcon,
-		double *shcon,ITG *nshcon,double *cocon,ITG *ncocon,
-		double *ttime,double *time,ITG *istep,ITG *iinc,
-		ITG *coriolis,ITG *ibody,double *xloadold,double *reltime,
-		double *veold,double *springarea,ITG *nstate_,
-		double *xstateini,double *xstate,double *thicke,
-		ITG *integerglob,double *doubleglob,char *tieset,
-		ITG *istartset,ITG *iendset,ITG *ialset,ITG *ntie,
-		ITG *nasym,double *pslavsurf,double *pmastsurf,ITG *mortar,
-		double *clearini,ITG *ielprop,double *prop,ITG *ne0,
-		ITG *kscale,ITG *iponoel,ITG *inoel,ITG *network,char *set,
-		ITG *nset);
+void FORTRAN(mafillsmas, (double *co, ITG *nk, ITG *kon, ITG *ipkon, char *lakon,
+                          ITG *ne, ITG *nodeboun, ITG *ndirboun, double *xboun,
+                          ITG *nboun, ITG *ipompc, ITG *nodempc, double *coefmpc,
+                          ITG *nmpc, ITG *nodeforc, ITG *ndirforc,
+                          double *xforc, ITG *nforc, ITG *nelemload, char *sideload,
+                          double *xload, ITG *nload, double *xbody, ITG *ipobody,
+                          ITG *nbody, double *cgr,
+                          double *ad, double *au, double *bb, ITG *nactdof,
+                          ITG *icol, ITG *jq, ITG *irow, ITG *neq, ITG *nzl,
+                          ITG *nmethod, ITG *ikmpc, ITG *ilmpc, ITG *ikboun,
+                          ITG *   ilboun,
+                          double *elcon, ITG *nelcon, double *rhcon, ITG *nrhcon,
+                          double *alcon, ITG *nalcon, double *alzero, ITG *ielmat,
+                          ITG *ielorien, ITG *norien, double *orab, ITG *ntmat_,
+                          double *t0, double *t1, ITG *ithermal,
+                          double *prestr, ITG *iprestr, double *vold,
+                          ITG *iperturb, double *sti, ITG *nzs, double *stx,
+                          double *adb, double *aub, ITG *iexpl,
+                          double *plicon, ITG *nplicon, double *plkcon, ITG *nplkcon,
+                          double *xstiff,
+                          ITG *npmat_, double *dtime, char *matname, ITG *mi,
+                          ITG *ncmat_, ITG *mass, ITG *stiffness, ITG *buckling, ITG *rhs,
+                          ITG *intscheme, double *physcon, double *shcon, ITG *nshcon,
+                          double *cocon, ITG *ncocon, double *ttime, double *time,
+                          ITG *istep, ITG *kinc, ITG *coriolis, ITG *ibody,
+                          double *xloadold, double *reltime, double *veold,
+                          double *springarea, ITG *nstate_, double *xstateini,
+                          double *xstate, double *thicke,
+                          ITG *integerglob, double *doubleglob, char *tieset,
+                          ITG *istartset, ITG *iendset, ITG *ialset, ITG *ntie,
+                          ITG *nasym, double *pslavsurf, double *pmastsurf, ITG *mortar,
+                          double *clearini, ITG *ielprop, double *prop, ITG *ne0,
+                          ITG *kscale, ITG *iponoel, ITG *inoel, ITG *network,
+                          ITG *neam, ITG *nebm, ITG *neat, ITG *nebt, char *set, ITG *nset));
+
+void mafillsmasmain(double *co, ITG *nk, ITG *kon, ITG *ipkon, char *lakon, ITG *ne,
+                    ITG *nodeboun, ITG *ndirboun, double *xboun, ITG *nboun,
+                    ITG *ipompc, ITG *nodempc, double *coefmpc, ITG *nmpc,
+                    ITG *nodeforc, ITG *ndirforc, double *xforc, ITG *nforc,
+                    ITG *nelemload, char *sideload, double *xload, ITG *nload,
+                    double *xbody, ITG *ipobody, ITG *nbody, double *cgr, double *ad,
+                    double *au, double *bb, ITG *nactdof, ITG *icol, ITG *jq,
+                    ITG *irow, ITG *neq, ITG *nzl, ITG *nmethod, ITG *ikmpc,
+                    ITG *ilmpc, ITG *ikboun, ITG *ilboun, double *elcon, ITG *nelcon,
+                    double *rhcon, ITG *nrhcon, double *alcon, ITG *nalcon,
+                    double *alzero, ITG *ielmat, ITG *ielorien, ITG *norien,
+                    double *orab, ITG *ntmat_, double *t0, double *t1, ITG *ithermal,
+                    double *prestr, ITG *iprestr, double *vold, ITG *iperturb,
+                    double *sti, ITG *nzs, double *stx, double *adb, double *aub,
+                    ITG *iexpl, double *plicon, ITG *nplicon, double *plkcon,
+                    ITG *nplkcon, double *xstiff, ITG *npmat_, double *dtime,
+                    char *matname, ITG *mi, ITG *ncmat_, ITG *mass, ITG *stiffness,
+                    ITG *buckling, ITG *rhsi, ITG *intscheme, double *physcon,
+                    double *shcon, ITG *nshcon, double *cocon, ITG *ncocon,
+                    double *ttime, double *time, ITG *istep, ITG *iinc,
+                    ITG *coriolis, ITG *ibody, double *xloadold, double *reltime,
+                    double *veold, double *springarea, ITG *nstate_,
+                    double *xstateini, double *xstate, double *thicke,
+                    ITG *integerglob, double *doubleglob, char *tieset,
+                    ITG *istartset, ITG *iendset, ITG *ialset, ITG *ntie,
+                    ITG *nasym, double *pslavsurf, double *pmastsurf, ITG *mortar,
+                    double *clearini, ITG *ielprop, double *prop, ITG *ne0,
+                    ITG *kscale, ITG *iponoel, ITG *inoel, ITG *network, char *set,
+                    ITG *nset);
 
 void *mafillsmasmt(ITG *i);
 
-void FORTRAN(mafillsmcs,(double *co,ITG *nk,ITG *kon,ITG *ipkon,
-               char *lakon,
-               ITG *ne,ITG *nodeboun,ITG *ndirboun,double *xboun,
-               ITG *nboun,ITG *ipompc,ITG *nodempc,double *coefmpc,
-               ITG *nmpc,ITG *nodeforc,ITG *ndirforc,
-               double *xforc,ITG *nforc,ITG *nelemload,char *sideload,
-               double *xload,ITG *nload,double *xbody,ITG *ipobody,
-               ITG *nbody,double *cgr,
-               double *ad,double *au,double *bb,ITG *nactdof,
-               ITG *icol,ITG *jq,ITG *irow,ITG *neq,ITG *nzl,
-               ITG *nmethod,ITG *ikmpc,ITG *ilmpc,ITG *ikboun,
-               ITG *ilboun,
-               double *elcon,ITG *nelcon,double *rhcon,ITG *nrhcon,
-               double *alcon,ITG *nalcon,double *alzero,ITG *ielmat,
-               ITG *ielorien,ITG *norien,double *orab,ITG *ntmat_,
-               double *t0,double *t1,ITG *ithermal,
-               double *prestr,ITG *iprestr,double *vold,
-               ITG *iperturb,double *sti,ITG *nzs,double *stx,
-               double *adb,double *aub,ITG *iexpl,double *plicon,
-               ITG *nplicon,double *plkcon,ITG *nplkcon,double *xstiff,
-               ITG *npmat_,double *dtime,char *matname,ITG *mi,
-               ITG *ics,double *cs,ITG *nm,ITG *ncmat_,char *labmpc,
-               ITG *mass,ITG *stiffness,ITG *buckling,ITG *rhs,
-               ITG *intscheme,ITG *mcs,ITG *coriolis,ITG *ibody,
-               double *xloadold,double *reltime,ITG *ielcs,double *veold,
-               double *springarea,double *thicke,
-               ITG *integerglob,double *doubleglob,char *tieset,
-               ITG *istartset,ITG *iendset,ITG *ialset,ITG *ntie,
-               ITG *nasym,double *pslavsurf,double *pmastsurf,ITG *mortar,
-               double *clearini,ITG *ielprop,double *prop,ITG *ne0,
-               ITG *kscale,double *xstateini,double *xstate,ITG *nstate_,
-	       char *set,ITG *nset));
+void FORTRAN(mafillsmcs, (double *co, ITG *nk, ITG *kon, ITG *ipkon,
+                          char *lakon,
+                          ITG *ne, ITG *nodeboun, ITG *ndirboun, double *xboun,
+                          ITG *nboun, ITG *ipompc, ITG *nodempc, double *coefmpc,
+                          ITG *nmpc, ITG *nodeforc, ITG *ndirforc,
+                          double *xforc, ITG *nforc, ITG *nelemload, char *sideload,
+                          double *xload, ITG *nload, double *xbody, ITG *ipobody,
+                          ITG *nbody, double *cgr,
+                          double *ad, double *au, double *bb, ITG *nactdof,
+                          ITG *icol, ITG *jq, ITG *irow, ITG *neq, ITG *nzl,
+                          ITG *nmethod, ITG *ikmpc, ITG *ilmpc, ITG *ikboun,
+                          ITG *   ilboun,
+                          double *elcon, ITG *nelcon, double *rhcon, ITG *nrhcon,
+                          double *alcon, ITG *nalcon, double *alzero, ITG *ielmat,
+                          ITG *ielorien, ITG *norien, double *orab, ITG *ntmat_,
+                          double *t0, double *t1, ITG *ithermal,
+                          double *prestr, ITG *iprestr, double *vold,
+                          ITG *iperturb, double *sti, ITG *nzs, double *stx,
+                          double *adb, double *aub, ITG *iexpl, double *plicon,
+                          ITG *nplicon, double *plkcon, ITG *nplkcon, double *xstiff,
+                          ITG *npmat_, double *dtime, char *matname, ITG *mi,
+                          ITG *ics, double *cs, ITG *nm, ITG *ncmat_, char *labmpc,
+                          ITG *mass, ITG *stiffness, ITG *buckling, ITG *rhs,
+                          ITG *intscheme, ITG *mcs, ITG *coriolis, ITG *ibody,
+                          double *xloadold, double *reltime, ITG *ielcs, double *veold,
+                          double *springarea, double *thicke,
+                          ITG *integerglob, double *doubleglob, char *tieset,
+                          ITG *istartset, ITG *iendset, ITG *ialset, ITG *ntie,
+                          ITG *nasym, double *pslavsurf, double *pmastsurf, ITG *mortar,
+                          double *clearini, ITG *ielprop, double *prop, ITG *ne0,
+                          ITG *kscale, double *xstateini, double *xstate, ITG *nstate_,
+                          char *set, ITG *nset));
 
-void FORTRAN(mafillsmcsas,(double *co,ITG *nk,ITG *kon,ITG *ipkon,
-               char *lakon,
-               ITG *ne,ITG *nodeboun,ITG *ndirboun,double *xboun,
-               ITG *nboun,ITG *ipompc,ITG *nodempc,double *coefmpc,
-               ITG *nmpc,ITG *nodeforc,ITG *ndirforc,
-               double *xforc,ITG *nforc,ITG *nelemload,char *sideload,
-               double *xload,ITG *nload,double *xbody,ITG *ipobody,
-               ITG *nbody,double *cgr,
-               double *ad,double *au,double *bb,ITG *nactdof,
-               ITG *icol,ITG *jq,ITG *irow,ITG *neq,ITG *nzl,
-               ITG *nmethod,ITG *ikmpc,ITG *ilmpc,ITG *ikboun,
-               ITG *ilboun,
-               double *elcon,ITG *nelcon,double *rhcon,ITG *nrhcon,
-               double *alcon,ITG *nalcon,double *alzero,ITG *ielmat,
-               ITG *ielorien,ITG *norien,double *orab,ITG *ntmat_,
-               double *t0,double *t1,ITG *ithermal,
-               double *prestr,ITG *iprestr,double *vold,
-               ITG *iperturb,double *sti,ITG *nzs,double *stx,
-               double *adb,double *aub,ITG *iexpl,double *plicon,
-               ITG *nplicon,double *plkcon,ITG *nplkcon,double *xstiff,
-               ITG *npmat_,double *dtime,char *matname,ITG *mi,
-               ITG *ics,double *cs,ITG *nm,ITG *ncmat_,char *labmpc,
-               ITG *mass,ITG *stiffness,ITG *buckling,ITG *rhs,
-               ITG *intscheme,ITG *mcs,ITG *coriolis,ITG *ibody,
-               double *xloadold,double *reltime,ITG *ielcs,double *veold,
-               double *springarea,double *thicke,
-               ITG *integerglob,double *doubleglob,char *tieset,
-               ITG *istartset,ITG *iendset,ITG *ialset,ITG *ntie,
-               ITG *nasym,ITG *nstate_,double *xstateini,double *xstate,
-               double *pslavsurf,double *pmastsurf,ITG *mortar,
-               double *clearini,ITG *ielprop,double *prop,ITG *ne0,
-               ITG *kscale,char *set,ITG *nset));
+void FORTRAN(mafillsmcsas, (double *co, ITG *nk, ITG *kon, ITG *ipkon,
+                            char *lakon,
+                            ITG *ne, ITG *nodeboun, ITG *ndirboun, double *xboun,
+                            ITG *nboun, ITG *ipompc, ITG *nodempc, double *coefmpc,
+                            ITG *nmpc, ITG *nodeforc, ITG *ndirforc,
+                            double *xforc, ITG *nforc, ITG *nelemload, char *sideload,
+                            double *xload, ITG *nload, double *xbody, ITG *ipobody,
+                            ITG *nbody, double *cgr,
+                            double *ad, double *au, double *bb, ITG *nactdof,
+                            ITG *icol, ITG *jq, ITG *irow, ITG *neq, ITG *nzl,
+                            ITG *nmethod, ITG *ikmpc, ITG *ilmpc, ITG *ikboun,
+                            ITG *   ilboun,
+                            double *elcon, ITG *nelcon, double *rhcon, ITG *nrhcon,
+                            double *alcon, ITG *nalcon, double *alzero, ITG *ielmat,
+                            ITG *ielorien, ITG *norien, double *orab, ITG *ntmat_,
+                            double *t0, double *t1, ITG *ithermal,
+                            double *prestr, ITG *iprestr, double *vold,
+                            ITG *iperturb, double *sti, ITG *nzs, double *stx,
+                            double *adb, double *aub, ITG *iexpl, double *plicon,
+                            ITG *nplicon, double *plkcon, ITG *nplkcon, double *xstiff,
+                            ITG *npmat_, double *dtime, char *matname, ITG *mi,
+                            ITG *ics, double *cs, ITG *nm, ITG *ncmat_, char *labmpc,
+                            ITG *mass, ITG *stiffness, ITG *buckling, ITG *rhs,
+                            ITG *intscheme, ITG *mcs, ITG *coriolis, ITG *ibody,
+                            double *xloadold, double *reltime, ITG *ielcs, double *veold,
+                            double *springarea, double *thicke,
+                            ITG *integerglob, double *doubleglob, char *tieset,
+                            ITG *istartset, ITG *iendset, ITG *ialset, ITG *ntie,
+                            ITG *nasym, ITG *nstate_, double *xstateini, double *xstate,
+                            double *pslavsurf, double *pmastsurf, ITG *mortar,
+                            double *clearini, ITG *ielprop, double *prop, ITG *ne0,
+                            ITG *kscale, char *set, ITG *nset));
 
-void FORTRAN(mafillsmforc,(ITG *nforc,ITG *ndirforc,ITG *nodeforc,
-             double *xforc,ITG *nactdof,double *fext,ITG *ipompc,
-             ITG *nodempc,double *coefmpc,ITG *mi,ITG *rhsi,double *fnext,
-             ITG *nmethod,ITG *ntrans,ITG *inotr,double *trab,double *co));
+void FORTRAN(mafillsmforc, (ITG * nforc, ITG *ndirforc, ITG *nodeforc,
+                            double *xforc, ITG *nactdof, double *fext, ITG *ipompc,
+                            ITG *nodempc, double *coefmpc, ITG *mi, ITG *rhsi, double *fnext,
+                            ITG *nmethod, ITG *ntrans, ITG *inotr, double *trab, double *co));
 
-void FORTRAN(mafillsm_company,(double *co,ITG *nk,ITG *kon,ITG *ipkon,
-               char *lakon,
-               ITG *ne,ITG *nodeboun,ITG *ndirboun,double *xboun,
-               ITG *nboun,ITG *ipompc,ITG *nodempc,double *coefmpc,
-               ITG *nmpc,ITG *nodeforc,ITG *ndirforc,
-               double *xforc,ITG *nforc,ITG *nelemload,char *sideload,
-               double *xload,ITG *nload,double *xbody,ITG *ipobody,
-               ITG *nbody,double *cgr,
-               double *ad,double *au,double *bb,ITG *nactdof,
-               ITG *icol,ITG *jq,ITG *irow,ITG *neq,ITG *nzl,
-               ITG *nmethod,ITG *ikmpc,ITG *ilmpc,ITG *ikboun,
-               ITG *ilboun,
-               double *elcon,ITG *nelcon,double *rhcon,ITG *nrhcon,
-               double *alcon,ITG *nalcon,double *alzero,ITG *ielmat,
-               ITG *ielorien,ITG *norien,double *orab,ITG *ntmat_,
-               double *t0,double *t1,ITG *ithermal,
-               double *prestr,ITG *iprestr,double *vold,
-               ITG *iperturb,double *sti,ITG *nzs,double *stx,
-               double *adb,double *aub,ITG *iexpl,
-               double *plicon,ITG *nplicon,double *plkcon,ITG *nplkcon,
-               double *xstiff,
-               ITG *npmat_,double *dtime,char *matname,ITG *mi,
-               ITG *ncmat_,ITG *mass,ITG *stiffness,ITG *buckling,ITG *rhs,
-               ITG *intscheme,double *physcon,double *shcon,ITG *nshcon,
-               double *cocon,ITG *ncocon,double *ttime,double *time,
-               ITG *istep,ITG *kinc,ITG *coriolis,ITG *ibody,
-               double *xloadold,double *reltime,double *veold,
-               double *springarea,ITG *nstate_,double *xstateini,
-               double *xstate,double *thicke,
-               ITG *integerglob,double *doubleglob,char *tieset,
-               ITG *istartset,ITG *iendset,ITG *ialset,ITG *ntie,
-               ITG *nasym,double *pslavsurf,double *pmastsurf,ITG *mortar,
-               double *clearini,ITG *ielprop,double *prop,ITG *ne0,
-               double *fnext,ITG *kscale,ITG *iponoel,
-               ITG *inoel,ITG *network,ITG *ntrans,ITG *inotr,double *trab));
+void FORTRAN(mafillsm_company, (double *co, ITG *nk, ITG *kon, ITG *ipkon,
+                                char *lakon,
+                                ITG *ne, ITG *nodeboun, ITG *ndirboun, double *xboun,
+                                ITG *nboun, ITG *ipompc, ITG *nodempc, double *coefmpc,
+                                ITG *nmpc, ITG *nodeforc, ITG *ndirforc,
+                                double *xforc, ITG *nforc, ITG *nelemload, char *sideload,
+                                double *xload, ITG *nload, double *xbody, ITG *ipobody,
+                                ITG *nbody, double *cgr,
+                                double *ad, double *au, double *bb, ITG *nactdof,
+                                ITG *icol, ITG *jq, ITG *irow, ITG *neq, ITG *nzl,
+                                ITG *nmethod, ITG *ikmpc, ITG *ilmpc, ITG *ikboun,
+                                ITG *   ilboun,
+                                double *elcon, ITG *nelcon, double *rhcon, ITG *nrhcon,
+                                double *alcon, ITG *nalcon, double *alzero, ITG *ielmat,
+                                ITG *ielorien, ITG *norien, double *orab, ITG *ntmat_,
+                                double *t0, double *t1, ITG *ithermal,
+                                double *prestr, ITG *iprestr, double *vold,
+                                ITG *iperturb, double *sti, ITG *nzs, double *stx,
+                                double *adb, double *aub, ITG *iexpl,
+                                double *plicon, ITG *nplicon, double *plkcon, ITG *nplkcon,
+                                double *xstiff,
+                                ITG *npmat_, double *dtime, char *matname, ITG *mi,
+                                ITG *ncmat_, ITG *mass, ITG *stiffness, ITG *buckling, ITG *rhs,
+                                ITG *intscheme, double *physcon, double *shcon, ITG *nshcon,
+                                double *cocon, ITG *ncocon, double *ttime, double *time,
+                                ITG *istep, ITG *kinc, ITG *coriolis, ITG *ibody,
+                                double *xloadold, double *reltime, double *veold,
+                                double *springarea, ITG *nstate_, double *xstateini,
+                                double *xstate, double *thicke,
+                                ITG *integerglob, double *doubleglob, char *tieset,
+                                ITG *istartset, ITG *iendset, ITG *ialset, ITG *ntie,
+                                ITG *nasym, double *pslavsurf, double *pmastsurf, ITG *mortar,
+                                double *clearini, ITG *ielprop, double *prop, ITG *ne0,
+                                double *fnext, ITG *kscale, ITG *iponoel,
+                                ITG *inoel, ITG *network, ITG *ntrans, ITG *inotr, double *trab));
 
-void FORTRAN(mafilltlhs,(double *co,ITG *nk,ITG *kon,ITG *ipkon,char *lakon,
-			 ITG *ne,ITG *nodeboun,ITG *ndirboun,double *xboun,
-			 ITG *nboun,ITG *ipompc,ITG *nodempc,double *coefmpc,
-			 ITG *nmpc,ITG *nactdoh,ITG *icolt,ITG *jqt,ITG *irowt,
-			 ITG *neqt,ITG *nzlt,ITG *ikmpc,ITG *ilmpc,ITG *ikboun,
-			 ITG *ilboun,ITG *nzst,double *adbt,double *aubt,
-			 ITG *ipvar,double *var,double *dhel));
-	  
-void FORTRAN(mafilltrhs,(double *co,ITG *nk,ITG *kon,ITG *ipkon,char *lakon,
-             ITG *ne,ITG *nodeboun,ITG *ndirboun,double *xboun,ITG *nboun,
-             ITG *ipompc,ITG *nodempc,double *coefmpc,ITG *nmpc,
-             ITG *nodeforc,ITG *ndirforc,double *xforc,ITG *nforc,
-             ITG *nelemload,char *sideload,double *xload,ITG *nload,
-             double *xbody,ITG *ipobody,ITG *nbody,double *b,ITG *nactdoh,
-             ITG *neqt,ITG *nmethod,ITG *ikmpc,ITG *ilmpc,ITG *ikboun,
-             ITG *ilboun,double *rhcon,ITG *nrhcon,ITG *ielmat,ITG *ntmat_,
-             double *t0,ITG *ithermal,double *vold,double *voldaux,ITG *nzst,
-	     double *dt,char *matname,ITG *mi,ITG *ncmat_,
-             double *physcon,double *shcon,ITG *nshcon,double *ttime,
-             double *timef,ITG *istep,ITG *iinc,ITG *ibody,double *xloadold,
-             double *reltime,double *cocon,ITG *ncocon,ITG *nelemface,
-	     char *sideface,ITG *nface,ITG *compressible,
-	     double *yy,ITG *turbulent,ITG *nea,ITG *neb,
-	     double *dtimef,ITG *ipvar,double *var,ITG *ipvarf,double *varf,
-	     ITG *ipface));
+void FORTRAN(mafilltlhs, (double *co, ITG *nk, ITG *kon, ITG *ipkon, char *lakon,
+                          ITG *ne, ITG *nodeboun, ITG *ndirboun, double *xboun,
+                          ITG *nboun, ITG *ipompc, ITG *nodempc, double *coefmpc,
+                          ITG *nmpc, ITG *nactdoh, ITG *icolt, ITG *jqt, ITG *irowt,
+                          ITG *neqt, ITG *nzlt, ITG *ikmpc, ITG *ilmpc, ITG *ikboun,
+                          ITG *ilboun, ITG *nzst, double *adbt, double *aubt,
+                          ITG *ipvar, double *var, double *dhel));
+
+void FORTRAN(mafilltrhs, (double *co, ITG *nk, ITG *kon, ITG *ipkon, char *lakon,
+                          ITG *ne, ITG *nodeboun, ITG *ndirboun, double *xboun, ITG *nboun,
+                          ITG *ipompc, ITG *nodempc, double *coefmpc, ITG *nmpc,
+                          ITG *nodeforc, ITG *ndirforc, double *xforc, ITG *nforc,
+                          ITG *nelemload, char *sideload, double *xload, ITG *nload,
+                          double *xbody, ITG *ipobody, ITG *nbody, double *b, ITG *nactdoh,
+                          ITG *neqt, ITG *nmethod, ITG *ikmpc, ITG *ilmpc, ITG *ikboun,
+                          ITG *ilboun, double *rhcon, ITG *nrhcon, ITG *ielmat, ITG *ntmat_,
+                          double *t0, ITG *ithermal, double *vold, double *voldaux, ITG *nzst,
+                          double *dt, char *matname, ITG *mi, ITG *ncmat_,
+                          double *physcon, double *shcon, ITG *nshcon, double *ttime,
+                          double *timef, ITG *istep, ITG *iinc, ITG *ibody, double *xloadold,
+                          double *reltime, double *cocon, ITG *ncocon, ITG *nelemface,
+                          char *sideface, ITG *nface, ITG *compressible,
+                          double *yy, ITG *turbulent, ITG *nea, ITG *neb,
+                          double *dtimef, ITG *ipvar, double *var, ITG *ipvarf, double *varf,
+                          ITG *ipface));
 
 void *mafilltrhsmt(ITG *i);
 
-void FORTRAN(mafillv1rhs,(double *co,ITG *nk,ITG *kon,ITG *ipkon,
-         char *lakon,ITG *ne,
-	 ITG *ipompc,ITG *nodempc,double *coefmpc,
-         ITG *nmpc,
-	 ITG *nelemload,char *sideload,double *xload,
-         ITG *nload,double *xbody,ITG *ipobody,ITG *nbody,
-         double *b,ITG *nactdoh,
-         ITG *nmethod,ITG *ikmpc,ITG *ilmpc,
-         double *rhcon,ITG *nrhcon,ITG *ielmat,
-         ITG *ntmat_,ITG *ithermal,double *vold,
-	 double *vcon,
-         ITG *mi,double *physcon,double *shcon,ITG *nshcon,
-         double *ttime,double *timef,ITG *istep,ITG *ibody,
-         double *xloadold,ITG *turbulent,
-	 ITG *nelemface,char *sideface,ITG *nface,ITG *compressible,
-	 ITG *nea,ITG *neb,double *dtimef,ITG *ipvar,double *var,
-	 ITG *ipvarf,double *varf,ITG *ipface,ITG *ifreesurface,
-	 double *depth,double *dgravity,double *cocon,ITG *ncocon,ITG *inc,
-	 double *theta1,double *reltimef,double *v));
+void FORTRAN(mafillv1rhs, (double *co, ITG *nk, ITG *kon, ITG *ipkon,
+                           char *lakon, ITG *ne,
+                           ITG *ipompc, ITG *nodempc, double *coefmpc,
+                           ITG *nmpc,
+                           ITG *nelemload, char *sideload, double *xload,
+                           ITG *nload, double *xbody, ITG *ipobody, ITG *nbody,
+                           double *b, ITG *nactdoh,
+                           ITG *nmethod, ITG *ikmpc, ITG *ilmpc,
+                           double *rhcon, ITG *nrhcon, ITG *ielmat,
+                           ITG *ntmat_, ITG *ithermal, double *vold,
+                           double *vcon,
+                           ITG *mi, double *physcon, double *shcon, ITG *nshcon,
+                           double *ttime, double *timef, ITG *istep, ITG *ibody,
+                           double *xloadold, ITG *turbulent,
+                           ITG *nelemface, char *sideface, ITG *nface, ITG *compressible,
+                           ITG *nea, ITG *neb, double *dtimef, ITG *ipvar, double *var,
+                           ITG *ipvarf, double *varf, ITG *ipface, ITG *ifreesurface,
+                           double *depth, double *dgravity, double *cocon, ITG *ncocon, ITG *inc,
+                           double *theta1, double *reltimef, double *v));
 
 void *mafillv1rhsmt(ITG *i);
 
-void FORTRAN(mafillv2rhs,(ITG *kon,ITG *ipkon,char *lakon,double *b2,double *v,
-			  ITG *nea,ITG *neb,ITG *mi,double *dtimef,ITG *ipvar,
-			  double *var,ITG *ne));
+void FORTRAN(mafillv2rhs, (ITG * kon, ITG *ipkon, char *lakon, double *b2, double *v,
+                           ITG *nea, ITG *neb, ITG *mi, double *dtimef, ITG *ipvar,
+                           double *var, ITG *ne));
 
 void *mafillv2rhsmt(ITG *i);
 
-void FORTRAN(mafillvlhs,(ITG *nk,ITG *kon,ITG *ipkon,char *lakon,ITG *ne,
-			 ITG *icolv,ITG *jqv,ITG *irowv,ITG *nzsv,double *adbv,
-			 double *aubv,ITG *ipvar,double *var));
+void FORTRAN(mafillvlhs, (ITG * nk, ITG *kon, ITG *ipkon, char *lakon, ITG *ne,
+                          ITG *icolv, ITG *jqv, ITG *irowv, ITG *nzsv, double *adbv,
+                          double *aubv, ITG *ipvar, double *var));
 
-void FORTRAN(map3dto1d2d,(double *extnor,ITG *ipkon,ITG *inum,ITG *kon,
-                          char *lakon,ITG *nfield,ITG *nk,ITG *ne,
-                          char *cflag,double *co,double *vold,ITG *iforce,
-                          ITG *mi,ITG *ielprop,double *prop));
+void FORTRAN(map3dto1d2d, (double *extnor, ITG *ipkon, ITG *inum, ITG *kon,
+                           char *lakon, ITG *nfield, ITG *nk, ITG *ne,
+                           char *cflag, double *co, double *vold, ITG *iforce,
+                           ITG *mi, ITG *ielprop, double *prop));
 
-void massless(ITG *kslav,ITG *lslav,ITG *ktot,ITG *ltot,
-	      double *au,double *ad,double *auc,double *adc, 
-	      ITG *jq,ITG *irow,ITG *neq,ITG *nzs,double *auw,ITG *jqw,
-	      ITG *iroww,ITG *nzsw,ITG *islavnode,ITG *nslavnode,
-	      ITG *nslavs,ITG *imastnode,ITG *nmastnode,ITG *ntie,
-	      ITG *nactdof,ITG *mi ,double *vold,double *volddof,
-	      double *veold,ITG *nk,double *fext,  
-	      ITG *isolver,ITG *iperturb,double *co,double *springarea ,
-	      ITG *neqslav,ITG *neqtot,double *qbk,double *b);
+void massless(ITG *kslav, ITG *lslav, ITG *ktot, ITG *ltot,
+              double *au, double *ad, double *auc, double *adc,
+              ITG *jq, ITG *irow, ITG *neq, ITG *nzs, double *auw, ITG *jqw,
+              ITG *iroww, ITG *nzsw, ITG *islavnode, ITG *nslavnode,
+              ITG *nslavs, ITG *imastnode, ITG *nmastnode, ITG *ntie,
+              ITG *nactdof, ITG *mi, double *vold, double *volddof,
+              double *veold, ITG *nk, double *fext,
+              ITG *isolver, ITG *iperturb, double *co, double *springarea,
+              ITG *neqslav, ITG *neqtot, double *qbk, double *b);
 
-void mastruct(ITG *nk,ITG *kon,ITG *ipkon,char *lakon,ITG *ne,
-              ITG *nodeboun,ITG *ndirboun,ITG *nboun,ITG *ipompc,
-              ITG *nodempc,ITG *nmpc,ITG *nactdof,ITG *icol,
-              ITG *jq,ITG **mast1p,ITG **irowp,ITG *isolver,ITG *neq,
-              ITG *ikmpc,ITG *ilmpc,ITG *ipointer,ITG *nzs,ITG *nmethod,
-              ITG *ithermal,ITG *ikboun,ITG *ilboun,ITG *iperturb,
-              ITG *mi,ITG *mortar,char *typeboun,char *labmpc,
-              ITG *iit,ITG *icascade,ITG *network,ITG *iexpl);
+void mastruct(ITG *nk, ITG *kon, ITG *ipkon, char *lakon, ITG *ne,
+              ITG *nodeboun, ITG *ndirboun, ITG *nboun, ITG *ipompc,
+              ITG *nodempc, ITG *nmpc, ITG *nactdof, ITG *icol,
+              ITG *jq, ITG **mast1p, ITG **irowp, ITG *isolver, ITG *neq,
+              ITG *ikmpc, ITG *ilmpc, ITG *ipointer, ITG *nzs, ITG *nmethod,
+              ITG *ithermal, ITG *ikboun, ITG *ilboun, ITG *iperturb,
+              ITG *mi, ITG *mortar, char *typeboun, char *labmpc,
+              ITG *iit, ITG *icascade, ITG *network, ITG *iexpl);
 
-void mastructcmatrix(ITG *icolc,ITG *jqc,ITG **mast1p,ITG **irowcp,
-		     ITG *ipointer,ITG *nzsc,ITG *ndesibou,ITG *nodedesibou,
-		     ITG *nodedesiinvbou,ITG *jqs,ITG *irows,ITG *icols,
-		     ITG *ndesi,ITG *nodedesi);
+void mastructcmatrix(ITG *icolc, ITG *jqc, ITG **mast1p, ITG **irowcp,
+                     ITG *ipointer, ITG *nzsc, ITG *ndesibou, ITG *nodedesibou,
+                     ITG *nodedesiinvbou, ITG *jqs, ITG *irows, ITG *icols,
+                     ITG *ndesi, ITG *nodedesi);
 
-void mastructcs(ITG *nk,ITG *kon,ITG *ipkon,char *lakon,
-               ITG *ne,ITG *nodeboun,
-               ITG *ndirboun,ITG *nboun,ITG *ipompc,ITG *nodempc,
-               ITG *nmpc,ITG *nactdof,ITG *icol,ITG *jq,ITG **mast1p,
-               ITG **irowp,ITG *isolver,ITG *neq,
-               ITG *ikmpc,ITG *ilmpc,ITG *ipointer,
-               ITG *nzs,ITG *nmethod,ITG *ics,double *cs,
-               char *labmpc,ITG *mcs,ITG *mi,ITG *mortar);
+void mastructcs(ITG *nk, ITG *kon, ITG *ipkon, char *lakon,
+                ITG *ne, ITG *nodeboun,
+                ITG *ndirboun, ITG *nboun, ITG *ipompc, ITG *nodempc,
+                ITG *nmpc, ITG *nactdof, ITG *icol, ITG *jq, ITG **mast1p,
+                ITG **irowp, ITG *isolver, ITG *neq,
+                ITG *ikmpc, ITG *ilmpc, ITG *ipointer,
+                ITG *nzs, ITG *nmethod, ITG *ics, double *cs,
+                char *labmpc, ITG *mcs, ITG *mi, ITG *mortar);
 
-void mastructdmatrix(ITG *icold,ITG *jqd,ITG **mast1p,ITG **irowdp,
-		     ITG *ipointer,ITG *nzss,ITG *ndesibou,ITG *nodedesibou,
-		     ITG *nodedesiinvbou,ITG *jqs,ITG *irows,ITG *icols,
-		     ITG *ndesi,ITG *nodedesi);
+void mastructdmatrix(ITG *icold, ITG *jqd, ITG **mast1p, ITG **irowdp,
+                     ITG *ipointer, ITG *nzss, ITG *ndesibou, ITG *nodedesibou,
+                     ITG *nodedesiinvbou, ITG *jqs, ITG *irows, ITG *icols,
+                     ITG *ndesi, ITG *nodedesi);
 
-void mastructem(ITG *nk,ITG *kon,ITG *ipkon,char *lakon,ITG *ne,
-              ITG *nodeboun,ITG *ndirboun,ITG *nboun,ITG *ipompc,
-              ITG *nodempc,ITG *nmpc,ITG *nactdof,ITG *icol,
-              ITG *jq,ITG **mast1p,ITG **irowp,ITG *isolver,ITG *neq,
-              ITG *ikmpc,ITG *ilmpc,ITG *ipointer,ITG *nzs,
-              ITG *ithermal,ITG *mi,ITG *ielmat,double *elcon,ITG *ncmat_,
-              ITG *ntmat_,ITG *inomat,ITG *network);
+void mastructem(ITG *nk, ITG *kon, ITG *ipkon, char *lakon, ITG *ne,
+                ITG *nodeboun, ITG *ndirboun, ITG *nboun, ITG *ipompc,
+                ITG *nodempc, ITG *nmpc, ITG *nactdof, ITG *icol,
+                ITG *jq, ITG **mast1p, ITG **irowp, ITG *isolver, ITG *neq,
+                ITG *ikmpc, ITG *ilmpc, ITG *ipointer, ITG *nzs,
+                ITG *ithermal, ITG *mi, ITG *ielmat, double *elcon, ITG *ncmat_,
+                ITG *ntmat_, ITG *inomat, ITG *network);
 
-void mastructffem(ITG *nk,ITG *kon,ITG *ipkon,char *lakon,ITG *ne,
-              ITG *nodeboun,ITG *ndirboun,ITG *nboun,ITG *ipompc,
-              ITG *nodempc,ITG *nmpc,ITG *nactdoh,
-              ITG *icolv,ITG *icolp,ITG *jqv,ITG *jqp,
-              ITG **mast1p,ITG **irowvp,ITG **irowpp,
-              ITG *neqp,ITG *ipointer,ITG *nzsv,ITG *nzsp,
-              ITG *nzs,ITG *compressible,ITG *inomat);
+void mastructffem(ITG *nk, ITG *kon, ITG *ipkon, char *lakon, ITG *ne,
+                  ITG *nodeboun, ITG *ndirboun, ITG *nboun, ITG *ipompc,
+                  ITG *nodempc, ITG *nmpc, ITG *nactdoh,
+                  ITG *icolv, ITG *icolp, ITG *jqv, ITG *jqp,
+                  ITG **mast1p, ITG **irowvp, ITG **irowpp,
+                  ITG *neqp, ITG *ipointer, ITG *nzsv, ITG *nzsp,
+                  ITG *nzs, ITG *compressible, ITG *inomat);
 
-void mastructnmatrix(ITG *icols,ITG *jqs,ITG **mast1p,ITG **irowsp,
-		     ITG *ipointer,ITG *nzss,ITG *nactive,ITG *nnlconst);
+void mastructnmatrix(ITG *icols, ITG *jqs, ITG **mast1p, ITG **irowsp,
+                     ITG *ipointer, ITG *nzss, ITG *nactive, ITG *nnlconst);
 
-void mastructrad(ITG *ntr,ITG *nloadtr,char *sideload,ITG *ipointerrad,
-              ITG **mast1radp,ITG **irowradp,ITG *nzsrad,
-              ITG *jqrad,ITG *icolrad);
+void mastructrad(ITG *ntr, ITG *nloadtr, char *sideload, ITG *ipointerrad,
+                 ITG **mast1radp, ITG **irowradp, ITG *nzsrad,
+                 ITG *jqrad, ITG *icolrad);
 
-void mastructrand(ITG *icols,ITG *jqs,ITG **mast1p,ITG **irowsp,
-                  ITG *ipointer,ITG *nzss,
-                  ITG *ndesi,double *physcon,double *xo,double *yo,
-                  double *zo,double *x,double *y,double *z,ITG *nx,
-                  ITG *ny,ITG *nz);
+void mastructrand(ITG *icols, ITG *jqs, ITG **mast1p, ITG **irowsp,
+                  ITG *ipointer, ITG *nzss,
+                  ITG *ndesi, double *physcon, double *xo, double *yo,
+                  double *zo, double *x, double *y, double *z, ITG *nx,
+                  ITG *ny, ITG *nz);
 
-void mastructse(ITG *kon,ITG *ipkon,char *lakon,ITG *ne,
-              ITG *ipompc,ITG *nodempc,ITG *nmpc,
-              ITG *nactdof,ITG *jqs,ITG **mast1p,ITG **irowsp,
-              ITG *ipointer,ITG *nzss,ITG *mi,ITG *mortar,
-              ITG *nodedesi,ITG *ndesi,ITG *icoordinate,ITG *ielorien,
-              ITG *istartdesi,ITG *ialdesi);
+void mastructse(ITG *kon, ITG *ipkon, char *lakon, ITG *ne,
+                ITG *ipompc, ITG *nodempc, ITG *nmpc,
+                ITG *nactdof, ITG *jqs, ITG **mast1p, ITG **irowsp,
+                ITG *ipointer, ITG *nzss, ITG *mi, ITG *mortar,
+                ITG *nodedesi, ITG *ndesi, ITG *icoordinate, ITG *ielorien,
+                ITG *istartdesi, ITG *ialdesi);
 
-void matrixstorage(double *ad,double **aup,double *adb,double *aub,
-                double *sigma,ITG *icol,ITG **irowp,
-                ITG *neq,ITG *nzs,ITG *ntrans,ITG *inotr,
-                double *trab,double *co,ITG *nk,ITG *nactdof,
-                char *jobnamec,ITG *mi,ITG *ipkon,char *lakon,
-                ITG *kon,ITG *ne,ITG *mei,ITG *nboun,ITG *nmpc,
-                double *cs,ITG *mcs,ITG *ithermal,ITG *nmethod);
+void matrixstorage(double *ad, double **aup, double *adb, double *aub,
+                   double *sigma, ITG *icol, ITG **irowp,
+                   ITG *neq, ITG *nzs, ITG *ntrans, ITG *inotr,
+                   double *trab, double *co, ITG *nk, ITG *nactdof,
+                   char *jobnamec, ITG *mi, ITG *ipkon, char *lakon,
+                   ITG *kon, ITG *ne, ITG *mei, ITG *nboun, ITG *nmpc,
+                   double *cs, ITG *mcs, ITG *ithermal, ITG *nmethod);
 
-void FORTRAN(meannode,(ITG *nk,ITG *inum,double *v));
+void FORTRAN(meannode, (ITG * nk, ITG *inum, double *v));
 
-void FORTRAN(merge_ikactmech1,(ITG *ikactmech1,ITG *nactmech1,ITG *neq,
-			       ITG *ikactmech,ITG *nactmech,ITG *num_cpu));
+void FORTRAN(merge_ikactmech1, (ITG * ikactmech1, ITG *nactmech1, ITG *neq,
+                                ITG *ikactmech, ITG *nactmech, ITG *num_cpu));
 
-void FORTRAN(meshquality,(ITG *netet_,ITG *kontet,double *cotet,
-			  double *quality,ITG *ielem));
+void FORTRAN(meshquality, (ITG * netet_, ITG *kontet, double *cotet,
+                           double *quality, ITG *ielem));
 
-void FORTRAN(meshqualitycavity,(ITG *no1,ITG *no2,ITG *no3,ITG *no4,
-				double *cotet,double *quality,double *volume));
+void FORTRAN(meshqualitycavity, (ITG * no1, ITG *no2, ITG *no3, ITG *no4,
+                                 double *cotet, double *quality, double *volume));
 
-void FORTRAN(midexternaledges,(ITG *iexternedg,ITG *nexternedg,ITG *iedgext,
-                              ITG *ifreeed,ITG *ieled,ITG *ipoeled,
-                              ITG *iedg,ITG *iedtet,ITG *kontetor));
+void FORTRAN(midexternaledges, (ITG * iexternedg, ITG *nexternedg, ITG *iedgext,
+                                ITG *ifreeed, ITG *ieled, ITG *ipoeled,
+                                ITG *iedg, ITG *iedtet, ITG *kontetor));
 
-void FORTRAN(midexternalfaces,(ITG *iexternfa,ITG *nexternfa,ITG *ifacext,
-                               ITG *ifreefa,ITG *itetfa,
-                               ITG *ifac,ITG *kontet,ITG *kontetor,
-                               ITG *ialsetexternel,ITG *nexternel,
-                               ITG *iedgextfa,ITG *ifacexted,
-                               ITG *ipoed,ITG *iedg,ITG *iexternedg));
+void FORTRAN(midexternalfaces, (ITG * iexternfa, ITG *nexternfa, ITG *ifacext,
+                                ITG *ifreefa, ITG *itetfa,
+                                ITG *ifac, ITG *kontet, ITG *kontetor,
+                                ITG *ialsetexternel, ITG *nexternel,
+                                ITG *iedgextfa, ITG *ifacexted,
+                                ITG *ipoed, ITG *iedg, ITG *iexternedg));
 
-void FORTRAN(modifympc,(ITG *inodestet,ITG *nnodestet,double *co,
-			double *doubleglob,ITG *integerglob,ITG *ipompc,
-			ITG *nodempc,double *coefmpc,ITG *nmpc,ITG *nmpc_,
-			char *labmpc,ITG *mpcfree,ITG *ikmpc,ITG *ilmpc,
-			ITG *jq,ITG *irow,ITG *icol,
-			ITG *iloc,ITG *kloc,ITG *jloc,ITG *itemp,
-			double *au,ITG *ixcol,ITG *ikboun,ITG *nboun,
-			ITG *nodeboun,ITG *mpcrfna,ITG *mpcrfnb,
-			ITG *nodempcref,double *coefmpcref,ITG *memmpcref_,
-			ITG *mpcfreeref,ITG *maxlenmpcref,ITG *memmpc_,
-			ITG *maxlenmpc,ITG *istep));
+void FORTRAN(modifympc, (ITG * inodestet, ITG *nnodestet, double *co,
+                         double *doubleglob, ITG *integerglob, ITG *ipompc,
+                         ITG *nodempc, double *coefmpc, ITG *nmpc, ITG *nmpc_,
+                         char *labmpc, ITG *mpcfree, ITG *ikmpc, ITG *ilmpc,
+                         ITG *jq, ITG *irow, ITG *icol,
+                         ITG *iloc, ITG *kloc, ITG *jloc, ITG *itemp,
+                         double *au, ITG *ixcol, ITG *ikboun, ITG *nboun,
+                         ITG *nodeboun, ITG *mpcrfna, ITG *mpcrfnb,
+                         ITG *nodempcref, double *coefmpcref, ITG *memmpcref_,
+                         ITG *mpcfreeref, ITG *maxlenmpcref, ITG *memmpc_,
+                         ITG *maxlenmpc, ITG *istep));
 
-void FORTRAN(mpcrem,(ITG *i,ITG *mpcfree,ITG *nodempc,ITG *nmpc,ITG *ikmpc,
-                     ITG *ilmpc,char *labmpc,double *coefmpc,ITG *ipompc));
+void FORTRAN(mpcrem, (ITG * i, ITG *mpcfree, ITG *nodempc, ITG *nmpc, ITG *ikmpc,
+                      ITG *ilmpc, char *labmpc, double *coefmpc, ITG *ipompc));
 
 void mtseed(ITG *iseed);
 
-void FORTRAN(mult,(double *matrix,double *trans,ITG *n));
+void FORTRAN(mult, (double *matrix, double *trans, ITG *n));
 
-void FORTRAN(mulmatvec_asym,(double *aa,ITG *jjq,ITG *iidof,ITG *nrow, 
-			     double *x,double *y,ITG *type ));
+void FORTRAN(mulmatvec_asym, (double *aa, ITG *jjq, ITG *iidof, ITG *nrow,
+                              double *x, double *y, ITG *type));
 
-void FORTRAN(near3d_se,(double *xo,double *yo,double *zo,double *x,
-			double *y,double *z,ITG *nx,ITG *ny,ITG *nz,
-			double *xp,double *yp,double *zp,ITG *n,
-			ITG *ir,double *r,ITG *nr,double *radius));
+void FORTRAN(near3d_se, (double *xo, double *yo, double *zo, double *x,
+                         double *y, double *z, ITG *nx, ITG *ny, ITG *nz,
+                         double *xp, double *yp, double *zp, ITG *n,
+                         ITG *ir, double *r, ITG *nr, double *radius));
 
-void FORTRAN(negativepressure,(ITG *ne0,ITG *ne,ITG *mi,double *stx,
-                               double *pressureratio));
+void FORTRAN(negativepressure, (ITG * ne0, ITG *ne, ITG *mi, double *stx,
+                                double *pressureratio));
 
-void FORTRAN(networkelementpernode,(ITG *iponoel,ITG *inoel,char *lakon,
-             ITG *ipkon,ITG *kon,ITG *inoelsize,ITG *nflow,ITG *ieg,
-             ITG *ne,ITG *network));
+void FORTRAN(networkelementpernode, (ITG * iponoel, ITG *inoel, char *lakon,
+                                     ITG *ipkon, ITG *kon, ITG *inoelsize, ITG *nflow, ITG *ieg,
+                                     ITG *ne, ITG *network));
 
-void FORTRAN(networkinum,(ITG *ipkon,ITG *inum,ITG *kon,char *lakon,
-       ITG *ne,ITG *itg,ITG *ntg));
+void FORTRAN(networkinum, (ITG * ipkon, ITG *inum, ITG *kon, char *lakon,
+                           ITG *ne, ITG *itg, ITG *ntg));
 
-void FORTRAN(newnodes,(ITG *nktet_,ITG *ipoed,ITG *n,
-                       ITG *iedg,double *h,double *d,double *r,
-                       double *conewnodes,double *cotet,ITG *ibasenewnodes,
-                       ITG *ipoeled,ITG *ieled,double *doubleglob,
-                       ITG *integerglob,ITG *nnewnodes,ITG *iedgnewnodes,
-                       double *hnewnodes,ITG *n1newnodes,ITG *n2newnodes));
+void FORTRAN(newnodes, (ITG * nktet_, ITG *ipoed, ITG *n,
+                        ITG *iedg, double *h, double *d, double *r,
+                        double *conewnodes, double *cotet, ITG *ibasenewnodes,
+                        ITG *ipoeled, ITG *ieled, double *doubleglob,
+                        ITG *integerglob, ITG *nnewnodes, ITG *iedgnewnodes,
+                        double *hnewnodes, ITG *n1newnodes, ITG *n2newnodes));
 
-void FORTRAN(nident,(ITG *x,ITG *px,ITG *n,ITG *id));
+void FORTRAN(nident, (ITG * x, ITG *px, ITG *n, ITG *id));
 
-void FORTRAN(nidentll,(long long *x,long long *px,ITG *n,ITG *id));
+void FORTRAN(nidentll, (long long *x, long long *px, ITG *n, ITG *id));
 
-void FORTRAN(nmatrix,(double *ad,double *au,ITG *jqs,ITG *irows,ITG *ndesi,
-		      ITG *nodedesi,double *dgdxglob,ITG *nactive,ITG *nobject,
-		      ITG *nnlconst,ITG *ipoacti,ITG *nk));         
+void FORTRAN(nmatrix, (double *ad, double *au, ITG *jqs, ITG *irows, ITG *ndesi,
+                       ITG *nodedesi, double *dgdxglob, ITG *nactive, ITG *nobject,
+                       ITG *nnlconst, ITG *ipoacti, ITG *nk));
 
-void FORTRAN(nodesperface,(ITG *ipkonf,ITG *konf,char *lakonf,ITG *nface,
-			   ITG *ielfa,ITG *iponofa,ITG *inofa));
+void FORTRAN(nodesperface, (ITG * ipkonf, ITG *konf, char *lakonf, ITG *nface,
+                            ITG *ielfa, ITG *iponofa, ITG *inofa));
 
-void FORTRAN(nodestiedface,(char *tieset,ITG *ntie,ITG *ipkon,ITG *kon,
-       char *lakon,char *set,ITG *istartset,ITG *iendset,ITG *ialset,
-       ITG *nset,ITG *faceslave,ITG *istartfield,ITG *iendfield,
-       ITG *ifield,ITG *nconf,ITG *ncone,char *kind));
+void FORTRAN(nodestiedface, (char *tieset, ITG *ntie, ITG *ipkon, ITG *kon,
+                             char *lakon, char *set, ITG *istartset, ITG *iendset, ITG *ialset,
+                             ITG *nset, ITG *faceslave, ITG *istartfield, ITG *iendfield,
+                             ITG *ifield, ITG *nconf, ITG *ncone, char *kind));
 
-void nonlingeo(double **co,ITG *nk,ITG **konp,ITG **ipkonp,char **lakonp,
-	       ITG *ne,
-	       ITG *nodeboun,ITG *ndirboun,double *xboun,ITG *nboun,
-	       ITG **ipompcp,ITG **nodempcp,double **coefmpcp,char **labmpcp,
-	       ITG *nmpc,
-	       ITG *nodeforc,ITG *ndirforc,double *xforc,ITG *nforc,
-	       ITG **nelemloadp,char **sideloadp,double *xload,
-	       ITG *nload,ITG *nactdof,
-	       ITG **icolp,ITG *jq,ITG **irowp,ITG *neq,ITG *nzl,
-	       ITG *nmethod,ITG **ikmpcp,ITG **ilmpcp,ITG *ikboun,
-	       ITG *ilboun,
-	       double *elcon,ITG *nelcon,double *rhcon,ITG *nrhcon,
-	       double *alcon,ITG *nalcon,double *alzero,ITG **ielmatp,
-	       ITG **ielorienp,ITG *norien,double *orab,ITG *ntmat_,
-	       double *t0,double *t1,double *t1old,
-	       ITG *ithermal,double *prestr,ITG *iprestr,
-	       double **vold,ITG *iperturb,double *sti,ITG *nzs,
-	       ITG *kode,char *filab,ITG *idrct,
-	       ITG *jmax,ITG *jout,double *timepar,
-	       double *eme,double *xbounold,
-	       double *xforcold,double *xloadold,
-	       double *veold,double *accold,
-	       char *amname,double *amta,ITG *namta,ITG *nam,
-	       ITG *iamforc,ITG **iamloadp,
-	       ITG *iamt1,double *alpha,ITG *iexpl,
-	       ITG *iamboun,double *plicon,ITG *nplicon,double *plkcon,
-	       ITG *nplkcon,
-	       double **xstatep,ITG *npmat_,ITG *istep,double *ttime,
-	       char *matname,double *qaold,ITG *mi,
-	       ITG *isolver,ITG *ncmat_,ITG *nstate_,ITG *iumat,
-	       double *cs,ITG *mcs,ITG *nkon,double **ener,ITG *mpcinfo,
-	       char *output,
-	       double *shcon,ITG *nshcon,double *cocon,ITG *ncocon,
-	       double *physcon,ITG *nflow,double *ctrl,
-	       char *set,ITG *nset,ITG *istartset,
-	       ITG *iendset,ITG *ialset,ITG *nprint,char *prlab,
-	       char *prset,ITG *nener,ITG *ikforc,ITG *ilforc,double *trab,
-	       ITG *inotr,ITG *ntrans,double **fmpcp,char *cbody,
-	       ITG *ibody,double *xbody,ITG *nbody,double *xbodyold,
-	       ITG *ielprop,double *prop,ITG *ntie,char *tieset,
-	       ITG *itpamp,ITG *iviewfile,char *jobnamec,double *tietol,
-	       ITG *nslavs,double *thicke,ITG *ics,
-	       ITG *nintpoint,ITG *mortar,ITG *ifacecount,char *typeboun,
-	       ITG **islavsurfp,double **pslavsurfp,double **clearinip,
-	       ITG *nmat,double *xmodal,ITG *iaxial,ITG *inext,ITG *nprop,
-	       ITG *network,char *orname,double *vel,ITG *nef,
-	       double *velo,double *veloo,double *energy,ITG *itempuser,
-	       ITG *ipobody,ITG *inewton,double *t0g,double *t1g,
-	       ITG *ifreebody);
+void nonlingeo(double **co, ITG *nk, ITG **konp, ITG **ipkonp, char **lakonp,
+               ITG *ne,
+               ITG *nodeboun, ITG *ndirboun, double *xboun, ITG *nboun,
+               ITG **ipompcp, ITG **nodempcp, double **coefmpcp, char **labmpcp,
+               ITG *nmpc,
+               ITG *nodeforc, ITG *ndirforc, double *xforc, ITG *nforc,
+               ITG **nelemloadp, char **sideloadp, double *xload,
+               ITG *nload, ITG *nactdof,
+               ITG **icolp, ITG *jq, ITG **irowp, ITG *neq, ITG *nzl,
+               ITG *nmethod, ITG **ikmpcp, ITG **ilmpcp, ITG *ikboun,
+               ITG *   ilboun,
+               double *elcon, ITG *nelcon, double *rhcon, ITG *nrhcon,
+               double *alcon, ITG *nalcon, double *alzero, ITG **ielmatp,
+               ITG **ielorienp, ITG *norien, double *orab, ITG *ntmat_,
+               double *t0, double *t1, double *t1old,
+               ITG *ithermal, double *prestr, ITG *iprestr,
+               double **vold, ITG *iperturb, double *sti, ITG *nzs,
+               ITG *kode, char *filab, ITG *idrct,
+               ITG *jmax, ITG *jout, double *timepar,
+               double *eme, double *xbounold,
+               double *xforcold, double *xloadold,
+               double *veold, double *accold,
+               char *amname, double *amta, ITG *namta, ITG *nam,
+               ITG *iamforc, ITG **iamloadp,
+               ITG *iamt1, double *alpha, ITG *iexpl,
+               ITG *iamboun, double *plicon, ITG *nplicon, double *plkcon,
+               ITG *    nplkcon,
+               double **xstatep, ITG *npmat_, ITG *istep, double *ttime,
+               char *matname, double *qaold, ITG *mi,
+               ITG *isolver, ITG *ncmat_, ITG *nstate_, ITG *iumat,
+               double *cs, ITG *mcs, ITG *nkon, double **ener, ITG *mpcinfo,
+               char *  output,
+               double *shcon, ITG *nshcon, double *cocon, ITG *ncocon,
+               double *physcon, ITG *nflow, double *ctrl,
+               char *set, ITG *nset, ITG *istartset,
+               ITG *iendset, ITG *ialset, ITG *nprint, char *prlab,
+               char *prset, ITG *nener, ITG *ikforc, ITG *ilforc, double *trab,
+               ITG *inotr, ITG *ntrans, double **fmpcp, char *cbody,
+               ITG *ibody, double *xbody, ITG *nbody, double *xbodyold,
+               ITG *ielprop, double *prop, ITG *ntie, char *tieset,
+               ITG *itpamp, ITG *iviewfile, char *jobnamec, double *tietol,
+               ITG *nslavs, double *thicke, ITG *ics,
+               ITG *nintpoint, ITG *mortar, ITG *ifacecount, char *typeboun,
+               ITG **islavsurfp, double **pslavsurfp, double **clearinip,
+               ITG *nmat, double *xmodal, ITG *iaxial, ITG *inext, ITG *nprop,
+               ITG *network, char *orname, double *vel, ITG *nef,
+               double *velo, double *veloo, double *energy, ITG *itempuser,
+               ITG *ipobody, ITG *inewton, double *t0g, double *t1g,
+               ITG *ifreebody);
 
-void nonlingeo_precice(double **co,ITG *nk,ITG **konp,ITG **ipkonp,char **lakonp,
-	       ITG *ne,
-	       ITG *nodeboun,ITG *ndirboun,double *xboun,ITG *nboun,
-	       ITG **ipompcp,ITG **nodempcp,double **coefmpcp,char **labmpcp,
-	       ITG *nmpc,
-	       ITG *nodeforc,ITG *ndirforc,double *xforc,ITG *nforc,
-	       ITG **nelemloadp,char **sideloadp,double *xload,
-	       ITG *nload,ITG *nactdof,
-	       ITG **icolp,ITG *jq,ITG **irowp,ITG *neq,ITG *nzl,
-	       ITG *nmethod,ITG **ikmpcp,ITG **ilmpcp,ITG *ikboun,
-	       ITG *ilboun,
-	       double *elcon,ITG *nelcon,double *rhcon,ITG *nrhcon,
-	       double *alcon,ITG *nalcon,double *alzero,ITG **ielmatp,
-	       ITG **ielorienp,ITG *norien,double *orab,ITG *ntmat_,
-	       double *t0,double *t1,double *t1old,
-	       ITG *ithermal,double *prestr,ITG *iprestr,
-	       double **vold,ITG *iperturb,double *sti,ITG *nzs,
-	       ITG *kode,char *filab,ITG *idrct,
-	       ITG *jmax,ITG *jout,double *timepar,
-	       double *eme,double *xbounold,
-	       double *xforcold,double *xloadold,
-	       double *veold,double *accold,
-	       char *amname,double *amta,ITG *namta,ITG *nam,
-	       ITG *iamforc,ITG **iamloadp,
-	       ITG *iamt1,double *alpha,ITG *iexpl,
-	       ITG *iamboun,double *plicon,ITG *nplicon,double *plkcon,
-	       ITG *nplkcon,
-	       double **xstatep,ITG *npmat_,ITG *istep,double *ttime,
-	       char *matname,double *qaold,ITG *mi,
-	       ITG *isolver,ITG *ncmat_,ITG *nstate_,ITG *iumat,
-	       double *cs,ITG *mcs,ITG *nkon,double **ener,ITG *mpcinfo,
-	       char *output,
-	       double *shcon,ITG *nshcon,double *cocon,ITG *ncocon,
-	       double *physcon,ITG *nflow,double *ctrl,
-	       char *set,ITG *nset,ITG *istartset,
-	       ITG *iendset,ITG *ialset,ITG *nprint,char *prlab,
-	       char *prset,ITG *nener,ITG *ikforc,ITG *ilforc,double *trab,
-	       ITG *inotr,ITG *ntrans,double **fmpcp,char *cbody,
-	       ITG *ibody,double *xbody,ITG *nbody,double *xbodyold,
-	       ITG *ielprop,double *prop,ITG *ntie,char *tieset,
-	       ITG *itpamp,ITG *iviewfile,char *jobnamec,double *tietol,
-	       ITG *nslavs,double *thicke,ITG *ics,
-	       ITG *nintpoint,ITG *mortar,ITG *ifacecount,char *typeboun,
-	       ITG **islavsurfp,double **pslavsurfp,double **clearinip,
-	       ITG *nmat,double *xmodal,ITG *iaxial,ITG *inext,ITG *nprop,
-	       ITG *network,char *orname,double *vel,ITG *nef,
-	       double *velo,double *veloo,double *energy,ITG *itempuser,
-	       ITG *ipobody,ITG *inewton,double *t0g,double *t1g,
-	       ITG *ifreebody,char * preciceParticipantName, char * configFilename);
+void nonlingeo_precice(double **co, ITG *nk, ITG **konp, ITG **ipkonp, char **lakonp,
+                       ITG *ne,
+                       ITG *nodeboun, ITG *ndirboun, double *xboun, ITG *nboun,
+                       ITG **ipompcp, ITG **nodempcp, double **coefmpcp, char **labmpcp,
+                       ITG *nmpc,
+                       ITG *nodeforc, ITG *ndirforc, double *xforc, ITG *nforc,
+                       ITG **nelemloadp, char **sideloadp, double *xload,
+                       ITG *nload, ITG *nactdof,
+                       ITG **icolp, ITG *jq, ITG **irowp, ITG *neq, ITG *nzl,
+                       ITG *nmethod, ITG **ikmpcp, ITG **ilmpcp, ITG *ikboun,
+                       ITG *   ilboun,
+                       double *elcon, ITG *nelcon, double *rhcon, ITG *nrhcon,
+                       double *alcon, ITG *nalcon, double *alzero, ITG **ielmatp,
+                       ITG **ielorienp, ITG *norien, double *orab, ITG *ntmat_,
+                       double *t0, double *t1, double *t1old,
+                       ITG *ithermal, double *prestr, ITG *iprestr,
+                       double **vold, ITG *iperturb, double *sti, ITG *nzs,
+                       ITG *kode, char *filab, ITG *idrct,
+                       ITG *jmax, ITG *jout, double *timepar,
+                       double *eme, double *xbounold,
+                       double *xforcold, double *xloadold,
+                       double *veold, double *accold,
+                       char *amname, double *amta, ITG *namta, ITG *nam,
+                       ITG *iamforc, ITG **iamloadp,
+                       ITG *iamt1, double *alpha, ITG *iexpl,
+                       ITG *iamboun, double *plicon, ITG *nplicon, double *plkcon,
+                       ITG *    nplkcon,
+                       double **xstatep, ITG *npmat_, ITG *istep, double *ttime,
+                       char *matname, double *qaold, ITG *mi,
+                       ITG *isolver, ITG *ncmat_, ITG *nstate_, ITG *iumat,
+                       double *cs, ITG *mcs, ITG *nkon, double **ener, ITG *mpcinfo,
+                       char *  output,
+                       double *shcon, ITG *nshcon, double *cocon, ITG *ncocon,
+                       double *physcon, ITG *nflow, double *ctrl,
+                       char *set, ITG *nset, ITG *istartset,
+                       ITG *iendset, ITG *ialset, ITG *nprint, char *prlab,
+                       char *prset, ITG *nener, ITG *ikforc, ITG *ilforc, double *trab,
+                       ITG *inotr, ITG *ntrans, double **fmpcp, char *cbody,
+                       ITG *ibody, double *xbody, ITG *nbody, double *xbodyold,
+                       ITG *ielprop, double *prop, ITG *ntie, char *tieset,
+                       ITG *itpamp, ITG *iviewfile, char *jobnamec, double *tietol,
+                       ITG *nslavs, double *thicke, ITG *ics,
+                       ITG *nintpoint, ITG *mortar, ITG *ifacecount, char *typeboun,
+                       ITG **islavsurfp, double **pslavsurfp, double **clearinip,
+                       ITG *nmat, double *xmodal, ITG *iaxial, ITG *inext, ITG *nprop,
+                       ITG *network, char *orname, double *vel, ITG *nef,
+                       double *velo, double *veloo, double *energy, ITG *itempuser,
+                       ITG *ipobody, ITG *inewton, double *t0g, double *t1g,
+                       ITG *ifreebody, char *preciceParticipantName, char *configFilename);
 
-void FORTRAN(nonlinmpc,(double *co,double *vold,ITG *ipompc,ITG *nodempc,
-			double *coefmpc,char *labmpc,ITG *nmpc,ITG *ikboun,
-			ITG *ilboun,ITG *nboun,double *xbounact,double *aux,
-			ITG *iaux,ITG *maxlenmpc,ITG *ikmpc,ITG *ilmpc,
-			ITG *icascade,ITG *kon,ITG *ipkon,char *lakon,
-			ITG *ne,double *reltime,ITG *newstep,double *xboun,
-			double *fmpc,ITG *newinc,ITG *idiscon,ITG *ncont,
-			double *trab,ITG *ntrans,ITG *ithermal,ITG *mi,
-			ITG *kchdep));
+void FORTRAN(nonlinmpc, (double *co, double *vold, ITG *ipompc, ITG *nodempc,
+                         double *coefmpc, char *labmpc, ITG *nmpc, ITG *ikboun,
+                         ITG *ilboun, ITG *nboun, double *xbounact, double *aux,
+                         ITG *iaux, ITG *maxlenmpc, ITG *ikmpc, ITG *ilmpc,
+                         ITG *icascade, ITG *kon, ITG *ipkon, char *lakon,
+                         ITG *ne, double *reltime, ITG *newstep, double *xboun,
+                         double *fmpc, ITG *newinc, ITG *idiscon, ITG *ncont,
+                         double *trab, ITG *ntrans, ITG *ithermal, ITG *mi,
+                         ITG *kchdep));
 
-void FORTRAN(norm,(double *vel,double *velnorm,ITG *nef));
+void FORTRAN(norm, (double *vel, double *velnorm, ITG *nef));
 
-void FORTRAN(normmpc,(ITG *nmpc,ITG *ipompc,ITG *nodempc,double *coefmpc,
-		      ITG *inomat,double *coefmodmpc,ITG *ikboun,ITG *nboun));
+void FORTRAN(normmpc, (ITG * nmpc, ITG *ipompc, ITG *nodempc, double *coefmpc,
+                       ITG *inomat, double *coefmodmpc, ITG *ikboun, ITG *nboun));
 
-void FORTRAN(normalsforequ_se,(ITG *nk,double *co,ITG *iponoelfa,
-                               ITG *inoelfa,ITG *konfa,ITG *ipkonfa,
-                               char *lakonfa,ITG *ne,ITG *ipnor,
-                               double *xnor,ITG *nodedesiinv,char *jobnamef,
-                               ITG *iponexp,ITG *nmpc,char *labmpc,
-                               ITG *ipompc,ITG *nodempc,ITG *ipretinfo,
-                               ITG *kon,ITG *ipkon,char *lakon,ITG *iponoel,
-                               ITG *inoel,ITG *iponor2d,ITG *knor2d,
-                               ITG *iponod2dto3d,ITG *ipoface,ITG *nodeface));
+void FORTRAN(normalsforequ_se, (ITG * nk, double *co, ITG *iponoelfa,
+                                ITG *inoelfa, ITG *konfa, ITG *ipkonfa,
+                                char *lakonfa, ITG *ne, ITG *ipnor,
+                                double *xnor, ITG *nodedesiinv, char *jobnamef,
+                                ITG *iponexp, ITG *nmpc, char *labmpc,
+                                ITG *ipompc, ITG *nodempc, ITG *ipretinfo,
+                                ITG *kon, ITG *ipkon, char *lakon, ITG *iponoel,
+                                ITG *inoel, ITG *iponor2d, ITG *knor2d,
+                                ITG *iponod2dto3d, ITG *ipoface, ITG *nodeface));
 
-void FORTRAN(normalsoninterface,(ITG *istartset,ITG *iendset,
-             ITG *ialset,ITG *imast,ITG *ipkon,ITG *kon,char *lakon,
-             ITG *imastnode,ITG *nmastnode,double *xmastnor,double *co));
+void FORTRAN(normalsoninterface, (ITG * istartset, ITG *iendset,
+                                  ITG *ialset, ITG *imast, ITG *ipkon, ITG *kon, char *lakon,
+                                  ITG *imastnode, ITG *nmastnode, double *xmastnor, double *co));
 
-void FORTRAN(normalsonsurface_se,(ITG *ipkon,ITG *kon,char*lakon,
-             double *extnor,double *co,ITG *nk,ITG *ipoface,
-             ITG *nodface,ITG *nactdof,ITG *mi,ITG *nodedesiinv,
-             ITG *iregion,ITG *iponoelfa,ITG *ndesi,ITG *nodedesi,
-             ITG *iponod2dto3d,ITG *ikboun,ITG *nboun,ITG *ne2d));
+void FORTRAN(normalsonsurface_se, (ITG * ipkon, ITG *kon, char *lakon,
+                                   double *extnor, double *co, ITG *nk, ITG *ipoface,
+                                   ITG *nodface, ITG *nactdof, ITG *mi, ITG *nodedesiinv,
+                                   ITG *iregion, ITG *iponoelfa, ITG *ndesi, ITG *nodedesi,
+                                   ITG *iponod2dto3d, ITG *ikboun, ITG *nboun, ITG *ne2d));
 
-void FORTRAN(normalsonsurface_robust,(ITG *ipkon,ITG *kon,char *lakon,
-				      double *extnor,double *co,ITG *nk,
-				      ITG *ipoface,ITG *nodface,ITG *nactdof,
-				      ITG *mi,ITG *nodedesiinv,ITG *iregion,
-				      ITG *iponoelfa,ITG *ndesi,ITG *nodedesi,
-				      ITG *iponod2dto3d,ITG *ikboun,ITG *nboun,
-				      ITG *ne2d)); 
+void FORTRAN(normalsonsurface_robust, (ITG * ipkon, ITG *kon, char *lakon,
+                                       double *extnor, double *co, ITG *nk,
+                                       ITG *ipoface, ITG *nodface, ITG *nactdof,
+                                       ITG *mi, ITG *nodedesiinv, ITG *iregion,
+                                       ITG *iponoelfa, ITG *ndesi, ITG *nodedesi,
+                                       ITG *iponod2dto3d, ITG *ikboun, ITG *nboun,
+                                       ITG *ne2d));
 
-void FORTRAN(objective_disp_tot,(double *dgdx,double *df,ITG *ndesi,
-                                 ITG *iobject,ITG *jqs,ITG *irows,
-                                 double *dgdu));
+void FORTRAN(objective_disp_tot, (double *dgdx, double *df, ITG *ndesi,
+                                  ITG *iobject, ITG *jqs, ITG *irows,
+                                  double *dgdu));
 
-void objectivemain_se(double *co,ITG *nk,ITG *kon,ITG *ipkon,char *lakon,
-             ITG *ne,double *v,double *stn,ITG *inum,
-             double *stx,
-             double *elcon,ITG *nelcon,double *rhcon,ITG *nrhcon,
-             double *alcon,ITG *nalcon,double *alzero,ITG *ielmat,
-             ITG *ielorien,ITG *norien,double *orab,ITG *ntmat_,
-             double *t0,double *t1,ITG *ithermal,double *prestr,
-             ITG *iprestr,char *filab,double *eme,double *emn,
-             double *een,ITG *iperturb,double *f,double *fn,ITG *nactdof,
-             ITG *iout,double *qa,
-             double *vold,ITG *nodeboun,ITG *ndirboun,
-             double *xboun,ITG *nboun,ITG *ipompc,ITG *nodempc,
-             double *coefmpc,char *labmpc,ITG *nmpc,ITG *nmethod,
-             double *cam,ITG *neq,double *veold,double *accold,
-             double *bet,double *gam,double *dtime,double *time,
-             double *ttime,double *plicon,
-             ITG *nplicon,double *plkcon,ITG *nplkcon,
-             double *xstateini,double *xstiff,double *xstate,ITG *npmat_,
-             double *epn,char *matname,ITG *mi,ITG *ielas,
-             ITG *icmd,ITG *ncmat_,ITG *nstate_,double *stiini,
-             double *vini,ITG *ikboun,ITG *ilboun,double *ener,
-             double *enern,double *emeini,double *xstaten,double *eei,
-             double *enerini,double *cocon,ITG *ncocon,char *set,
-             ITG *nset,ITG *istartset,
-             ITG *iendset,ITG *ialset,ITG *nprint,char *prlab,
-             char *prset,double *qfx,double *qfn,double *trab,
-             ITG *inotr,ITG *ntrans,double *fmpc,ITG *nelemload,
-             ITG *nload,ITG *ikmpc,ITG *ilmpc,ITG *istep,ITG *iinc,
-             double *springarea,double *reltime,ITG *ne0,double *xforc,
-             ITG *nforc,double *thicke,
-             double *shcon,ITG *nshcon,char *sideload,double *xload,
-             double *xloadold,ITG *icfd,ITG *inomat,double *pslavsurf,
-             double *pmastsurf,ITG *mortar,ITG *islavact,double *cdn,
-             ITG *islavnode,ITG *nslavnode,ITG *ntie,double *clearini,
-             ITG *islavsurf,ITG *ielprop,double *prop,double *energyini,
-             double *energy,double *distmin,
-             ITG *ndesi,ITG *nodedesi,ITG *nobject,
-             char *objectset,double *g0,double *dgdx,double *sti,
-             double *df,ITG *nactdofinv,ITG *jqs,ITG *irows,
-             ITG *idisplacement,ITG *nzs,char *jobnamec,ITG *isolver,
-             ITG *icol,ITG *irow,ITG *jq,ITG *kode,double *cs,char *output,
-             ITG *istartdesi,ITG *ialdesi,double *xdesi,char *orname,
-             ITG *icoordinate,ITG *iev,double *d,double *z,double *au,
-             double *ad,double *aub,double *adb,ITG *cyclicsymmetry,
-             ITG *nzss,ITG *nev,ITG *ishapeenergy,double *fint,
-             ITG *nlabel,ITG *igreen,ITG *nasym,ITG *iponoel,ITG *inoel,
-             ITG *nodedesiinv,double *dgdxglob,
-             ITG *nkon,ITG *iponod2dto3d,ITG *iponk2dto3d,ITG *ics,
-             ITG *mcs,ITG *mpcend,ITG *noddiam,ITG *ipobody,ITG *ibody,
-	     double *xbody,ITG *nbody,ITG *nobjectstart,double *dfm);
+void objectivemain_se(double *co, ITG *nk, ITG *kon, ITG *ipkon, char *lakon,
+                      ITG *ne, double *v, double *stn, ITG *inum,
+                      double *stx,
+                      double *elcon, ITG *nelcon, double *rhcon, ITG *nrhcon,
+                      double *alcon, ITG *nalcon, double *alzero, ITG *ielmat,
+                      ITG *ielorien, ITG *norien, double *orab, ITG *ntmat_,
+                      double *t0, double *t1, ITG *ithermal, double *prestr,
+                      ITG *iprestr, char *filab, double *eme, double *emn,
+                      double *een, ITG *iperturb, double *f, double *fn, ITG *nactdof,
+                      ITG *iout, double *qa,
+                      double *vold, ITG *nodeboun, ITG *ndirboun,
+                      double *xboun, ITG *nboun, ITG *ipompc, ITG *nodempc,
+                      double *coefmpc, char *labmpc, ITG *nmpc, ITG *nmethod,
+                      double *cam, ITG *neq, double *veold, double *accold,
+                      double *bet, double *gam, double *dtime, double *time,
+                      double *ttime, double *plicon,
+                      ITG *nplicon, double *plkcon, ITG *nplkcon,
+                      double *xstateini, double *xstiff, double *xstate, ITG *npmat_,
+                      double *epn, char *matname, ITG *mi, ITG *ielas,
+                      ITG *icmd, ITG *ncmat_, ITG *nstate_, double *stiini,
+                      double *vini, ITG *ikboun, ITG *ilboun, double *ener,
+                      double *enern, double *emeini, double *xstaten, double *eei,
+                      double *enerini, double *cocon, ITG *ncocon, char *set,
+                      ITG *nset, ITG *istartset,
+                      ITG *iendset, ITG *ialset, ITG *nprint, char *prlab,
+                      char *prset, double *qfx, double *qfn, double *trab,
+                      ITG *inotr, ITG *ntrans, double *fmpc, ITG *nelemload,
+                      ITG *nload, ITG *ikmpc, ITG *ilmpc, ITG *istep, ITG *iinc,
+                      double *springarea, double *reltime, ITG *ne0, double *xforc,
+                      ITG *nforc, double *thicke,
+                      double *shcon, ITG *nshcon, char *sideload, double *xload,
+                      double *xloadold, ITG *icfd, ITG *inomat, double *pslavsurf,
+                      double *pmastsurf, ITG *mortar, ITG *islavact, double *cdn,
+                      ITG *islavnode, ITG *nslavnode, ITG *ntie, double *clearini,
+                      ITG *islavsurf, ITG *ielprop, double *prop, double *energyini,
+                      double *energy, double *distmin,
+                      ITG *ndesi, ITG *nodedesi, ITG *nobject,
+                      char *objectset, double *g0, double *dgdx, double *sti,
+                      double *df, ITG *nactdofinv, ITG *jqs, ITG *irows,
+                      ITG *idisplacement, ITG *nzs, char *jobnamec, ITG *isolver,
+                      ITG *icol, ITG *irow, ITG *jq, ITG *kode, double *cs, char *output,
+                      ITG *istartdesi, ITG *ialdesi, double *xdesi, char *orname,
+                      ITG *icoordinate, ITG *iev, double *d, double *z, double *au,
+                      double *ad, double *aub, double *adb, ITG *cyclicsymmetry,
+                      ITG *nzss, ITG *nev, ITG *ishapeenergy, double *fint,
+                      ITG *nlabel, ITG *igreen, ITG *nasym, ITG *iponoel, ITG *inoel,
+                      ITG *nodedesiinv, double *dgdxglob,
+                      ITG *nkon, ITG *iponod2dto3d, ITG *iponk2dto3d, ITG *ics,
+                      ITG *mcs, ITG *mpcend, ITG *noddiam, ITG *ipobody, ITG *ibody,
+                      double *xbody, ITG *nbody, ITG *nobjectstart, double *dfm);
 
 void *objectivemt_shapeener_dx(ITG *i);
 
 void *objectivemt_mass_dx(ITG *i);
 
-void FORTRAN(objective_disp,(ITG *nodeset,ITG *istartset,ITG *iendset,
-             ITG *ialset,ITG *nk,ITG *idesvar,ITG *iobject,ITG *mi,
-             double *g0,ITG *nobject,double *vold,char *objectset));
+void FORTRAN(objective_disp, (ITG * nodeset, ITG *istartset, ITG *iendset,
+                              ITG *ialset, ITG *nk, ITG *idesvar, ITG *iobject, ITG *mi,
+                              double *g0, ITG *nobject, double *vold, char *objectset));
 
-void FORTRAN(objective_disp_dx,(ITG *nodeset,ITG *istartset,ITG *iendset,
-             ITG *ialset,ITG *nk,ITG *idesvar,ITG *iobject,ITG *mi,
-             ITG *nactdof,double *dgdx,ITG *ndesi,ITG *nobject,
-             double *vold,double *b,char *objectset));
+void FORTRAN(objective_disp_dx, (ITG * nodeset, ITG *istartset, ITG *iendset,
+                                 ITG *ialset, ITG *nk, ITG *idesvar, ITG *iobject, ITG *mi,
+                                 ITG *nactdof, double *dgdx, ITG *ndesi, ITG *nobject,
+                                 double *vold, double *b, char *objectset));
 
-void FORTRAN(objective_freq,(double *dgdx,double *df,double *vold,
-             ITG *ndesi,ITG *iobject,ITG *mi,ITG *nactdofinv,ITG *jqs,
-             ITG *irows));
+void FORTRAN(objective_freq, (double *dgdx, double *df, double *vold,
+                              ITG *ndesi, ITG *iobject, ITG *mi, ITG *nactdofinv, ITG *jqs,
+                              ITG *irows));
 
-void FORTRAN(objective_freq_cs,(double *dgdx,double *df,double *vold,
-             ITG *ndesi,ITG *iobject,ITG *mi,ITG *nactdofinv,ITG *jqs,
-             ITG *irows,ITG *nk,ITG *nzss));
+void FORTRAN(objective_freq_cs, (double *dgdx, double *df, double *vold,
+                                 ITG *ndesi, ITG *iobject, ITG *mi, ITG *nactdofinv, ITG *jqs,
+                                 ITG *irows, ITG *nk, ITG *nzss));
 
-void FORTRAN(objective_mass_dx,(double *co1,ITG *kon1,ITG *ipkon1,char *lakon1,
-             ITG *nelcon1,double *rhcon1,ITG *ielmat1,
-             ITG *ielorien1,ITG *norien1,ITG *ntmat1_,
-             char *matname1,ITG *mi1,double *thicke1,ITG *mortar1,ITG *nea,
-             ITG *neb,ITG *ielprop1,double *prop1,double *distmin1,
-             ITG *ndesi1,ITG *nodedesi1,ITG *nobject1,
-             double *g01,double *dgdx1,ITG *iobject1,double *xmass1,
-             ITG *istartdesi1,ITG *ialdesi1,double *xdesi1,ITG *idesvar));
+void FORTRAN(objective_mass_dx, (double *co1, ITG *kon1, ITG *ipkon1, char *lakon1,
+                                 ITG *nelcon1, double *rhcon1, ITG *ielmat1,
+                                 ITG *ielorien1, ITG *norien1, ITG *ntmat1_,
+                                 char *matname1, ITG *mi1, double *thicke1, ITG *mortar1, ITG *nea,
+                                 ITG *neb, ITG *ielprop1, double *prop1, double *distmin1,
+                                 ITG *ndesi1, ITG *nodedesi1, ITG *nobject1,
+                                 double *g01, double *dgdx1, ITG *iobject1, double *xmass1,
+                                 ITG *istartdesi1, ITG *ialdesi1, double *xdesi1, ITG *idesvar));
 
-void FORTRAN(objective_modalstress,(ITG *ndesi,ITG *neq,double *b,
-				    double *daldx,double *bfix,ITG *jqs,
-				    ITG *irows,double *df,ITG *iev,ITG *nev,
-				    double *z,double *dgduz,double *d,
-				    ITG *iobject,double *dgdx,double *dfm));
+void FORTRAN(objective_modalstress, (ITG * ndesi, ITG *neq, double *b,
+                                     double *daldx, double *bfix, ITG *jqs,
+                                     ITG *irows, double *df, ITG *iev, ITG *nev,
+                                     double *z, double *dgduz, double *d,
+                                     ITG *iobject, double *dgdx, double *dfm));
 
-void FORTRAN(objective_shapeener_dx,(double *co1,ITG *kon1,ITG *ipkon1,
-             char *lakon1,ITG *ne1,double *stx1,double *elcon1,
-             ITG *nelcon1,double *rhcon1,ITG *nrhcon1,double *alcon1,
-             ITG *nalcon1,double *alzero1,ITG *ielmat1,ITG *ielorien1,
-             ITG *norien1,double *orab1,ITG *ntmat1_,double *t01,
-             double *t11,ITG *ithermal1,double *prestr1,ITG *iprestr1,
-             ITG *iperturb1,ITG *iout1,double *vold1,ITG *nmethod1,
-             double *veold1,double *dtime1,double *time1,double *ttime1,
-             double *plicon1,ITG *nplicon1,double *plkcon1,ITG *nplkcon1,
-             double *xstateini1,double *xstiff1,double *xstate1,
-             ITG *npmat1_,char *matname1,ITG *mi1,ITG *ielas1,ITG *icmd1,
-             ITG *ncmat1_,ITG *nstate1_,double *stiini1,double *vini1,
-             double *ener1,double *enerini1,ITG *istep1,ITG *iinc1,
-             double *springarea1,double *reltime1,ITG *calcul_qa1,
-             ITG *iener1,ITG *ikin1,ITG *ne01,double *thicke1,
-             double *emeini1,double *pslavsurf1,double *pmastsurf1,
-             ITG *mortar1,double *clearini1,ITG *nea,ITG *neb,
-             ITG *ielprop1,double *prop1,double *distmin1,ITG *ndesi1,
-             ITG *nodedesi1,ITG *nobject1,double *g01,
-             double *dgdx1,ITG *iobject1,double *sti1,double *xener1,
-             ITG *istartdesi1,ITG *ialdesi1,double *xdesi1,ITG *idesvar));
+void FORTRAN(objective_shapeener_dx, (double *co1, ITG *kon1, ITG *ipkon1,
+                                      char *lakon1, ITG *ne1, double *stx1, double *elcon1,
+                                      ITG *nelcon1, double *rhcon1, ITG *nrhcon1, double *alcon1,
+                                      ITG *nalcon1, double *alzero1, ITG *ielmat1, ITG *ielorien1,
+                                      ITG *norien1, double *orab1, ITG *ntmat1_, double *t01,
+                                      double *t11, ITG *ithermal1, double *prestr1, ITG *iprestr1,
+                                      ITG *iperturb1, ITG *iout1, double *vold1, ITG *nmethod1,
+                                      double *veold1, double *dtime1, double *time1, double *ttime1,
+                                      double *plicon1, ITG *nplicon1, double *plkcon1, ITG *nplkcon1,
+                                      double *xstateini1, double *xstiff1, double *xstate1,
+                                      ITG *npmat1_, char *matname1, ITG *mi1, ITG *ielas1, ITG *icmd1,
+                                      ITG *ncmat1_, ITG *nstate1_, double *stiini1, double *vini1,
+                                      double *ener1, double *enerini1, ITG *istep1, ITG *iinc1,
+                                      double *springarea1, double *reltime1, ITG *calcul_qa1,
+                                      ITG *iener1, ITG *ikin1, ITG *ne01, double *thicke1,
+                                      double *emeini1, double *pslavsurf1, double *pmastsurf1,
+                                      ITG *mortar1, double *clearini1, ITG *nea, ITG *neb,
+                                      ITG *ielprop1, double *prop1, double *distmin1, ITG *ndesi1,
+                                      ITG *nodedesi1, ITG *nobject1, double *g01,
+                                      double *dgdx1, ITG *iobject1, double *sti1, double *xener1,
+                                      ITG *istartdesi1, ITG *ialdesi1, double *xdesi1, ITG *idesvar));
 
-void FORTRAN(objective_shapeener_tot,(ITG *ne,ITG *kon,ITG *ipkon,char *lakon,
-             double *fint,double *vold,ITG *iperturb,ITG *mi,ITG *nactdof,
-             double *dgdx,double *df,ITG *ndesi,ITG *iobject,ITG *jqs,
-             ITG *irows,double *vec,ITG *iponk2dto3d));
+void FORTRAN(objective_shapeener_tot, (ITG * ne, ITG *kon, ITG *ipkon, char *lakon,
+                                       double *fint, double *vold, ITG *iperturb, ITG *mi, ITG *nactdof,
+                                       double *dgdx, double *df, ITG *ndesi, ITG *iobject, ITG *jqs,
+                                       ITG *irows, double *vec, ITG *iponk2dto3d));
 
-void FORTRAN(objective_peeq,(ITG *nodeset,ITG *istartset,ITG *iendset,
-             ITG *ialset,ITG *nk,ITG *idesvar,ITG *iobject,ITG *mi,
-             double *g0,ITG *nobject,double *epn,char *objectset,
-             double *expks));
+void FORTRAN(objective_peeq, (ITG * nodeset, ITG *istartset, ITG *iendset,
+                              ITG *ialset, ITG *nk, ITG *idesvar, ITG *iobject, ITG *mi,
+                              double *g0, ITG *nobject, double *epn, char *objectset,
+                              double *expks));
 
-void FORTRAN(objective_peeq_se,(ITG *nk,ITG *iobject,ITG *mi,double *depn,
-             char *objectset,ITG *ialnneigh,ITG *naneigh,ITG *nbneigh,
-             double *epn,double *dksper));
+void FORTRAN(objective_peeq_se, (ITG * nk, ITG *iobject, ITG *mi, double *depn,
+                                 char *objectset, ITG *ialnneigh, ITG *naneigh, ITG *nbneigh,
+                                 double *epn, double *dksper));
 
-void FORTRAN(objective_stress,(ITG *nodeset,ITG *istartset,ITG *iendset,
-             ITG *ialset,ITG *nk,ITG *idesvar,ITG *iobject,ITG *mi,
-             double *g0,ITG *nobject,double *stn,char *objectset,
-             double *expks));
+void FORTRAN(objective_stress, (ITG * nodeset, ITG *istartset, ITG *iendset,
+                                ITG *ialset, ITG *nk, ITG *idesvar, ITG *iobject, ITG *mi,
+                                double *g0, ITG *nobject, double *stn, char *objectset,
+                                double *expks));
 
-void FORTRAN(objective_stress_dx_dy,(ITG *nodeset,ITG *istartset,ITG *iendset,
-             ITG *ialset,ITG *nk,ITG *idesvar1,ITG *idesvar2,ITG *iobject,
-             double *dgdx,ITG *ndesi,ITG *nobject,double *stn,double *dstn1,
-             double *dstn2,double *dstn12,char *objectset,double *g0,
-             double *dgdxdy));
+void FORTRAN(objective_stress_dx_dy, (ITG * nodeset, ITG *istartset, ITG *iendset,
+                                      ITG *ialset, ITG *nk, ITG *idesvar1, ITG *idesvar2, ITG *iobject,
+                                      double *dgdx, ITG *ndesi, ITG *nobject, double *stn, double *dstn1,
+                                      double *dstn2, double *dstn12, char *objectset, double *g0,
+                                      double *dgdxdy));
 
-void FORTRAN(objective_stress_se,(ITG *nk,ITG *iobject,ITG *mi,double *dstn,
-             char *objectset,ITG *ialnneigh,ITG *naneigh,ITG *nbneigh,
-             double *stn,double *dksper));
-              
-void FORTRAN(objective_stress_tot,(double *dgdx,double *df,ITG *ndesi,
-                                   ITG *iobject,ITG *jqs,ITG *irows,
-                                   double *dgdu));
+void FORTRAN(objective_stress_se, (ITG * nk, ITG *iobject, ITG *mi, double *dstn,
+                                   char *objectset, ITG *ialnneigh, ITG *naneigh, ITG *nbneigh,
+                                   double *stn, double *dksper));
 
-void FORTRAN(op,(ITG *n,double *x,double *y,double *ad,double *au,ITG *jq,ITG *irow));
+void FORTRAN(objective_stress_tot, (double *dgdx, double *df, ITG *ndesi,
+                                    ITG *iobject, ITG *jqs, ITG *irows,
+                                    double *dgdu));
 
-void FORTRAN(opas,(ITG *n,double *x,double *y,double *ad,double *au,ITG *jq,
-                   ITG *irow,ITG *nzs));
+void FORTRAN(op, (ITG * n, double *x, double *y, double *ad, double *au, ITG *jq, ITG *irow));
 
-void FORTRAN(op_corio,(ITG *n,double *x,double *y,double *ad,double *au,
-                       ITG *jq,ITG *irow));
+void FORTRAN(opas, (ITG * n, double *x, double *y, double *ad, double *au, ITG *jq,
+                    ITG *irow, ITG *nzs));
 
-void FORTRAN(openfile,(char *jobname));
+void FORTRAN(op_corio, (ITG * n, double *x, double *y, double *ad, double *au,
+                        ITG *jq, ITG *irow));
 
-void FORTRAN(openfilefluidfem,(char *jobname));
+void FORTRAN(openfile, (char *jobname));
 
-void FORTRAN(paracfd,(double *b,ITG *irowcpu,ITG *jqcpu,ITG *num_cpus,
-		      ITG *nk,ITG *idofa,ITG *idofb,ITG *nka,ITG *nkb,
-		      ITG *idima,ITG *idimb));
+void FORTRAN(openfilefluidfem, (char *jobname));
+
+void FORTRAN(paracfd, (double *b, ITG *irowcpu, ITG *jqcpu, ITG *num_cpus,
+                       ITG *nk, ITG *idofa, ITG *idofb, ITG *nka, ITG *nkb,
+                       ITG *idima, ITG *idimb));
 
 void *paracfdmt(ITG *i);
 
-void peeq_sen_dx(double *co,ITG *nk,ITG *kon,ITG *ipkon,char *lakon,ITG *ne,
-       double *depn,double *elcon,ITG *nelcon,
-       double *rhcon,ITG *nrhcon,double *alcon,ITG *nalcon,double *alzero,
-       ITG *ielmat,ITG *ielorien,ITG *norien,double *orab,ITG *ntmat_,
-       double *t0,double *t1,ITG *ithermal,double *prestr,ITG *iprestr,
-       char *filab,ITG *iperturb,double *vold,ITG *nmethod,double *dtime, 
-       double *time,double *ttime,double *plicon,ITG *nplicon,double *plkcon,
-       ITG *nplkcon,double *xstateini,double *dxstate,ITG *npmat_,char *matname,
-       ITG *mi,ITG *ielas,ITG *ncmat_,ITG *nstate_,double *stiini,double *vini,
-       double *emeini,double *enerini,ITG *istep,ITG *iinc,double *springarea,
-       double *reltime,ITG *ne0,double *thicke,double *pslavsurf,
-       double *pmastsurf,ITG *mortar,double *clearini,ITG *ielprop,double *prop,
-       ITG *kscale,ITG *iobject,char *objectset,double *g0,double *dgdx,
-       ITG *nea,ITG *neb,ITG *nasym,double *distmin,ITG*idesvar,double *stx, 
-       ITG *ialdesi,ITG *ialeneigh,ITG *neaneigh,ITG *nebneigh,ITG *ialnneigh,
-       ITG *naneigh,ITG *nbneigh,double *epn,double *expks,ITG *ndesi);
+void peeq_sen_dx(double *co, ITG *nk, ITG *kon, ITG *ipkon, char *lakon, ITG *ne,
+                 double *depn, double *elcon, ITG *nelcon,
+                 double *rhcon, ITG *nrhcon, double *alcon, ITG *nalcon, double *alzero,
+                 ITG *ielmat, ITG *ielorien, ITG *norien, double *orab, ITG *ntmat_,
+                 double *t0, double *t1, ITG *ithermal, double *prestr, ITG *iprestr,
+                 char *filab, ITG *iperturb, double *vold, ITG *nmethod, double *dtime,
+                 double *time, double *ttime, double *plicon, ITG *nplicon, double *plkcon,
+                 ITG *nplkcon, double *xstateini, double *dxstate, ITG *npmat_, char *matname,
+                 ITG *mi, ITG *ielas, ITG *ncmat_, ITG *nstate_, double *stiini, double *vini,
+                 double *emeini, double *enerini, ITG *istep, ITG *iinc, double *springarea,
+                 double *reltime, ITG *ne0, double *thicke, double *pslavsurf,
+                 double *pmastsurf, ITG *mortar, double *clearini, ITG *ielprop, double *prop,
+                 ITG *kscale, ITG *iobject, char *objectset, double *g0, double *dgdx,
+                 ITG *nea, ITG *neb, ITG *nasym, double *distmin, ITG *idesvar, double *stx,
+                 ITG *ialdesi, ITG *ialeneigh, ITG *neaneigh, ITG *nebneigh, ITG *ialnneigh,
+                 ITG *naneigh, ITG *nbneigh, double *epn, double *expks, ITG *ndesi);
 
 void *peeq_sen_dxmt(ITG *i);
 
-void peeq_sen_dv(double *co,ITG *nk,ITG *kon,ITG *ipkon,char *lakon,ITG *ne,
-       double *depn,double *elcon,ITG *nelcon,
-       double *rhcon,ITG *nrhcon,double *alcon,ITG *nalcon,double *alzero,
-       ITG *ielmat,ITG *ielorien,ITG *norien,double *orab,ITG *ntmat_,
-       double *t0,double *t1,ITG *ithermal,double *prestr,ITG *iprestr,
-       char *filab,ITG *iperturb,double *dv,ITG *nmethod,double *dtime,
-       double *time,double *ttime,double *plicon,ITG *nplicon,double *plkcon,
-       ITG *nplkcon,double *xstateini,double *dxstate,ITG *npmat_,char *matname,
-       ITG *mi,ITG *ielas,ITG *ncmat_,ITG *nstate_,double *stiini,double *vini,
-       double *emeini,double *enerini,ITG *istep,ITG *iinc,double *springarea,
-       double *reltime,ITG *ne0,double *thicke,double *pslavsurf,
-       double *pmastsurf,ITG *mortar,double *clearini,ITG *ielprop,
-       double *prop, 
-       ITG *kscale,ITG *iobject,double *g0,ITG *nea,ITG *neb,ITG *nasym,
-       double *distmin,double *stx,ITG *ialnk,double *dgdu,ITG *ialeneigh, 
-       ITG *neaneigh,ITG *nebneigh,ITG *ialnneigh,ITG *naneigh,ITG *nbneigh,
-       double *epn,double *expks,char *objectset,ITG *idof,ITG *node,
-       ITG *idir,double *vold,double *dispmin);       
+void peeq_sen_dv(double *co, ITG *nk, ITG *kon, ITG *ipkon, char *lakon, ITG *ne,
+                 double *depn, double *elcon, ITG *nelcon,
+                 double *rhcon, ITG *nrhcon, double *alcon, ITG *nalcon, double *alzero,
+                 ITG *ielmat, ITG *ielorien, ITG *norien, double *orab, ITG *ntmat_,
+                 double *t0, double *t1, ITG *ithermal, double *prestr, ITG *iprestr,
+                 char *filab, ITG *iperturb, double *dv, ITG *nmethod, double *dtime,
+                 double *time, double *ttime, double *plicon, ITG *nplicon, double *plkcon,
+                 ITG *nplkcon, double *xstateini, double *dxstate, ITG *npmat_, char *matname,
+                 ITG *mi, ITG *ielas, ITG *ncmat_, ITG *nstate_, double *stiini, double *vini,
+                 double *emeini, double *enerini, ITG *istep, ITG *iinc, double *springarea,
+                 double *reltime, ITG *ne0, double *thicke, double *pslavsurf,
+                 double *pmastsurf, ITG *mortar, double *clearini, ITG *ielprop,
+                 double *prop,
+                 ITG *kscale, ITG *iobject, double *g0, ITG *nea, ITG *neb, ITG *nasym,
+                 double *distmin, double *stx, ITG *ialnk, double *dgdu, ITG *ialeneigh,
+                 ITG *neaneigh, ITG *nebneigh, ITG *ialnneigh, ITG *naneigh, ITG *nbneigh,
+                 double *epn, double *expks, char *objectset, ITG *idof, ITG *node,
+                 ITG *idir, double *vold, double *dispmin);
 
 void *peeq_sen_dvmt(ITG *i);
 
-void FORTRAN(postprojectgrad,(ITG *ndesi,ITG *nodedesi,double *dgdxglob,
-                              ITG *nactive,ITG *nobject,ITG *nnlconst,
-                              ITG *ipoacti,ITG *nk,char *objectset,
-                              ITG *inameacti));
+void FORTRAN(postprojectgrad, (ITG * ndesi, ITG *nodedesi, double *dgdxglob,
+                               ITG *nactive, ITG *nobject, ITG *nnlconst,
+                               ITG *ipoacti, ITG *nk, char *objectset,
+                               ITG *inameacti));
 
-void FORTRAN(posttransition,(double *dgdxglob,ITG *nobject,ITG *nk,
-             ITG *nodedesi,ITG *ndesi,char *objectset));
+void FORTRAN(posttransition, (double *dgdxglob, ITG *nobject, ITG *nk,
+                              ITG *nodedesi, ITG *ndesi, char *objectset));
 
-void FORTRAN(postview,(ITG *ntr,char *sideload,ITG *nelemload,ITG *kontri,
-             ITG *ntri,ITG *nloadtr,double *tenv,double *adview,double *auview,
-             double *area,double *fenv,ITG *jqrad,ITG *irowrad,ITG *nzsrad));
+void FORTRAN(postview, (ITG * ntr, char *sideload, ITG *nelemload, ITG *kontri,
+                        ITG *ntri, ITG *nloadtr, double *tenv, double *adview, double *auview,
+                        double *area, double *fenv, ITG *jqrad, ITG *irowrad, ITG *nzsrad));
 
-void FORTRAN(preconditioning,(double *ad,double *au,double *b,ITG *neq,
-			      ITG *irow,ITG *jq,double *adaux));
+void FORTRAN(preconditioning, (double *ad, double *au, double *b, ITG *neq,
+                               ITG *irow, ITG *jq, double *adaux));
 
-void FORTRAN(precondrandomfield,(double *auc,ITG *jqc,ITG *irowc,double *rhs,
-				 ITG *idesvar));
+void FORTRAN(precondrandomfield, (double *auc, ITG *jqc, ITG *irowc, double *rhs,
+                                  ITG *idesvar));
 
-void precontact(ITG *ncont,ITG *ntie,char *tieset,ITG *nset,char *set,
-        ITG *istartset,ITG *iendset,ITG *ialset,ITG *itietri,
-        char *lakon,ITG *ipkon,ITG *kon,ITG *koncont,ITG *ne,
-        double *cg,double *straight,double *co,double *vold,
-        ITG *istep,ITG *iinc,ITG *iit,ITG *itiefac,
-        ITG *islavsurf,ITG *islavnode,ITG *imastnode,
-        ITG *nslavnode,ITG *nmastnode,ITG *imastop,ITG *mi,
-        ITG *ipe,ITG *ime,double *tietol,ITG *iflagact,
-        ITG *nintpoint,double **pslavsurfp,double *xmastnor,double *cs,
-        ITG *mcs,ITG *ics,double *clearini,ITG *nslavs);
+void precontact(ITG *ncont, ITG *ntie, char *tieset, ITG *nset, char *set,
+                ITG *istartset, ITG *iendset, ITG *ialset, ITG *itietri,
+                char *lakon, ITG *ipkon, ITG *kon, ITG *koncont, ITG *ne,
+                double *cg, double *straight, double *co, double *vold,
+                ITG *istep, ITG *iinc, ITG *iit, ITG *itiefac,
+                ITG *islavsurf, ITG *islavnode, ITG *imastnode,
+                ITG *nslavnode, ITG *nmastnode, ITG *imastop, ITG *mi,
+                ITG *ipe, ITG *ime, double *tietol, ITG *iflagact,
+                ITG *nintpoint, double **pslavsurfp, double *xmastnor, double *cs,
+                ITG *mcs, ITG *ics, double *clearini, ITG *nslavs);
 
-void FORTRAN(predgmres,(ITG *n,double *b,double *x,ITG *nelt,ITG *ia,ITG *ja,
-             double *a,ITG *isym,ITG *itol,double *tol,ITG *itmax,ITG *iter,
-             double *err,ITG *ierr,ITG *iunit,double *sb,double *sx,
-             double *rgwk,ITG *lrgw,ITG *igwk,ITG *ligw,double *rwork,
-             ITG *iwork));
+void FORTRAN(predgmres, (ITG * n, double *b, double *x, ITG *nelt, ITG *ia, ITG *ja,
+                         double *a, ITG *isym, ITG *itol, double *tol, ITG *itmax, ITG *iter,
+                         double *err, ITG *ierr, ITG *iunit, double *sb, double *sx,
+                         double *rgwk, ITG *lrgw, ITG *igwk, ITG *ligw, double *rwork,
+                         ITG *iwork));
 
-void FORTRAN(predgmres_struct,(ITG *neq,double *b,double *sol,ITG *nelt,
-                               ITG *irow,ITG *jq,double *au,ITG *isym,
-                               ITG *itol,double *tol,ITG *itmax,ITG *iter,double *err,
-                               ITG *ierr,ITG *iunit,double *sb,double *sx,
-                               double *rgwk,ITG *lrgw,ITG *igwk,ITG *ligw,
-                               double *rwork,ITG *iwork));
+void FORTRAN(predgmres_struct, (ITG * neq, double *b, double *sol, ITG *nelt,
+                                ITG *irow, ITG *jq, double *au, ITG *isym,
+                                ITG *itol, double *tol, ITG *itmax, ITG *iter, double *err,
+                                ITG *ierr, ITG *iunit, double *sb, double *sx,
+                                double *rgwk, ITG *lrgw, ITG *igwk, ITG *ligw,
+                                double *rwork, ITG *iwork));
 
-void predgmres_struct_mt(double *ad,double **au,double *adb,double *aub,
-         double *sigma,double *b,ITG *icol,ITG *irow,
-         ITG *neq,ITG *nzs,ITG *symmetryflag,ITG *inputformat,ITG *jq,
-         ITG *nzs3,ITG *nrhs);
+void predgmres_struct_mt(double *ad, double **au, double *adb, double *aub,
+                         double *sigma, double *b, ITG *icol, ITG *irow,
+                         ITG *neq, ITG *nzs, ITG *symmetryflag, ITG *inputformat, ITG *jq,
+                         ITG *nzs3, ITG *nrhs);
 
-void prediction(double *uam,ITG *nmethod,double *bet,double *gam,double *dtime,
-               ITG *ithermal,ITG *nk,double *veold,double *accold,double *v,
-               ITG *iinc,ITG *idiscon,double *vold,ITG *nactdof,ITG *mi,
-               ITG *num_cpus);
+void prediction(double *uam, ITG *nmethod, double *bet, double *gam, double *dtime,
+                ITG *ithermal, ITG *nk, double *veold, double *accold, double *v,
+                ITG *iinc, ITG *idiscon, double *vold, ITG *nactdof, ITG *mi,
+                ITG *num_cpus);
 
-void prediction_em(double *uam,ITG *nmethod,double *bet,double *gam,double *dtime,
-               ITG *ithermal,ITG *nk,double *veold,double *v,
-               ITG *iinc,ITG *idiscon,double *vold,ITG *nactdof,ITG *mi);
+void prediction_em(double *uam, ITG *nmethod, double *bet, double *gam, double *dtime,
+                   ITG *ithermal, ITG *nk, double *veold, double *v,
+                   ITG *iinc, ITG *idiscon, double *vold, ITG *nactdof, ITG *mi);
 
-void FORTRAN(prefilter,(double *co,ITG *nodedesi,ITG *ndesi,double *xo,
-                        double *yo,double *zo,double *x,double *y,
-                        double *z,ITG *nx,ITG *ny,ITG *nz));
+void FORTRAN(prefilter, (double *co, ITG *nodedesi, ITG *ndesi, double *xo,
+                         double *yo, double *zo, double *x, double *y,
+                         double *z, ITG *nx, ITG *ny, ITG *nz));
 
-void preiter(double *ad,double **aup,double *b,ITG **icolp,ITG **irowp,
-             ITG *neq,ITG *nzs,ITG *isolver,ITG *iperturb);
+void preiter(double *ad, double **aup, double *b, ITG **icolp, ITG **irowp,
+             ITG *neq, ITG *nzs, ITG *isolver, ITG *iperturb);
 
-void preparll(ITG *mt,double *dtime,double *veold,double *scal1,
-                   double *accold,double *uam,ITG *nactdof,double *v,
-                   double *vold,double *scal2,ITG *nk,ITG *num_cpus);
+void preparll(ITG *mt, double *dtime, double *veold, double *scal1,
+              double *accold, double *uam, ITG *nactdof, double *v,
+              double *vold, double *scal2, ITG *nk, ITG *num_cpus);
 
 void *preparllmt(ITG *i);
 
-void FORTRAN(preprojectgrad,(double *vector,ITG *ndesi,ITG *nodedesi,
-                             double *dgdxglob,
-                             ITG *nactive,ITG *nobject,ITG *nnlconst,
-                             ITG *ipoacti,ITG *nk,double *rhs,ITG *iconst,
-                             char *objectset,double *xtf));
+void FORTRAN(preprojectgrad, (double *vector, ITG *ndesi, ITG *nodedesi,
+                              double *dgdxglob,
+                              ITG *nactive, ITG *nobject, ITG *nnlconst,
+                              ITG *ipoacti, ITG *nk, double *rhs, ITG *iconst,
+                              char *objectset, double *xtf));
 
-void FORTRAN(presgradient,(ITG *iponoel,ITG *inoel,double *sa,
-            ITG *nk,double *shockcoef,double *dtimef,ITG *ipkon,
-            ITG *kon,char *lakon,double *vold,ITG *mi,
-            ITG *nmethod,ITG *nactdoh,ITG *neqp));
+void FORTRAN(presgradient, (ITG * iponoel, ITG *inoel, double *sa,
+                            ITG *nk, double *shockcoef, double *dtimef, ITG *ipkon,
+                            ITG *kon, char *lakon, double *vold, ITG *mi,
+                            ITG *nmethod, ITG *nactdoh, ITG *neqp));
 
-void FORTRAN(prethickness,(double *co,double *xo,double *yo,
-             double *zo,double *x,double *y,double *z,ITG *nx,ITG *ny,
-             ITG *nz,ITG *ifree,ITG *nodedesiinv,ITG *ndesiboun,
-             ITG *nodedesiboun,char *set,ITG *nset,char *objectset,
-             ITG *iobject,ITG *istartset,ITG *iendset,ITG *ialset));       
+void FORTRAN(prethickness, (double *co, double *xo, double *yo,
+                            double *zo, double *x, double *y, double *z, ITG *nx, ITG *ny,
+                            ITG *nz, ITG *ifree, ITG *nodedesiinv, ITG *ndesiboun,
+                            ITG *nodedesiboun, char *set, ITG *nset, char *objectset,
+                            ITG *iobject, ITG *istartset, ITG *iendset, ITG *ialset));
 
-void FORTRAN(pretransition,(ITG *ipkon,ITG *kon,char *lakon,double *co,
-             ITG *nk,ITG *ipoface,ITG *nodface,ITG *nodedesiinv,double *xo,
-             double *yo,double *zo,double *x,double *y,double *z,ITG *nx,
-             ITG *ny,ITG *nz,ITG *ifree));
-      
-void FORTRAN(printoutebhe,(char *set,ITG *nset,ITG *istartset,ITG *iendset,
-			   ITG *ialset,ITG *nprint,char *prlab,char *prset,
-			   double *t1,ITG *ipkon,char *lakon,double *stx,
-			   double *ener,ITG *mi,ITG *ithermal,double *co,
-			   ITG *kon,double *ttime,ITG *ne,double *vold,
-			   ITG *ielmat,double *thicke,ITG *mortar,double *time,
-			   ITG *ielprop,double *prop,ITG *nelemload,ITG *nload,
-			   char *sideload,double *xload,double *rhcon,
-			   ITG *nrhcon,ITG *ntmat_,ITG *ipobody,ITG *ibody,
-			   double *xbody,ITG *nbody,ITG *nmethod));
+void FORTRAN(pretransition, (ITG * ipkon, ITG *kon, char *lakon, double *co,
+                             ITG *nk, ITG *ipoface, ITG *nodface, ITG *nodedesiinv, double *xo,
+                             double *yo, double *zo, double *x, double *y, double *z, ITG *nx,
+                             ITG *ny, ITG *nz, ITG *ifree));
 
-void FORTRAN(printoutfluidfem,(char *set,ITG *nset,ITG *istartset,ITG *iendset,
-			       ITG *ialset,ITG *nprint,char *prlab,char *prset,
-			       double *v,ITG *ipkon,
-			       char *lakon,double *stx,ITG *mi,
-			       ITG *ithermal,double *co,ITG *kon,
-			       double *qfx,double *ttime,double *trab,
-			       ITG *inotr,ITG *ntrans,double *orab,
-			       ITG *ielorien,ITG *norien,
-			       double *vold,ITG *ielmat,double *thicke,
-			       double *physcon,ITG *ielprop,double *prop,
-			       char *orname,double *vcon,ITG *nk,ITG *nknew,
-			       ITG *nelnew));
+void FORTRAN(printoutebhe, (char *set, ITG *nset, ITG *istartset, ITG *iendset,
+                            ITG *ialset, ITG *nprint, char *prlab, char *prset,
+                            double *t1, ITG *ipkon, char *lakon, double *stx,
+                            double *ener, ITG *mi, ITG *ithermal, double *co,
+                            ITG *kon, double *ttime, ITG *ne, double *vold,
+                            ITG *ielmat, double *thicke, ITG *mortar, double *time,
+                            ITG *ielprop, double *prop, ITG *nelemload, ITG *nload,
+                            char *sideload, double *xload, double *rhcon,
+                            ITG *nrhcon, ITG *ntmat_, ITG *ipobody, ITG *ibody,
+                            double *xbody, ITG *nbody, ITG *nmethod));
 
-void FORTRAN(printoutface,(double *co,double *rhcon,ITG *nrhcon,ITG *ntmat_,
-            double *vold,double *shcon,ITG *nshcon,double *cocon,
-            ITG *ncocon,ITG *compressible,ITG *istartset,ITG *iendset,
-            ITG *ipkon,char *lakon,ITG *kon,ITG *ialset,char *prset,
-            double *timef,ITG *nset,char *set,ITG *nprint,char *prlab,
-            ITG *ielmat,ITG *mi,ITG *ithermal,ITG *nactdoh,ITG *icfd,
-            double *time,double *stn));
+void FORTRAN(printoutfluidfem, (char *set, ITG *nset, ITG *istartset, ITG *iendset,
+                                ITG *ialset, ITG *nprint, char *prlab, char *prset,
+                                double *v, ITG *ipkon,
+                                char *lakon, double *stx, ITG *mi,
+                                ITG *ithermal, double *co, ITG *kon,
+                                double *qfx, double *ttime, double *trab,
+                                ITG *inotr, ITG *ntrans, double *orab,
+                                ITG *ielorien, ITG *norien,
+                                double *vold, ITG *ielmat, double *thicke,
+                                double *physcon, ITG *ielprop, double *prop,
+                                char *orname, double *vcon, ITG *nk, ITG *nknew,
+                                ITG *nelnew));
 
-void printvecnodal2dof(ITG *nk,ITG *mt,ITG *nactdof,double *vecnode);
+void FORTRAN(printoutface, (double *co, double *rhcon, ITG *nrhcon, ITG *ntmat_,
+                            double *vold, double *shcon, ITG *nshcon, double *cocon,
+                            ITG *ncocon, ITG *compressible, ITG *istartset, ITG *iendset,
+                            ITG *ipkon, char *lakon, ITG *kon, ITG *ialset, char *prset,
+                            double *timef, ITG *nset, char *set, ITG *nprint, char *prlab,
+                            ITG *ielmat, ITG *mi, ITG *ithermal, ITG *nactdoh, ITG *icfd,
+                            double *time, double *stn));
 
-void FORTRAN(printoutfacefem,(double *co,ITG *ntmat_,
-			      double *vold,double *shcon,ITG *nshcon,
-			      ITG *compressible,ITG *istartset,ITG *iendset,
-			      ITG *ipkon,char *lakon,ITG *kon,ITG *ialset,
-			      char *prset,double *timef,ITG *nset,char *set,
-			      ITG *nprint,char *prlab,
-			      ITG *ielmat,ITG *mi,ITG *nelnew));
+void printvecnodal2dof(ITG *nk, ITG *mt, ITG *nactdof, double *vecnode);
 
-void FORTRAN(projectgrad,(double *vector,ITG *ndesi,ITG *nodedesi,
-                          double *dgdxglob,
-                          ITG *nactive,ITG *nobject,ITG *nnlconst,
-                          ITG *ipoacti,ITG *nk,double *rhs,ITG *iconst,
-                          char *objectset,double *lambda,double *xtf,
-                          double *objnorm));
+void FORTRAN(printoutfacefem, (double *co, ITG *ntmat_,
+                               double *vold, double *shcon, ITG *nshcon,
+                               ITG *compressible, ITG *istartset, ITG *iendset,
+                               ITG *ipkon, char *lakon, ITG *kon, ITG *ialset,
+                               char *prset, double *timef, ITG *nset, char *set,
+                               ITG *nprint, char *prlab,
+                               ITG *ielmat, ITG *mi, ITG *nelnew));
 
-void projectgradmain(ITG *nobject,char **objectsetp,double **dgdxglobp,
-                     double *g0,ITG *ndesi,ITG *nodedesi,ITG *nk,ITG *isolver,
-                     double *co,double *xdesi,double *distmin,ITG *nconstraint);
+void FORTRAN(projectgrad, (double *vector, ITG *ndesi, ITG *nodedesi,
+                           double *dgdxglob,
+                           ITG *nactive, ITG *nobject, ITG *nnlconst,
+                           ITG *ipoacti, ITG *nk, double *rhs, ITG *iconst,
+                           char *objectset, double *lambda, double *xtf,
+                           double *objnorm));
 
-void FORTRAN(projectnodes,(ITG *nktet_,ITG *ipoed,ITG *iedgmid,
-			   ITG *iexternedg,ITG *iedgext,double *cotet,
-			   ITG *nktet,ITG *iedg,ITG *iquad,ITG *iexternfa,
-			   ITG *ifacext,ITG *itreated,ITG *ilist,ITG *isharp,
-			   ITG *ipofa,ITG *ifac,ITG *iedgextfa,ITG *ifacexted,
-			   ITG *jfix,double *co,ITG *idimsh,ITG *ipoeln,
-			   ITG *ieln,ITG *kontet,double *c1,ITG *iflag));
+void projectgradmain(ITG *nobject, char **objectsetp, double **dgdxglobp,
+                     double *g0, ITG *ndesi, ITG *nodedesi, ITG *nk, ITG *isolver,
+                     double *co, double *xdesi, double *distmin, ITG *nconstraint);
 
-void FORTRAN(projectmidnodes,(ITG *nktet_,ITG *ipoed,ITG *iedgmid,
-			      ITG *iexternedg,ITG *iedgext,double *cotet,
-			      ITG *nktet,ITG *iedg,ITG *iexternfa,
-			      ITG *ifacext,ITG *itreated,ITG *ilist,ITG *isharp,
-			      ITG *ipofa,ITG *ifac,ITG *iedgextfa,
-			      ITG *ifacexted,
-			      ITG *jfix,double *co,ITG *idimsh,ITG *ipoeled,
-			      ITG *ieled,ITG *kontet,double *c1,ITG *jflag,
-			      ITG *iedtet,ITG *ibadnodes,ITG *nbadnodes,
-			      ITG *iwrite));
+void FORTRAN(projectnodes, (ITG * nktet_, ITG *ipoed, ITG *iedgmid,
+                            ITG *iexternedg, ITG *iedgext, double *cotet,
+                            ITG *nktet, ITG *iedg, ITG *iquad, ITG *iexternfa,
+                            ITG *ifacext, ITG *itreated, ITG *ilist, ITG *isharp,
+                            ITG *ipofa, ITG *ifac, ITG *iedgextfa, ITG *ifacexted,
+                            ITG *jfix, double *co, ITG *idimsh, ITG *ipoeln,
+                            ITG *ieln, ITG *kontet, double *c1, ITG *iflag));
 
-void FORTRAN(projectvertexnodes,(ITG *ipoed,ITG *iexternedg,ITG *iedgext,
-				 double *cotet,ITG *nktet,ITG *iedg,
-				 ITG *iexternfa,ITG *ifacext,ITG *itreated,
-				 ITG *ilist,ITG *isharp,ITG *ipofa,ITG *ifac,
-				 ITG *iedgextfa,ITG *ifacexted,double *co,
-				 ITG *idimsh,ITG *ipoeln,ITG *ieln,ITG *kontet,
-				 double *c1,ITG *iflag,ITG *ibadnodes,
-				 ITG *nbadnodes,ITG *iwrite));
-                       
-void FORTRAN(propertynet,(ITG *ieg,ITG *nflow,double *prop,ITG *ielprop,
-                          char *lakon,ITG *iin,double *prop_store,
-                          double *ttime,double *time,ITG *nam,char *amname,
-                          ITG *namta,double *amta));
+void FORTRAN(projectmidnodes, (ITG * nktet_, ITG *ipoed, ITG *iedgmid,
+                               ITG *iexternedg, ITG *iedgext, double *cotet,
+                               ITG *nktet, ITG *iedg, ITG *iexternfa,
+                               ITG *ifacext, ITG *itreated, ITG *ilist, ITG *isharp,
+                               ITG *ipofa, ITG *ifac, ITG *iedgextfa,
+                               ITG *ifacexted,
+                               ITG *jfix, double *co, ITG *idimsh, ITG *ipoeled,
+                               ITG *ieled, ITG *kontet, double *c1, ITG *jflag,
+                               ITG *iedtet, ITG *ibadnodes, ITG *nbadnodes,
+                               ITG *iwrite));
 
-int pthread_create (pthread_t *thread_id,const pthread_attr_t *attributes,
-                    void *(*thread_function)(void *),void *arguments);
+void FORTRAN(projectvertexnodes, (ITG * ipoed, ITG *iexternedg, ITG *iedgext,
+                                  double *cotet, ITG *nktet, ITG *iedg,
+                                  ITG *iexternfa, ITG *ifacext, ITG *itreated,
+                                  ITG *ilist, ITG *isharp, ITG *ipofa, ITG *ifac,
+                                  ITG *iedgextfa, ITG *ifacexted, double *co,
+                                  ITG *idimsh, ITG *ipoeln, ITG *ieln, ITG *kontet,
+                                  double *c1, ITG *iflag, ITG *ibadnodes,
+                                  ITG *nbadnodes, ITG *iwrite));
 
-int pthread_join (pthread_t thread,void **status_ptr);
+void FORTRAN(propertynet, (ITG * ieg, ITG *nflow, double *prop, ITG *ielprop,
+                           char *lakon, ITG *iin, double *prop_store,
+                           double *ttime, double *time, ITG *nam, char *amname,
+                           ITG *namta, double *amta));
 
-void FORTRAN(quadmeshquality,(ITG *netet_,double *cotet,ITG *kontet,ITG *iedtet,
-			      ITG *iedgmid,double *qualityjac,ITG *ielem));
-          
-void FORTRAN(quadraticsens,(ITG *ipkon,
-             char *lakon,ITG *kon,ITG *nobject,double *dgdxglob,
-             double *xinterpol,ITG *nnodes,ITG *ne,ITG *nk,
-             ITG *nodedesiinv,char *objectset,ITG* nobjectstart));
+int pthread_create(pthread_t *thread_id, const pthread_attr_t *attributes,
+                   void *(*thread_function)(void *), void *    arguments);
 
-void radcyc(ITG *nk,ITG *kon,ITG *ipkon,char *lakon,ITG *ne,
-            double *cs,ITG *mcs,ITG *nkon,ITG *ialset,ITG *istartset,
-            ITG *iendset,ITG **kontrip,ITG *ntri,
-            double **cop,double **voldp,ITG *ntrit,ITG *inocs,ITG *mi);
+int pthread_join(pthread_t thread, void **status_ptr);
 
-void radflowload(ITG *itg,ITG *ieg,ITG *ntg,ITG *ntr,double *adrad,
-       double *aurad,
-       double *bcr,ITG *ipivr,double *ac,double *bc,ITG *nload,
-       char *sideload,ITG *nelemload,double *xloadact,char *lakon,ITG *ipiv,
-       ITG *ntmat_,double *vold,double *shcon,ITG *nshcon,ITG *ipkon,
-       ITG *kon,double *co,ITG *kontri,ITG *ntri,
-       ITG *nloadtr,double *tarea,double *tenv,double *physcon,double *erad,
-       double **adviewp,double **auviewp,
-       ITG *nflow,ITG *ikboun,double *xboun,ITG *nboun,ITG *ithermal,
-       ITG *iinc,ITG *iit,double *cs,ITG *mcs,ITG *inocs,ITG *ntrit,
-       ITG *nk,double *fenv,ITG *istep,double *dtime,double *ttime,
-       double *time,ITG *ilboun,ITG *ikforc,ITG *ilforc,double *xforc,
-       ITG *nforc,double *cam,ITG *ielmat,ITG *nteq,double *prop,
-       ITG *ielprop,ITG *nactdog,ITG *nacteq,ITG *nodeboun,ITG *ndirboun,
-       ITG *network,double *rhcon,ITG *nrhcon,
-       ITG *ipobody,ITG *ibody,double *xbody,ITG *nbody,ITG *iviewfile,
-       char *jobnamef,double *ctrl,double *xloadold,double *reltime,
-       ITG *nmethod,char *set,ITG *mi,ITG * istartset,ITG* iendset,
-       ITG *ialset,ITG *nset,ITG *ineighe,ITG *nmpc,ITG *nodempc,
-       ITG *ipompc,double *coefmpc,char *labmpc,ITG *iemchange,ITG *nam,
-       ITG *iamload,ITG *jqrad,ITG *irowrad,ITG *nzsrad,ITG *icolrad,
-       ITG *ne,ITG *iaxial,double *qa,double *cocon,ITG *ncocon,
-       ITG *iponoel,ITG *inoel,ITG *nprop,char *amname,ITG *namta,
-       double *amta);
+void FORTRAN(quadmeshquality, (ITG * netet_, double *cotet, ITG *kontet, ITG *iedtet,
+                               ITG *iedgmid, double *qualityjac, ITG *ielem));
 
-void FORTRAN (radmatrix,(ITG *ntr,double *adrad,double *aurad,double *bcr,
-       char *sideload,ITG *nelemload,double *xloadact,char *lakon,
-       double *vold,ITG *ipkon,ITG *kon,double *co,ITG *nloadtr,
-       double *tarea,double *tenv,double *physcon,double *erad,
-       double *adview,double *auview,ITG *ithermal,ITG *iinc,
-       ITG *iit,double *fenv,ITG *istep,
-       double *dtime,double *ttime,double *time,ITG *iviewfile,
-       double *xloadold,double *reltime,ITG *nmethod,
-       ITG *mi,ITG *iemchange,ITG *nam,ITG *iamload,ITG *jqrad,
-       ITG *irowrad,ITG *nzsrad));
+void FORTRAN(quadraticsens, (ITG * ipkon,
+                             char *lakon, ITG *kon, ITG *nobject, double *dgdxglob,
+                             double *xinterpol, ITG *nnodes, ITG *ne, ITG *nk,
+                             ITG *nodedesiinv, char *objectset, ITG *nobjectstart));
 
-void FORTRAN(radresult,(ITG *ntr,double *xloadact,double *bcr,
-       ITG *nloadtr,double *tarea,double * tenv,double *physcon,double *erad,
-       double *auview,double *fenv,ITG *irowrad,ITG *jqrad,
-       ITG *nzsrad,double *q));
+void radcyc(ITG *nk, ITG *kon, ITG *ipkon, char *lakon, ITG *ne,
+            double *cs, ITG *mcs, ITG *nkon, ITG *ialset, ITG *istartset,
+            ITG *iendset, ITG **kontrip, ITG *ntri,
+            double **cop, double **voldp, ITG *ntrit, ITG *inocs, ITG *mi);
+
+void radflowload(ITG *itg, ITG *ieg, ITG *ntg, ITG *ntr, double *adrad,
+                 double *aurad,
+                 double *bcr, ITG *ipivr, double *ac, double *bc, ITG *nload,
+                 char *sideload, ITG *nelemload, double *xloadact, char *lakon, ITG *ipiv,
+                 ITG *ntmat_, double *vold, double *shcon, ITG *nshcon, ITG *ipkon,
+                 ITG *kon, double *co, ITG *kontri, ITG *ntri,
+                 ITG *nloadtr, double *tarea, double *tenv, double *physcon, double *erad,
+                 double **adviewp, double **auviewp,
+                 ITG *nflow, ITG *ikboun, double *xboun, ITG *nboun, ITG *ithermal,
+                 ITG *iinc, ITG *iit, double *cs, ITG *mcs, ITG *inocs, ITG *ntrit,
+                 ITG *nk, double *fenv, ITG *istep, double *dtime, double *ttime,
+                 double *time, ITG *ilboun, ITG *ikforc, ITG *ilforc, double *xforc,
+                 ITG *nforc, double *cam, ITG *ielmat, ITG *nteq, double *prop,
+                 ITG *ielprop, ITG *nactdog, ITG *nacteq, ITG *nodeboun, ITG *ndirboun,
+                 ITG *network, double *rhcon, ITG *nrhcon,
+                 ITG *ipobody, ITG *ibody, double *xbody, ITG *nbody, ITG *iviewfile,
+                 char *jobnamef, double *ctrl, double *xloadold, double *reltime,
+                 ITG *nmethod, char *set, ITG *mi, ITG *istartset, ITG *iendset,
+                 ITG *ialset, ITG *nset, ITG *ineighe, ITG *nmpc, ITG *nodempc,
+                 ITG *ipompc, double *coefmpc, char *labmpc, ITG *iemchange, ITG *nam,
+                 ITG *iamload, ITG *jqrad, ITG *irowrad, ITG *nzsrad, ITG *icolrad,
+                 ITG *ne, ITG *iaxial, double *qa, double *cocon, ITG *ncocon,
+                 ITG *iponoel, ITG *inoel, ITG *nprop, char *amname, ITG *namta,
+                 double *amta);
+
+void FORTRAN(radmatrix, (ITG * ntr, double *adrad, double *aurad, double *bcr,
+                         char *sideload, ITG *nelemload, double *xloadact, char *lakon,
+                         double *vold, ITG *ipkon, ITG *kon, double *co, ITG *nloadtr,
+                         double *tarea, double *tenv, double *physcon, double *erad,
+                         double *adview, double *auview, ITG *ithermal, ITG *iinc,
+                         ITG *iit, double *fenv, ITG *istep,
+                         double *dtime, double *ttime, double *time, ITG *iviewfile,
+                         double *xloadold, double *reltime, ITG *nmethod,
+                         ITG *mi, ITG *iemchange, ITG *nam, ITG *iamload, ITG *jqrad,
+                         ITG *irowrad, ITG *nzsrad));
+
+void FORTRAN(radresult, (ITG * ntr, double *xloadact, double *bcr,
+                         ITG *nloadtr, double *tarea, double *tenv, double *physcon, double *erad,
+                         double *auview, double *fenv, ITG *irowrad, ITG *jqrad,
+                         ITG *nzsrad, double *q));
 
 unsigned ITG randmt();
 
-void randomfieldmain(ITG *kon,ITG *ipkon,char *lakon,ITG *ne,ITG *nmpc,
-		     ITG *nactdof,ITG *mi,ITG *nodedesi,ITG *ndesi,
-		     ITG *istartdesi,
-		     ITG *ialdesi,double *co,double *physcon,ITG *isolver,
-		     ITG *ntrans,
-		     ITG *nk,ITG *inotr,double *trab,char *jobnamec,ITG *nboun,
-		     double *cs,       
-		     ITG *mcs,ITG *inum,ITG *nmethod,ITG *kode,char *filab,
-		     ITG *nstate_,
-		     ITG *istep,char *description,char *set,ITG *nset,
-		     ITG *iendset,
-		     char *output,ITG *istartset,ITG *ialset,double *extnor,
-		     ITG *irandomtype,double *randomval,ITG *irobustdesign,
-		     ITG *ndesibou,
-		     ITG *nodedesibou,ITG *nodedesiinvbou);
+void randomfieldmain(ITG *kon, ITG *ipkon, char *lakon, ITG *ne, ITG *nmpc,
+                     ITG *nactdof, ITG *mi, ITG *nodedesi, ITG *ndesi,
+                     ITG *istartdesi,
+                     ITG *ialdesi, double *co, double *physcon, ITG *isolver,
+                     ITG *ntrans,
+                     ITG *nk, ITG *inotr, double *trab, char *jobnamec, ITG *nboun,
+                     double *cs,
+                     ITG *mcs, ITG *inum, ITG *nmethod, ITG *kode, char *filab,
+                     ITG *nstate_,
+                     ITG *istep, char *description, char *set, ITG *nset,
+                     ITG * iendset,
+                     char *output, ITG *istartset, ITG *ialset, double *extnor,
+                     ITG *irandomtype, double *randomval, ITG *irobustdesign,
+                     ITG *ndesibou,
+                     ITG *nodedesibou, ITG *nodedesiinvbou);
 
-void FORTRAN(randomval,(double *randval,ITG *nev));
+void FORTRAN(randomval, (double *randval, ITG *nev));
 
-void FORTRAN(readforce,(double *zc,ITG *neq,ITG *nev,ITG *nactdof,
-             ITG *ikmpc,ITG *nmpc,ITG *ipompc,ITG *nodempc,ITG *mi,
-             double *coefmpc,char *jobnamec,double *aa,
-             ITG *igeneralizedforce));
+void FORTRAN(readforce, (double *zc, ITG *neq, ITG *nev, ITG *nactdof,
+                         ITG *ikmpc, ITG *nmpc, ITG *ipompc, ITG *nodempc, ITG *mi,
+                         double *coefmpc, char *jobnamec, double *aa,
+                         ITG *igeneralizedforce));
 
-void readinput(char *jobnamec,char **inpcp,ITG *nline,ITG *nset,ITG *ipoinp,
-               ITG **inpp,ITG **ipoinpcp,ITG *ithermal,ITG *nuel_,
-	       ITG *inp_size); 
+void readinput(char *jobnamec, char **inpcp, ITG *nline, ITG *nset, ITG *ipoinp,
+               ITG **inpp, ITG **ipoinpcp, ITG *ithermal, ITG *nuel_,
+               ITG *inp_size);
 
-void readnewmesh(char *jobnamec,ITG *nboun,ITG *nodeboun,ITG *iamboun,
-		 double *xboun,ITG *nload,char *sideload,ITG *iamload,
-		 ITG *nforc,ITG *nodeforc,
-		 ITG *iamforc,double *xforc,ITG *ithermal,ITG *nk,
-		 double **t1p,ITG **iamt1p,ITG *ne,char **lakonp,ITG **ipkonp,
-		 ITG **konp,ITG *istartset,ITG *iendset,ITG *ialset,
-		 char *set,ITG *nset,char *filab,double **cop,ITG **ipompcp,
-		 ITG **nodempcp,double **coefmpcp,ITG *nmpc,ITG *nmpc_,
-		 char **labmpcp,ITG *mpcfree,ITG *memmpc_,ITG **ikmpcp,
-		 ITG **ilmpcp,ITG *nk_,ITG *ne_,ITG *nkon_,ITG *istep,
-		 ITG *nprop_,ITG **ielpropp,ITG *ne1d,ITG *ne2d,ITG **iponorp,
-		 double **thicknp,double **thickep,ITG *mi,double **offsetp,
-		 ITG **iponoelp,ITG **rigp,ITG **ne2bounp,ITG **ielorienp,
-		 ITG **inotrp,double **t0p,double **t0gp,double **t1gp,
-		 double **prestrp,double **voldp,double **veoldp,ITG **ielmatp,
-		 ITG *irobustdesign,ITG **irandomtypep,double **randomvalp,
-		 ITG *nalset,ITG *nalset_,ITG *nkon,double *xnor,
-		 ITG *iaxial,ITG *network,ITG *nlabel,ITG *iuel,ITG *iperturb,
-		 ITG *iprestr,ITG *ntie,char *tieset,ITG **iparentelp,
-		 ITG *ikboun,ITG *ifreebody,ITG **ipobodyp,ITG *nbody,
-		 ITG **iprfnp,ITG **konrfnp,double **ratiorfnp,ITG *nodempcref,
-		 double *coefmpcref,ITG *memmpcref_,ITG *mpcfreeref,
-		 ITG *maxlenmpcref,ITG *maxlenmpc,ITG *norien,double *tietol);
+void readnewmesh(char *jobnamec, ITG *nboun, ITG *nodeboun, ITG *iamboun,
+                 double *xboun, ITG *nload, char *sideload, ITG *iamload,
+                 ITG *nforc, ITG *nodeforc,
+                 ITG *iamforc, double *xforc, ITG *ithermal, ITG *nk,
+                 double **t1p, ITG **iamt1p, ITG *ne, char **lakonp, ITG **ipkonp,
+                 ITG **konp, ITG *istartset, ITG *iendset, ITG *ialset,
+                 char *set, ITG *nset, char *filab, double **cop, ITG **ipompcp,
+                 ITG **nodempcp, double **coefmpcp, ITG *nmpc, ITG *nmpc_,
+                 char **labmpcp, ITG *mpcfree, ITG *memmpc_, ITG **ikmpcp,
+                 ITG **ilmpcp, ITG *nk_, ITG *ne_, ITG *nkon_, ITG *istep,
+                 ITG *nprop_, ITG **ielpropp, ITG *ne1d, ITG *ne2d, ITG **iponorp,
+                 double **thicknp, double **thickep, ITG *mi, double **offsetp,
+                 ITG **iponoelp, ITG **rigp, ITG **ne2bounp, ITG **ielorienp,
+                 ITG **inotrp, double **t0p, double **t0gp, double **t1gp,
+                 double **prestrp, double **voldp, double **veoldp, ITG **ielmatp,
+                 ITG *irobustdesign, ITG **irandomtypep, double **randomvalp,
+                 ITG *nalset, ITG *nalset_, ITG *nkon, double *xnor,
+                 ITG *iaxial, ITG *network, ITG *nlabel, ITG *iuel, ITG *iperturb,
+                 ITG *iprestr, ITG *ntie, char *tieset, ITG **iparentelp,
+                 ITG *ikboun, ITG *ifreebody, ITG **ipobodyp, ITG *nbody,
+                 ITG **iprfnp, ITG **konrfnp, double **ratiorfnp, ITG *nodempcref,
+                 double *coefmpcref, ITG *memmpcref_, ITG *mpcfreeref,
+                 ITG *maxlenmpcref, ITG *maxlenmpc, ITG *norien, double *tietol);
 
-void FORTRAN(readsen,(double *g0,double *dgdx,ITG *ndesi,ITG *nobject,
-                       ITG *nodedesi,char *jobnamef));
+void FORTRAN(readsen, (double *g0, double *dgdx, ITG *ndesi, ITG *nobject,
+                       ITG *nodedesi, char *jobnamef));
 
-void FORTRAN(readview,(ITG *ntr,double *adview,double *auview,double *fenv,
-             ITG *nzsrad,ITG *ithermal,char *jobnamef));
+void FORTRAN(readview, (ITG * ntr, double *adview, double *auview, double *fenv,
+                        ITG *nzsrad, ITG *ithermal, char *jobnamef));
 
-void FORTRAN(rearrange,(double *au,ITG *irow,ITG *icol,ITG *ndim,ITG *neq));
+void FORTRAN(rearrange, (double *au, ITG *irow, ITG *icol, ITG *ndim, ITG *neq));
 
-void FORTRAN(rearrangecfd,(ITG *ne,ITG *ipkon,char *lakon,ITG *ielmat,
-			   ITG *ielorien,ITG *norien,ITG *nef,ITG *ipkonf,
-			   char *lakonf,ITG *ielmatf,ITG *ielorienf,ITG *mi,
-			   ITG *nelold,ITG *nelnew,ITG *nkold,ITG *nknew,
-			   ITG *nk,ITG *nkf,ITG *konf,ITG *nkonf,ITG *nmpc,
-			   ITG *ipompc,ITG *nodempc,double *coefmpc,
-			   ITG *memmpc_,ITG *nmpcf,ITG *ipompcf,ITG *nodempcf,
-			   double *coefmpcf,ITG *memmpcf,ITG *nboun,
-			   ITG *nodeboun,ITG *ndirboun,double *xboun,
-			   ITG *nbounf,ITG *nodebounf,ITG *ndirbounf,
-			   double *xbounf,ITG *nload,ITG *nelemload,
-			   char *sideload,double *xload,ITG *nloadf,
-			   ITG *nelemloadf,char *sideloadf,double *xloadf,
-			   ITG *ipobody,ITG *ipobodyf,ITG *kon,ITG *neqf,
-			   double *co,double *cof,double *vold,double *voldf,
-			   ITG *ikbounf,ITG *ilbounf,ITG *ikmpcf,ITG *ilmpcf,
-			   ITG *iambounf,ITG *iamloadf,ITG *iamboun,
-			   ITG *iamload,double *xbounold,double *xbounoldf,
-			   double *xbounact,double *xbounactf,double *xloadold,
-			   double *xloadoldf,double *xloadact,double *xloadactf,
-			   ITG *inotr,ITG *inotrf,ITG *nam,ITG *ntrans,
-			   ITG *nbody));
+void FORTRAN(rearrangecfd, (ITG * ne, ITG *ipkon, char *lakon, ITG *ielmat,
+                            ITG *ielorien, ITG *norien, ITG *nef, ITG *ipkonf,
+                            char *lakonf, ITG *ielmatf, ITG *ielorienf, ITG *mi,
+                            ITG *nelold, ITG *nelnew, ITG *nkold, ITG *nknew,
+                            ITG *nk, ITG *nkf, ITG *konf, ITG *nkonf, ITG *nmpc,
+                            ITG *ipompc, ITG *nodempc, double *coefmpc,
+                            ITG *memmpc_, ITG *nmpcf, ITG *ipompcf, ITG *nodempcf,
+                            double *coefmpcf, ITG *memmpcf, ITG *nboun,
+                            ITG *nodeboun, ITG *ndirboun, double *xboun,
+                            ITG *nbounf, ITG *nodebounf, ITG *ndirbounf,
+                            double *xbounf, ITG *nload, ITG *nelemload,
+                            char *sideload, double *xload, ITG *nloadf,
+                            ITG *nelemloadf, char *sideloadf, double *xloadf,
+                            ITG *ipobody, ITG *ipobodyf, ITG *kon, ITG *neqf,
+                            double *co, double *cof, double *vold, double *voldf,
+                            ITG *ikbounf, ITG *ilbounf, ITG *ikmpcf, ITG *ilmpcf,
+                            ITG *iambounf, ITG *iamloadf, ITG *iamboun,
+                            ITG *iamload, double *xbounold, double *xbounoldf,
+                            double *xbounact, double *xbounactf, double *xloadold,
+                            double *xloadoldf, double *xloadact, double *xloadactf,
+                            ITG *inotr, ITG *inotrf, ITG *nam, ITG *ntrans,
+                            ITG *nbody));
 
-void FORTRAN(rectcyl,(double *co,double *v,double *fn,double *stn,
-                      double *qfn,double *een,double *cs,ITG *nk,
-                      ITG *icntrl,double *t,char *filab,ITG *imag,
-                      ITG *mi,double *emn));
+void FORTRAN(rectcyl, (double *co, double *v, double *fn, double *stn,
+                       double *qfn, double *een, double *cs, ITG *nk,
+                       ITG *icntrl, double *t, char *filab, ITG *imag,
+                       ITG *mi, double *emn));
 
-void FORTRAN(rectcylexp,(double *co,double *v,double *fn,double *stn,
-                      double *qfn,double *een,double *cs,ITG *nkt,
-                      ITG *icntrl,double *t,char *filab,ITG *imag,ITG *mi,
-                      ITG *iznode,ITG *nznode,ITG *nsectors,ITG *nk,
-                      double *emn));
+void FORTRAN(rectcylexp, (double *co, double *v, double *fn, double *stn,
+                          double *qfn, double *een, double *cs, ITG *nkt,
+                          ITG *icntrl, double *t, char *filab, ITG *imag, ITG *mi,
+                          ITG *iznode, ITG *nznode, ITG *nsectors, ITG *nk,
+                          double *emn));
 
-void FORTRAN(rectcyltrfm,(ITG *node,double *co,double *cs,ITG *cntrl,
-             double *fin,double *fout));
+void FORTRAN(rectcyltrfm, (ITG * node, double *co, double *cs, ITG *cntrl,
+                           double *fin, double *fout));
 
-void FORTRAN(rectcylvi,(double *co,double *v,double *fn,double *stn,
-                      double *qfn,double *een,double *cs,ITG *nk,
-                      ITG *icntrl,double *t,char *filab,ITG *imag,ITG *mi,
-                      double *emn));
+void FORTRAN(rectcylvi, (double *co, double *v, double *fn, double *stn,
+                         double *qfn, double *een, double *cs, ITG *nk,
+                         ITG *icntrl, double *t, char *filab, ITG *imag, ITG *mi,
+                         double *emn));
 
-void FORTRAN(rectcylvold,(double *co,double *vold,double *cs,
-                      ITG *icntrl,ITG *mi,
-                      ITG *iznode,ITG *nznode,ITG *nsectors,ITG *nk));
+void FORTRAN(rectcylvold, (double *co, double *vold, double *cs,
+                           ITG *icntrl, ITG *mi,
+                           ITG *iznode, ITG *nznode, ITG *nsectors, ITG *nk));
 
-void FORTRAN(reducematrix,(double *au,double *ad,ITG *jq,ITG *irow,
-			   ITG *neq,ITG *neqtot,ITG *ktot));
+void FORTRAN(reducematrix, (double *au, double *ad, ITG *jq, ITG *irow,
+                            ITG *neq, ITG *neqtot, ITG *ktot));
 
-void refinemesh(ITG *nk,ITG *ne,double *co,ITG *ipkon,ITG *kon,
-                double *v,double *veold,double *stn,double *een,
-                double *emn,double *epn,double *enern,double *qfn,
-                double *errn,char *filab,ITG *mi,char *lakon,
-                char *jobnamec,ITG *istartset,ITG *iendset,ITG *ialset,
-		char *set,ITG *nset,char *matname,ITG *ithermal,
-		char *output,ITG *nmat);
+void refinemesh(ITG *nk, ITG *ne, double *co, ITG *ipkon, ITG *kon,
+                double *v, double *veold, double *stn, double *een,
+                double *emn, double *epn, double *enern, double *qfn,
+                double *errn, char *filab, ITG *mi, char *lakon,
+                char *jobnamec, ITG *istartset, ITG *iendset, ITG *ialset,
+                char *set, ITG *nset, char *matname, ITG *ithermal,
+                char *output, ITG *nmat);
 
-void FORTRAN(reinit_mesh,(ITG *kontet,ITG *ifac,ITG *netet_,ITG *newsize,
-	     ITG *ifatet,ITG *itetfa));
+void FORTRAN(reinit_mesh, (ITG * kontet, ITG *ifac, ITG *netet_, ITG *newsize,
+                           ITG *ifatet, ITG *itetfa));
 
-void FORTRAN(reinit_refine,(ITG *kontet,ITG *ifac,ITG *ieln,ITG *netet_,
-                      ITG *newsize,ITG *ifatet,ITG *itetfa,ITG *iedg,
-                      ITG *ieled));
+void FORTRAN(reinit_refine, (ITG * kontet, ITG *ifac, ITG *ieln, ITG *netet_,
+                             ITG *newsize, ITG *ifatet, ITG *itetfa, ITG *iedg,
+                             ITG *ieled));
 
-void FORTRAN(relaxval_al,(double *eps_al,double *gmatrix,ITG *gsize,
-			  ITG *ncdim));
+void FORTRAN(relaxval_al, (double *eps_al, double *gmatrix, ITG *gsize,
+                           ITG *ncdim));
 
-void remastruct(ITG *ipompc,double **coefmpcp,ITG **nodempcp,ITG *nmpc,
-		ITG *mpcfree,ITG *nodeboun,ITG *ndirboun,ITG *nboun,
-		ITG *ikmpc,ITG *ilmpc,ITG *ikboun,ITG *ilboun,
-		char *labmpc,ITG *nk,
-		ITG *memmpc_,ITG *icascade,ITG *maxlenmpc,
-		ITG *kon,ITG *ipkon,char *lakon,ITG *ne,
-		ITG *nactdof,ITG *icol,ITG *jq,ITG **irowp,ITG *isolver,
-		ITG *neq,ITG *nzs,ITG *nmethod,double **fp,
-		double **fextp,double **bp,double **aux2p,double **finip,
-		double **fextinip,double **adbp,double **aubp,ITG *ithermal,
-		ITG *iperturb,ITG *mass,ITG *mi,ITG *iexpl,ITG *mortar,
-		char *typeboun,double **cvp,double **cvinip,ITG *iit,
-		ITG *network,ITG *itiefac,ITG *ne0,ITG *nkon0,ITG *nintpoint,
-		ITG *islavsurf,double *pmastsurf,char*tieset,ITG *ntie,
-		ITG *num_cpus);
+void remastruct(ITG *ipompc, double **coefmpcp, ITG **nodempcp, ITG *nmpc,
+                ITG *mpcfree, ITG *nodeboun, ITG *ndirboun, ITG *nboun,
+                ITG *ikmpc, ITG *ilmpc, ITG *ikboun, ITG *ilboun,
+                char *labmpc, ITG *nk,
+                ITG *memmpc_, ITG *icascade, ITG *maxlenmpc,
+                ITG *kon, ITG *ipkon, char *lakon, ITG *ne,
+                ITG *nactdof, ITG *icol, ITG *jq, ITG **irowp, ITG *isolver,
+                ITG *neq, ITG *nzs, ITG *nmethod, double **fp,
+                double **fextp, double **bp, double **aux2p, double **finip,
+                double **fextinip, double **adbp, double **aubp, ITG *ithermal,
+                ITG *iperturb, ITG *mass, ITG *mi, ITG *iexpl, ITG *mortar,
+                char *typeboun, double **cvp, double **cvinip, ITG *iit,
+                ITG *network, ITG *itiefac, ITG *ne0, ITG *nkon0, ITG *nintpoint,
+                ITG *islavsurf, double *pmastsurf, char *tieset, ITG *ntie,
+                ITG *num_cpus);
 
-void remastructar(ITG *ipompc,double **coefmpcp,ITG **nodempcp,ITG *nmpc,
-              ITG *mpcfree,ITG *nodeboun,ITG *ndirboun,ITG *nboun,
-              ITG *ikmpc,ITG *ilmpc,ITG *ikboun,ITG *ilboun,
-              char *labmpc,ITG *nk,
-              ITG *memmpc_,ITG *icascade,ITG *maxlenmpc,
-              ITG *kon,ITG *ipkon,char *lakon,ITG *ne,
-              ITG *nactdof,ITG *icol,ITG *jq,ITG **irowp,ITG *isolver,
-              ITG *neq,ITG *nzs,ITG *nmethod,ITG *ithermal,
-              ITG *iperturb,ITG *mass,ITG *mi,ITG *ics,double *cs,
-              ITG *mcs,ITG *mortar,char *typeboun,ITG *iit,ITG *network,
-              ITG *iexpl);
+void remastructar(ITG *ipompc, double **coefmpcp, ITG **nodempcp, ITG *nmpc,
+                  ITG *mpcfree, ITG *nodeboun, ITG *ndirboun, ITG *nboun,
+                  ITG *ikmpc, ITG *ilmpc, ITG *ikboun, ITG *ilboun,
+                  char *labmpc, ITG *nk,
+                  ITG *memmpc_, ITG *icascade, ITG *maxlenmpc,
+                  ITG *kon, ITG *ipkon, char *lakon, ITG *ne,
+                  ITG *nactdof, ITG *icol, ITG *jq, ITG **irowp, ITG *isolver,
+                  ITG *neq, ITG *nzs, ITG *nmethod, ITG *ithermal,
+                  ITG *iperturb, ITG *mass, ITG *mi, ITG *ics, double *cs,
+                  ITG *mcs, ITG *mortar, char *typeboun, ITG *iit, ITG *network,
+                  ITG *iexpl);
 
-void remastructem(ITG *ipompc,double **coefmpcp,ITG **nodempcp,ITG *nmpc,
-              ITG *mpcfree,ITG *nodeboun,ITG *ndirboun,ITG *nboun,
-              ITG *ikmpc,ITG *ilmpc,ITG *ikboun,ITG *ilboun,
-              char *labmpc,ITG *nk,
-              ITG *memmpc_,ITG *icascade,ITG *maxlenmpc,
-              ITG *kon,ITG *ipkon,char *lakon,ITG *ne,
-              ITG *nactdof,ITG *icol,ITG *jq,ITG **irowp,ITG *isolver,
-              ITG *neq,ITG *nzs,ITG *nmethod,double **fp,
-              double **fextp,double **bp,double **aux2p,double **finip,
-              double **fextinip,double **adbp,double **aubp,ITG *ithermal,
-              ITG *iperturb,ITG *mass,ITG *mi,ITG *ielmat,double *elcon,
-              ITG *ncmat_,ITG *ntmat_,ITG *inomat,ITG *network);
+void remastructem(ITG *ipompc, double **coefmpcp, ITG **nodempcp, ITG *nmpc,
+                  ITG *mpcfree, ITG *nodeboun, ITG *ndirboun, ITG *nboun,
+                  ITG *ikmpc, ITG *ilmpc, ITG *ikboun, ITG *ilboun,
+                  char *labmpc, ITG *nk,
+                  ITG *memmpc_, ITG *icascade, ITG *maxlenmpc,
+                  ITG *kon, ITG *ipkon, char *lakon, ITG *ne,
+                  ITG *nactdof, ITG *icol, ITG *jq, ITG **irowp, ITG *isolver,
+                  ITG *neq, ITG *nzs, ITG *nmethod, double **fp,
+                  double **fextp, double **bp, double **aux2p, double **finip,
+                  double **fextinip, double **adbp, double **aubp, ITG *ithermal,
+                  ITG *iperturb, ITG *mass, ITG *mi, ITG *ielmat, double *elcon,
+                  ITG *ncmat_, ITG *ntmat_, ITG *inomat, ITG *network);
 
-void FORTRAN(removeboxtets,(ITG *kontet,ITG *ifatet,ITG *ifreetet,ITG *ifac,
-			    ITG *itetfa,ITG *ifreefa,ITG *ipofa,ITG *iexternfa,
-			    ITG *netet_,ITG *nktet));
+void FORTRAN(removeboxtets, (ITG * kontet, ITG *ifatet, ITG *ifreetet, ITG *ifac,
+                             ITG *itetfa, ITG *ifreefa, ITG *ipofa, ITG *iexternfa,
+                             ITG *netet_, ITG *nktet));
 
-void FORTRAN(removeconcavetets,(ITG *kontet,ITG *ipnei,ITG *neiel,ITG *ipoed,
-				ITG *iedg,ITG *ipoeled,ITG *ieled,ITG *nktet,
-				ITG *nef,ITG *iexternedg,ITG *iedtet,
-				ITG *iexternfa,ITG *ipofa,ITG *ifac,
-				ITG *ifatet,ITG *itetfa,ITG *ichange,
-				ITG *iponoelf,ITG *inoelf,ITG *ncfd,
-				ITG *ipkonf,char *lakonf,ITG *konf));
+void FORTRAN(removeconcavetets, (ITG * kontet, ITG *ipnei, ITG *neiel, ITG *ipoed,
+                                 ITG *iedg, ITG *ipoeled, ITG *ieled, ITG *nktet,
+                                 ITG *nef, ITG *iexternedg, ITG *iedtet,
+                                 ITG *iexternfa, ITG *ipofa, ITG *ifac,
+                                 ITG *ifatet, ITG *itetfa, ITG *ichange,
+                                 ITG *iponoelf, ITG *inoelf, ITG *ncfd,
+                                 ITG *ipkonf, char *lakonf, ITG *konf));
 
-void FORTRAN(removecutgeomtets,(ITG *kontet,ITG *ifatet,ITG *ifreetet,
-				ITG *ifac,ITG *itetfa,ITG *ifreefa,ITG *ipofa,
-				ITG *iexternfa,ITG *ipnei,ITG *neiel,
-				ITG *ipoed,ITG *iedg,ITG *ipoeled,ITG *ieled,
-				ITG *nktet,ITG *nef,double *xxn,ITG *iponoel,
-				ITG *inoel,ITG *ipkonf,ITG *konf,char *lakonf,
-				double *co,double *coel,ITG *neifa,
-				double *area,ITG *istack,ITG *ncfd));
+void FORTRAN(removecutgeomtets, (ITG * kontet, ITG *ifatet, ITG *ifreetet,
+                                 ITG *ifac, ITG *itetfa, ITG *ifreefa, ITG *ipofa,
+                                 ITG *iexternfa, ITG *ipnei, ITG *neiel,
+                                 ITG *ipoed, ITG *iedg, ITG *ipoeled, ITG *ieled,
+                                 ITG *nktet, ITG *nef, double *xxn, ITG *iponoel,
+                                 ITG *inoel, ITG *ipkonf, ITG *konf, char *lakonf,
+                                 double *co, double *coel, ITG *neifa,
+                                 double *area, ITG *istack, ITG *ncfd));
 
-void FORTRAN(removesliver,(ITG *netet_,ITG *kontet,ITG *iexternnode,
-			   ITG *iedtet,ITG *iexternedg,double *quality,
-			   ITG *itetfa,ITG *ipofa,ITG *ipoeln,ITG *ipoeled,
-			   ITG *ipoed,ITG *ifreetet,ITG *ifreeln,ITG *ifreele,
-			   ITG *ifreefa,ITG *ifreeed,ITG *ifatet,ITG *ifac,
-			   ITG *iexternfa,ITG *ieln,ITG *ieled,ITG *iedg,
-			   ITG *isharp));
+void FORTRAN(removesliver, (ITG * netet_, ITG *kontet, ITG *iexternnode,
+                            ITG *iedtet, ITG *iexternedg, double *quality,
+                            ITG *itetfa, ITG *ipofa, ITG *ipoeln, ITG *ipoeled,
+                            ITG *ipoed, ITG *ifreetet, ITG *ifreeln, ITG *ifreele,
+                            ITG *ifreefa, ITG *ifreeed, ITG *ifatet, ITG *ifac,
+                            ITG *iexternfa, ITG *ieln, ITG *ieled, ITG *iedg,
+                            ITG *isharp));
 
-void FORTRAN(removetet_mesh2,(ITG *kontet,ITG *ifatet,ITG *ifreetet,ITG *ifac,
-			      ITG *itetfa,ITG *ifreefa,ITG *ipofa,ITG *ielement,
-			      ITG *iexternfa));
+void FORTRAN(removetet_mesh2, (ITG * kontet, ITG *ifatet, ITG *ifreetet, ITG *ifac,
+                               ITG *itetfa, ITG *ifreefa, ITG *ipofa, ITG *ielement,
+                               ITG *iexternfa));
 
-void FORTRAN(removetet_mesh3,(ITG *kontet,ITG *ifatet,ITG *ifac,
-			      ITG *itetfa,ITG *ipofa,ITG *ielement,
-			      ITG *iexternfa,ITG *iedtet,ITG *ipoeled,
-			      ITG *ieled,ITG *ipoed,ITG *iedg,ITG *iexternedg));
+void FORTRAN(removetet_mesh3, (ITG * kontet, ITG *ifatet, ITG *ifac,
+                               ITG *itetfa, ITG *ipofa, ITG *ielement,
+                               ITG *iexternfa, ITG *iedtet, ITG *ipoeled,
+                               ITG *ieled, ITG *ipoed, ITG *iedg, ITG *iexternedg));
 
-void FORTRAN(removezerovoltets,(ITG *kontet,ITG *netet_,double *cotet,
-				ITG *ifatet,ITG *ifreetet,ITG *ifac,ITG *itetfa,
-				ITG *ifreefa,ITG *ipofa,ITG *iexternfa));
+void FORTRAN(removezerovoltets, (ITG * kontet, ITG *netet_, double *cotet,
+                                 ITG *ifatet, ITG *ifreetet, ITG *ifac, ITG *itetfa,
+                                 ITG *ifreefa, ITG *ipofa, ITG *iexternfa));
 
-void FORTRAN(renumber,(ITG *nnn,ITG *npn,ITG *adj,ITG *xadj,ITG *iw,
-                       ITG *mmm,ITG *xnpn,ITG *inum1,ITG *ipnei,ITG *nef,
-                       ITG *neiel,ITG *neifa,ITG *ifatie));
+void FORTRAN(renumber, (ITG * nnn, ITG *npn, ITG *adj, ITG *xadj, ITG *iw,
+                        ITG *mmm, ITG *xnpn, ITG *inum1, ITG *ipnei, ITG *nef,
+                        ITG *neiel, ITG *neifa, ITG *ifatie));
 
-void renumbermain(ITG *nef,ITG *ipnei,ITG *neiel,ITG *ipkonf,ITG *ielmatf,
-                  ITG *ielorienf,ITG *neifa,ITG *neij,ITG *nflnei,
-                  ITG *nactdoh,ITG *nactdohinv,ITG *nface,ITG *ielfa,
-                  ITG *mi,ITG *ifatie,ITG *norien,char *lakonf);
+void renumbermain(ITG *nef, ITG *ipnei, ITG *neiel, ITG *ipkonf, ITG *ielmatf,
+                  ITG *ielorienf, ITG *neifa, ITG *neij, ITG *nflnei,
+                  ITG *nactdoh, ITG *nactdohinv, ITG *nface, ITG *ielfa,
+                  ITG *mi, ITG *ifatie, ITG *norien, char *lakonf);
 
-void res1parll(ITG *mt,ITG *nactdof,double *aux2,double *vold,
-                    double *vini,double *dtime,double *accold,
-                    ITG *nk,ITG *num_cpus);
+void res1parll(ITG *mt, ITG *nactdof, double *aux2, double *vold,
+               double *vini, double *dtime, double *accold,
+               ITG *nk, ITG *num_cpus);
 
 void *res1parllmt(ITG *i);
 
-void res2parll(double *b,double *scal1,double *fext,double *f,
-	       double *alpha,double *fextini,double *fini,
-	       double *adb,double *aux2,ITG *neq0,ITG *num_cpus);
+void res2parll(double *b, double *scal1, double *fext, double *f,
+               double *alpha, double *fextini, double *fini,
+               double *adb, double *aux2, ITG *neq0, ITG *num_cpus);
 
 void *res2parllmt(ITG *i);
 
-void res3parll(ITG *mt,ITG *nactdof,double *f,double *fn,
-	       ITG *nk,ITG *num_cpus);
+void res3parll(ITG *mt, ITG *nactdof, double *f, double *fn,
+               ITG *nk, ITG *num_cpus);
 
 void *res3parllmt(ITG *i);
 
-void res4parll(double *cv,double *alpham,double *adb,double *aux2,
-	       double *b,double *scal1,double *alpha,double *cvini,
-	       ITG *neq0,ITG *num_cpus);
+void res4parll(double *cv, double *alpham, double *adb, double *aux2,
+               double *b, double *scal1, double *alpha, double *cvini,
+               ITG *neq0, ITG *num_cpus);
 
 void *res4parllmt(ITG *i);
 
-void FORTRAN(restartshort,(ITG *nset,ITG *nload,ITG *nbody,ITG *nforc,
-			   ITG *nboun,ITG *nk,ITG *ne,ITG *nmpc,ITG *nalset,
-			   ITG *nmat,ITG *ntmat,ITG *npmat,ITG *norien,
-			   ITG *nam,ITG *nprint,ITG *mint,ITG *ntrans,ITG *ncs,
-			   ITG *namtot,ITG *ncmat,ITG *memmpc,ITG *ne1d,
-			   ITG *ne2d,ITG *nflow,char *set,ITG *meminset,
-			   ITG *rmeminset,char *jobnamec,ITG *irestartstep,
-			   ITG *icntrl,ITG *ithermal,ITG *nener,ITG *nstate_,
-			   ITG *ntie,ITG *nslavs,ITG *nkon,ITG *mcs,ITG *nprop,
-			   ITG *mortar,ITG *ifacecount,ITG *nintpoint,
-			   ITG *infree,ITG *nef,ITG *mpcend,ITG *nheading_,
-			   ITG *network,ITG *nfc,ITG *ndc,ITG *iprestr));
+void FORTRAN(restartshort, (ITG * nset, ITG *nload, ITG *nbody, ITG *nforc,
+                            ITG *nboun, ITG *nk, ITG *ne, ITG *nmpc, ITG *nalset,
+                            ITG *nmat, ITG *ntmat, ITG *npmat, ITG *norien,
+                            ITG *nam, ITG *nprint, ITG *mint, ITG *ntrans, ITG *ncs,
+                            ITG *namtot, ITG *ncmat, ITG *memmpc, ITG *ne1d,
+                            ITG *ne2d, ITG *nflow, char *set, ITG *meminset,
+                            ITG *rmeminset, char *jobnamec, ITG *irestartstep,
+                            ITG *icntrl, ITG *ithermal, ITG *nener, ITG *nstate_,
+                            ITG *ntie, ITG *nslavs, ITG *nkon, ITG *mcs, ITG *nprop,
+                            ITG *mortar, ITG *ifacecount, ITG *nintpoint,
+                            ITG *infree, ITG *nef, ITG *mpcend, ITG *nheading_,
+                            ITG *network, ITG *nfc, ITG *ndc, ITG *iprestr));
 
-void FORTRAN(restartwrite,(ITG *istep,ITG *nset,ITG*nload,ITG *nforc,
-  ITG * nboun,ITG *nk,ITG *ne,ITG *nmpc,ITG *nalset,ITG *nmat,ITG *ntmat_,
-  ITG *npmat_,ITG *norien,ITG *nam,ITG *nprint,ITG *mi,
-  ITG *ntrans,ITG *ncs_,ITG *namtot,ITG *ncmat_,ITG *mpcend,
-  ITG *maxlenmpc,ITG *ne1d,
-  ITG *ne2d,ITG *nflow,ITG *nlabel,ITG *iplas,ITG *nkon,ITG *ithermal,
-  ITG *nmethod,ITG *iperturb,ITG *nstate_,ITG *nener,char *set,
-  ITG *istartset,ITG *iendset,ITG *ialset,double *co,ITG *kon,ITG *ipkon,
-  char *lakon,ITG *nodeboun,ITG *ndirboun,ITG *iamboun,double *xboun,
-  ITG *ikboun,ITG *ilboun,ITG *ipompc,ITG *nodempc,double *coefmpc,
-  char *labmpc,ITG *ikmpc,ITG *ilmpc,ITG *nodeforc,ITG *ndirforc,
-  ITG *iamforc,double *xforc,ITG *ikforc,ITG *ilforc,ITG *nelemload,
-  ITG *iamload,char *sideload,double *xload,
-  double *elcon,ITG *nelcon,double *rhcon,ITG *nrhcon,double *alcon,
-  ITG *nalcon,double *alzero,double *plicon,ITG *nplicon,double *plkcon,
-  ITG *nplkcon,char *orname,double *orab,ITG *ielorien,double *trab,
-  ITG *inotr,char *amname,double *amta,ITG *namta,double *t0,double *t1,
-  ITG *iamt1,double *veold,ITG *ielmat,char *matname,
-  char *prlab,char *prset,char *filab,double *vold,
-  ITG *nodebounold,ITG *ndirbounold,double *xbounold,double *xforcold,
-  double *xloadold,double *t1old,double *eme,ITG *iponor,
-  double *xnor,ITG *knor,double *thicke,double *offset,
-  ITG *iponoel,ITG *inoel,ITG *rig,
-  double *shcon,ITG *nshcon,double *cocon,ITG *ncocon,
-  ITG *ics,double *sti,double *ener,double *xstate,
-  char *jobnamec,ITG *infree,double *prestr,ITG *iprestr,
-  char *cbody,ITG *ibody,double *xbody,ITG *nbody,double *xbodyold,
-  double *ttime,double *qaold,double *cs,
-  ITG *mcs,char *output,double *physcon,double *ctrl,char *typeboun,
-  double *fmpc,char *tieset,ITG *ntie,double *tietol,ITG *nslavs,
-  double *t0g,double *t1g,ITG *nprop,ITG *ielprop,double *prop,ITG *mortar,
-  ITG *nintpoint,ITG *ifacecount,ITG *islavsurf,double *pslavsurf,
-  double *clearini,ITG *irstrt,double *vel,ITG *nef,double *velo,
-  double *veloo,ITG *ne2boun,ITG *memmpc_,char *heading,ITG *nheading_,
-  ITG *network,ITG *nfc,ITG *ndc,double *coeffc,ITG *ikdc,double *edc));
+void FORTRAN(restartwrite, (ITG * istep, ITG *nset, ITG *nload, ITG *nforc,
+                            ITG *nboun, ITG *nk, ITG *ne, ITG *nmpc, ITG *nalset, ITG *nmat, ITG *ntmat_,
+                            ITG *npmat_, ITG *norien, ITG *nam, ITG *nprint, ITG *mi,
+                            ITG *ntrans, ITG *ncs_, ITG *namtot, ITG *ncmat_, ITG *mpcend,
+                            ITG *maxlenmpc, ITG *ne1d,
+                            ITG *ne2d, ITG *nflow, ITG *nlabel, ITG *iplas, ITG *nkon, ITG *ithermal,
+                            ITG *nmethod, ITG *iperturb, ITG *nstate_, ITG *nener, char *set,
+                            ITG *istartset, ITG *iendset, ITG *ialset, double *co, ITG *kon, ITG *ipkon,
+                            char *lakon, ITG *nodeboun, ITG *ndirboun, ITG *iamboun, double *xboun,
+                            ITG *ikboun, ITG *ilboun, ITG *ipompc, ITG *nodempc, double *coefmpc,
+                            char *labmpc, ITG *ikmpc, ITG *ilmpc, ITG *nodeforc, ITG *ndirforc,
+                            ITG *iamforc, double *xforc, ITG *ikforc, ITG *ilforc, ITG *nelemload,
+                            ITG *iamload, char *sideload, double *xload,
+                            double *elcon, ITG *nelcon, double *rhcon, ITG *nrhcon, double *alcon,
+                            ITG *nalcon, double *alzero, double *plicon, ITG *nplicon, double *plkcon,
+                            ITG *nplkcon, char *orname, double *orab, ITG *ielorien, double *trab,
+                            ITG *inotr, char *amname, double *amta, ITG *namta, double *t0, double *t1,
+                            ITG *iamt1, double *veold, ITG *ielmat, char *matname,
+                            char *prlab, char *prset, char *filab, double *vold,
+                            ITG *nodebounold, ITG *ndirbounold, double *xbounold, double *xforcold,
+                            double *xloadold, double *t1old, double *eme, ITG *iponor,
+                            double *xnor, ITG *knor, double *thicke, double *offset,
+                            ITG *iponoel, ITG *inoel, ITG *rig,
+                            double *shcon, ITG *nshcon, double *cocon, ITG *ncocon,
+                            ITG *ics, double *sti, double *ener, double *xstate,
+                            char *jobnamec, ITG *infree, double *prestr, ITG *iprestr,
+                            char *cbody, ITG *ibody, double *xbody, ITG *nbody, double *xbodyold,
+                            double *ttime, double *qaold, double *cs,
+                            ITG *mcs, char *output, double *physcon, double *ctrl, char *typeboun,
+                            double *fmpc, char *tieset, ITG *ntie, double *tietol, ITG *nslavs,
+                            double *t0g, double *t1g, ITG *nprop, ITG *ielprop, double *prop, ITG *mortar,
+                            ITG *nintpoint, ITG *ifacecount, ITG *islavsurf, double *pslavsurf,
+                            double *clearini, ITG *irstrt, double *vel, ITG *nef, double *velo,
+                            double *veloo, ITG *ne2boun, ITG *memmpc_, char *heading, ITG *nheading_,
+                            ITG *network, ITG *nfc, ITG *ndc, double *coeffc, ITG *ikdc, double *edc));
 
-void FORTRAN(resultnet,(ITG *itg,ITG *ieg,ITG *ntg,
-                        double *bc,ITG *nload,char *sideload,
-                        ITG *nelemload,double *xloadact,char *lakon,
-                        ITG *ntmat_,double *v,double *shcon,ITG *nshcon,
-                        ITG *ipkon,ITG *kon,double *co,ITG *nflow,
-                        ITG *iinc,ITG *istep,
-                        double *dtime,double *ttime,double *time,
-                        ITG *ikforc,ITG *ilforc,
-                        double *xforcact,ITG *nforc,
-                        ITG *ielmat,ITG *nteq,double *prop,
-                        ITG *ielprop,ITG *nactdog,ITG *nacteq,ITG *iin,
-                        double *physcon,double *camt,double *camf,
-                        double *camp,double *rhcon,ITG *nrhcon,
-                        ITG *ipobody,ITG *ibody,double *xbody,ITG *nbody,
-                        double *dtheta,double *vold,double *xloadold,
-                        double *reltime,ITG *nmethod,char *set,ITG *mi,
-                        ITG *ineighe,double *cama,double *vamt,
-                        double *vamf,double *vamp,double *vama,
-                        ITG *nmpc,ITG *nodempc,ITG *ipompc,double *coefmpc,
-                        char *labmpc,ITG *iaxial,double *qat,double *qaf,
-                        double *ramt,double *ramf,double *ramp,
-                        double *cocon,ITG *ncocon,ITG *iponoel,ITG *inoel,
-                        ITG *iplausi));
+void FORTRAN(resultnet, (ITG * itg, ITG *ieg, ITG *ntg,
+                         double *bc, ITG *nload, char *sideload,
+                         ITG *nelemload, double *xloadact, char *lakon,
+                         ITG *ntmat_, double *v, double *shcon, ITG *nshcon,
+                         ITG *ipkon, ITG *kon, double *co, ITG *nflow,
+                         ITG *iinc, ITG *istep,
+                         double *dtime, double *ttime, double *time,
+                         ITG *ikforc, ITG *ilforc,
+                         double *xforcact, ITG *nforc,
+                         ITG *ielmat, ITG *nteq, double *prop,
+                         ITG *ielprop, ITG *nactdog, ITG *nacteq, ITG *iin,
+                         double *physcon, double *camt, double *camf,
+                         double *camp, double *rhcon, ITG *nrhcon,
+                         ITG *ipobody, ITG *ibody, double *xbody, ITG *nbody,
+                         double *dtheta, double *vold, double *xloadold,
+                         double *reltime, ITG *nmethod, char *set, ITG *mi,
+                         ITG *ineighe, double *cama, double *vamt,
+                         double *vamf, double *vamp, double *vama,
+                         ITG *nmpc, ITG *nodempc, ITG *ipompc, double *coefmpc,
+                         char *labmpc, ITG *iaxial, double *qat, double *qaf,
+                         double *ramt, double *ramf, double *ramp,
+                         double *cocon, ITG *ncocon, ITG *iponoel, ITG *inoel,
+                         ITG *iplausi));
 
-void results(double *co,ITG *nk,ITG *kon,ITG *ipkon,char *lakon,
-             ITG *ne,double *v,double *stn,ITG *inum,
+void results(double *co, ITG *nk, ITG *kon, ITG *ipkon, char *lakon,
+             ITG *ne, double *v, double *stn, ITG *inum,
              double *stx,
-             double *elcon,ITG *nelcon,double *rhcon,ITG *nrhcon,
-             double *alcon,ITG *nalcon,double *alzero,ITG *ielmat,
-             ITG *ielorien,ITG *norien,double *orab,ITG *ntmat_,
-             double *t0,double *t1,ITG *ithermal,double *prestr,
-             ITG *iprestr,char *filab,double *eme,double *emn,
-             double *een,ITG *iperturb,double *f,double *fn,ITG *nactdof,
-             ITG *iout,double *qa,
-             double *vold,double *b,ITG *nodeboun,ITG *ndirboun,
-             double *xboun,ITG *nboun,ITG *ipompc,ITG *nodempc,
-             double *coefmpc,char *labmpc,ITG *nmpc,ITG *nmethod,
-             double *vmax,ITG *neq,double *veold,double *accold,
-             double *beta,double *gamma,double *dtime,double *time,
-             double *ttime,double *plicon,
-             ITG *nplicon,double *plkcon,ITG *nplkcon,
-             double *xstateini,double *xstiff,double *xstate,ITG *npmat_,
-             double *epl,char *matname,ITG *mi,ITG *ielas,
-             ITG *icmd,ITG *ncmat_,ITG *nstate_,double *stiini,
-             double *vini,ITG *ikboun,ITG *ilboun,double *ener,
-             double *enern,double *emeini,double *xstaten,double *eei,
-             double *enerini,double *cocon,ITG *ncocon,char *set,
-             ITG *nset,ITG *istartset,
-             ITG *iendset,ITG *ialset,ITG *nprint,char *prlab,
-             char *prset,double *qfx,double *qfn,double *trab,
-             ITG *inotr,ITG *ntrans,double *fmpc,ITG *nelemload,
-             ITG *nload,ITG *ikmpc,ITG *ilmpc,ITG *istep,ITG *iinc,
-             double *springarea,double *reltime,ITG *ne0,double *thicke,
-             double *shcon,ITG *nshcon,char *sideload,double *xload,
-             double *xloadold,ITG *icfd,ITG *inomat,double *pslavsurf,
-             double *pmastsurf,ITG *mortar,ITG *islavact,double *cdn,
-             ITG *islavnode,ITG *nslavnode,ITG *ntie,double *clearini,
-             ITG *islavsurf,ITG *ielprop,double *prop,double *energyini,
-             double *energy,ITG *kscale,ITG *iponoel,ITG *inoel,ITG *nener,
-             char *orname,ITG *network,ITG *ipobody,double *xbodyact,
-             ITG *ibody,char *typeboun,ITG *itiefac,char *tieset,
-             double *smscale,ITG *mscalmethod,ITG *nbody,double *t0g,
-	     double *t1g,ITG *islavelinv,double *autloc,ITG *irowtloc,
-	     ITG *jqtloc,ITG *nboun2,ITG *ndirboun2,ITG *nodeboun2,
-	     double *xboun2,ITG *nmpc2,ITG *ipompc2,ITG *nodempc2,
-	     double *coefmpc2,char *labmpc2,ITG *ikboun2,ITG *ilboun2,
-	     ITG *ikmpc2,ITG *ilmpc2,ITG *mortartrafoflag,ITG *intscheme);
+             double *elcon, ITG *nelcon, double *rhcon, ITG *nrhcon,
+             double *alcon, ITG *nalcon, double *alzero, ITG *ielmat,
+             ITG *ielorien, ITG *norien, double *orab, ITG *ntmat_,
+             double *t0, double *t1, ITG *ithermal, double *prestr,
+             ITG *iprestr, char *filab, double *eme, double *emn,
+             double *een, ITG *iperturb, double *f, double *fn, ITG *nactdof,
+             ITG *iout, double *qa,
+             double *vold, double *b, ITG *nodeboun, ITG *ndirboun,
+             double *xboun, ITG *nboun, ITG *ipompc, ITG *nodempc,
+             double *coefmpc, char *labmpc, ITG *nmpc, ITG *nmethod,
+             double *vmax, ITG *neq, double *veold, double *accold,
+             double *beta, double *gamma, double *dtime, double *time,
+             double *ttime, double *plicon,
+             ITG *nplicon, double *plkcon, ITG *nplkcon,
+             double *xstateini, double *xstiff, double *xstate, ITG *npmat_,
+             double *epl, char *matname, ITG *mi, ITG *ielas,
+             ITG *icmd, ITG *ncmat_, ITG *nstate_, double *stiini,
+             double *vini, ITG *ikboun, ITG *ilboun, double *ener,
+             double *enern, double *emeini, double *xstaten, double *eei,
+             double *enerini, double *cocon, ITG *ncocon, char *set,
+             ITG *nset, ITG *istartset,
+             ITG *iendset, ITG *ialset, ITG *nprint, char *prlab,
+             char *prset, double *qfx, double *qfn, double *trab,
+             ITG *inotr, ITG *ntrans, double *fmpc, ITG *nelemload,
+             ITG *nload, ITG *ikmpc, ITG *ilmpc, ITG *istep, ITG *iinc,
+             double *springarea, double *reltime, ITG *ne0, double *thicke,
+             double *shcon, ITG *nshcon, char *sideload, double *xload,
+             double *xloadold, ITG *icfd, ITG *inomat, double *pslavsurf,
+             double *pmastsurf, ITG *mortar, ITG *islavact, double *cdn,
+             ITG *islavnode, ITG *nslavnode, ITG *ntie, double *clearini,
+             ITG *islavsurf, ITG *ielprop, double *prop, double *energyini,
+             double *energy, ITG *kscale, ITG *iponoel, ITG *inoel, ITG *nener,
+             char *orname, ITG *network, ITG *ipobody, double *xbodyact,
+             ITG *ibody, char *typeboun, ITG *itiefac, char *tieset,
+             double *smscale, ITG *mscalmethod, ITG *nbody, double *t0g,
+             double *t1g, ITG *islavelinv, double *autloc, ITG *irowtloc,
+             ITG *jqtloc, ITG *nboun2, ITG *ndirboun2, ITG *nodeboun2,
+             double *xboun2, ITG *nmpc2, ITG *ipompc2, ITG *nodempc2,
+             double *coefmpc2, char *labmpc2, ITG *ikboun2, ITG *ilboun2,
+             ITG *ikmpc2, ITG *ilmpc2, ITG *mortartrafoflag, ITG *intscheme);
 
-void FORTRAN(resultsem,(double *co,ITG *kon,ITG *ipkon,char *lakon,
-             double *v,double *elcon,ITG *nelcon,ITG *ielmat,ITG *ntmat_,
-             double *vold,double *dtime,char *matname,ITG *mi,ITG *ncmat_,
-             ITG *nea,ITG *neb,double *sti,double *alcon,
-             ITG *nalcon,double *h0,ITG *istartset,ITG *iendset,ITG *ialset,
-	     ITG *iactive,double *fn,double *eei,ITG *iout,ITG *nmethod));
+void FORTRAN(resultsem, (double *co, ITG *kon, ITG *ipkon, char *lakon,
+                         double *v, double *elcon, ITG *nelcon, ITG *ielmat, ITG *ntmat_,
+                         double *vold, double *dtime, char *matname, ITG *mi, ITG *ncmat_,
+                         ITG *nea, ITG *neb, double *sti, double *alcon,
+                         ITG *nalcon, double *h0, ITG *istartset, ITG *iendset, ITG *ialset,
+                         ITG *iactive, double *fn, double *eei, ITG *iout, ITG *nmethod));
 
 void *resultsemmt(ITG *i);
 
-void resultsforc(ITG *nk,double *f,double *fn,ITG *nactdof,
-       ITG *ipompc,ITG *nodempc,double *coefmpc,char *labmpc,ITG *nmpc,
-       ITG *mi,double *fmpc,ITG *calcul_fn,ITG *calcul_f,ITG *num_cpus);
+void resultsforc(ITG *nk, double *f, double *fn, ITG *nactdof,
+                 ITG *ipompc, ITG *nodempc, double *coefmpc, char *labmpc, ITG *nmpc,
+                 ITG *mi, double *fmpc, ITG *calcul_fn, ITG *calcul_f, ITG *num_cpus);
 
-void  FORTRAN(resultsforc_em,(ITG *nk,double *f,double *fn,ITG *nactdof,
-       ITG *ipompc,ITG *nodempc,double *coefmpc,char *labmpc,ITG *nmpc,
-       ITG *mi,double *fmpc,ITG *calcul_fn,ITG *calcul_f,ITG *inomat));
-       
-void  FORTRAN(resultsforc_se,(ITG *nk,double *dfn,ITG *nactdof,
-       ITG *ipompc,ITG *nodempc,double *coefmpc,ITG *nmpc,
-       ITG *mi,double *fmpc,ITG *calcul_fn,ITG *calcul_f,ITG *idesvar,
-       double *df,ITG *jqs,ITG *irows,double *distmin));
+void FORTRAN(resultsforc_em, (ITG * nk, double *f, double *fn, ITG *nactdof,
+                              ITG *ipompc, ITG *nodempc, double *coefmpc, char *labmpc, ITG *nmpc,
+                              ITG *mi, double *fmpc, ITG *calcul_fn, ITG *calcul_f, ITG *inomat));
 
-void resultsini(ITG *nk,double *v,ITG *ithermal,char *filab,
-		ITG *iperturb,double *f,double *fn,ITG *nactdof,ITG *iout,
-		double *qa,double *vold,double *b,ITG *nodeboun,ITG *ndirboun,
-		double *xboun,ITG *nboun,ITG *ipompc,ITG *nodempc,
-		double *coefmpc,char *labmpc,ITG *nmpc,ITG *nmethod,
-		double *cam,ITG *neq,double *veold,double *accold,double *bet,
-		double *gam,double *dtime,ITG *mi,double *vini,ITG *nprint,
-		char *prlab,ITG *intpointvar,ITG *calcul_fn,ITG *calcul_f,
-		ITG *calcul_qa,ITG *calcul_cauchy,ITG *ikin,ITG *intpointvart,
-		char *typeboun,ITG *num_cpus,ITG *mortar);
+void FORTRAN(resultsforc_se, (ITG * nk, double *dfn, ITG *nactdof,
+                              ITG *ipompc, ITG *nodempc, double *coefmpc, ITG *nmpc,
+                              ITG *mi, double *fmpc, ITG *calcul_fn, ITG *calcul_f, ITG *idesvar,
+                              double *df, ITG *jqs, ITG *irows, double *distmin));
 
-void FORTRAN(resultsini_em,(ITG *nk,double *v,ITG *ithermal,char *filab,
-       ITG *iperturb,double *f,double *fn,ITG *nactdof,ITG *iout,
-       double *qa,double *b,ITG *nodeboun,ITG *ndirboun,
-       double *xboun,ITG *nboun,ITG *ipompc,ITG *nodempc,double *coefmpc,
-       char *labmpc,ITG *nmpc,ITG *nmethod,double *cam,ITG *neq,
-       double *veold,double *dtime,
-       ITG *mi,double *vini,ITG *nprint,char *prlab,ITG *intpointvar,
-       ITG *calcul_fn,ITG *calcul_f,ITG *calcul_qa,ITG *calcul_cauchy,
-       ITG *iener,ITG *ikin,ITG *intpointvart,double *xforc,ITG *nforc));
+void resultsini(ITG *nk, double *v, ITG *ithermal, char *filab,
+                ITG *iperturb, double *f, double *fn, ITG *nactdof, ITG *iout,
+                double *qa, double *vold, double *b, ITG *nodeboun, ITG *ndirboun,
+                double *xboun, ITG *nboun, ITG *ipompc, ITG *nodempc,
+                double *coefmpc, char *labmpc, ITG *nmpc, ITG *nmethod,
+                double *cam, ITG *neq, double *veold, double *accold, double *bet,
+                double *gam, double *dtime, ITG *mi, double *vini, ITG *nprint,
+                char *prlab, ITG *intpointvar, ITG *calcul_fn, ITG *calcul_f,
+                ITG *calcul_qa, ITG *calcul_cauchy, ITG *ikin, ITG *intpointvart,
+                char *typeboun, ITG *num_cpus, ITG *mortar);
 
-void FORTRAN(resultsk,(ITG *nk,ITG *nactdoh,double *v,double *solk,
-		       double *solt,ITG *ipompc,ITG *nodempc,double *coefmpc,
-		       ITG *nmpc,ITG *mi));
+void FORTRAN(resultsini_em, (ITG * nk, double *v, ITG *ithermal, char *filab,
+                             ITG *iperturb, double *f, double *fn, ITG *nactdof, ITG *iout,
+                             double *qa, double *b, ITG *nodeboun, ITG *ndirboun,
+                             double *xboun, ITG *nboun, ITG *ipompc, ITG *nodempc, double *coefmpc,
+                             char *labmpc, ITG *nmpc, ITG *nmethod, double *cam, ITG *neq,
+                             double *veold, double *dtime,
+                             ITG *mi, double *vini, ITG *nprint, char *prlab, ITG *intpointvar,
+                             ITG *calcul_fn, ITG *calcul_f, ITG *calcul_qa, ITG *calcul_cauchy,
+                             ITG *iener, ITG *ikin, ITG *intpointvart, double *xforc, ITG *nforc));
 
-void FORTRAN(resultsmech,(double *co,ITG *kon,ITG *ipkon,char *lakon,ITG *ne,
-          double *v,double *stx,double *elcon,ITG *nelcon,double *rhcon,
-          ITG *nrhcon,double *alcon,ITG *nalcon,double *alzero,ITG *ielmat,
-          ITG *ielorien,ITG *norien,double *orab,ITG *ntmat_,double *t0,
-          double *t1,ITG *ithermal,double *prestr,ITG *iprestr,double *eme,
-          ITG *iperturb,double *fn,ITG *iout,double *qa,double *vold,
-          ITG *nmethod,double *veold,double *dtime,double *time,
-          double *ttime,double *plicon,ITG *nplicon,double *plkcon,
-          ITG *nplkcon,double *xstateini,double *xstiff,double *xstate,
-          ITG *npmat_,char *matname,ITG *mi,ITG *ielas,ITG *icmd,ITG *ncmat_,
-          ITG *nstate_,double *stiini,double *vini,double *ener,double *eei,
-          double *enerini,ITG *istep,ITG *iinc,double *springarea,
-          double *reltime,ITG *calcul_fn,ITG *calcul_qa,ITG *calcul_cauchy,
-          ITG *iener,ITG *ikin,ITG *nal,ITG *ne0,double *thicke,
-          double *emeini,double *pslavsurf,double *pmastsurf,ITG *mortar,
-          double *clearini,ITG *nea,ITG *neb,ITG *ielprop,double *prop,
-          ITG *kscale,ITG *list,ITG *ilist,double *smscale,ITG *mscalmethod,
-	  double *enerscal,double *t0g,double *t1g,ITG *islavelinv,
-	  double *autloc,ITG *irowtloc,ITG *jqtloc,ITG *mortartrafoflag,
-	  ITG *intscheme));
+void FORTRAN(resultsk, (ITG * nk, ITG *nactdoh, double *v, double *solk,
+                        double *solt, ITG *ipompc, ITG *nodempc, double *coefmpc,
+                        ITG *nmpc, ITG *mi));
+
+void FORTRAN(resultsmech, (double *co, ITG *kon, ITG *ipkon, char *lakon, ITG *ne,
+                           double *v, double *stx, double *elcon, ITG *nelcon, double *rhcon,
+                           ITG *nrhcon, double *alcon, ITG *nalcon, double *alzero, ITG *ielmat,
+                           ITG *ielorien, ITG *norien, double *orab, ITG *ntmat_, double *t0,
+                           double *t1, ITG *ithermal, double *prestr, ITG *iprestr, double *eme,
+                           ITG *iperturb, double *fn, ITG *iout, double *qa, double *vold,
+                           ITG *nmethod, double *veold, double *dtime, double *time,
+                           double *ttime, double *plicon, ITG *nplicon, double *plkcon,
+                           ITG *nplkcon, double *xstateini, double *xstiff, double *xstate,
+                           ITG *npmat_, char *matname, ITG *mi, ITG *ielas, ITG *icmd, ITG *ncmat_,
+                           ITG *nstate_, double *stiini, double *vini, double *ener, double *eei,
+                           double *enerini, ITG *istep, ITG *iinc, double *springarea,
+                           double *reltime, ITG *calcul_fn, ITG *calcul_qa, ITG *calcul_cauchy,
+                           ITG *iener, ITG *ikin, ITG *nal, ITG *ne0, double *thicke,
+                           double *emeini, double *pslavsurf, double *pmastsurf, ITG *mortar,
+                           double *clearini, ITG *nea, ITG *neb, ITG *ielprop, double *prop,
+                           ITG *kscale, ITG *list, ITG *ilist, double *smscale, ITG *mscalmethod,
+                           double *enerscal, double *t0g, double *t1g, ITG *islavelinv,
+                           double *autloc, ITG *irowtloc, ITG *jqtloc, ITG *mortartrafoflag,
+                           ITG *intscheme));
 
 void *resultsmechmt(ITG *i);
 
@@ -3979,154 +3988,154 @@ void *resultsmechmtstr(ITG *i);
 
 void *resultsmechmt_se(ITG *i);
 
-void FORTRAN(resultsmech_se,(double *co,ITG *kon,ITG *ipkon,char *lakon,ITG *ne,
-          double *v,double *stx,double *elcon,ITG *nelcon,double *rhcon,
-          ITG *nrhcon,double *alcon,ITG *nalcon,double *alzero,ITG *ielmat,
-          ITG *ielorien,ITG *norien,double *orab,ITG *ntmat_,double *t0,
-          double *t1,ITG *ithermal,double *prestr,ITG *iprestr,double *eme,
-          ITG *iperturb,double *fn,ITG *iout,double *vold,
-          ITG *nmethod,double *veold,double *dtime,double *time,
-          double *ttime,double *plicon,ITG *nplicon,double *plkcon,
-          ITG *nplkcon,double *xstateini,double *xstiff,double *xstate,
-          ITG *npmat_,char *matname,ITG *mi,ITG *ielas,ITG *icmd,ITG *ncmat_,
-          ITG *nstate_,double *stiini,double *vini,double *ener,double *eei,
-          double *enerini,ITG *istep,ITG *iinc,double *springarea,
-          double *reltime,ITG *calcul_fn,ITG *calcul_cauchy,
-          ITG *iener,ITG *ikin,ITG *ne0,double *thicke,
-          double *emeini,double *pslavsurf,double *pmastsurf,ITG *mortar,
-          double *clearini,ITG *nea,ITG *neb,ITG *ielprop,double *prop,
-          double *dfn,ITG *idesvar,ITG *nodedesi,
-          double *fn0,double *sti,ITG *icoordinate,
-          double *dxstiff,ITG *ialdesi,double *xdesi));
+void FORTRAN(resultsmech_se, (double *co, ITG *kon, ITG *ipkon, char *lakon, ITG *ne,
+                              double *v, double *stx, double *elcon, ITG *nelcon, double *rhcon,
+                              ITG *nrhcon, double *alcon, ITG *nalcon, double *alzero, ITG *ielmat,
+                              ITG *ielorien, ITG *norien, double *orab, ITG *ntmat_, double *t0,
+                              double *t1, ITG *ithermal, double *prestr, ITG *iprestr, double *eme,
+                              ITG *iperturb, double *fn, ITG *iout, double *vold,
+                              ITG *nmethod, double *veold, double *dtime, double *time,
+                              double *ttime, double *plicon, ITG *nplicon, double *plkcon,
+                              ITG *nplkcon, double *xstateini, double *xstiff, double *xstate,
+                              ITG *npmat_, char *matname, ITG *mi, ITG *ielas, ITG *icmd, ITG *ncmat_,
+                              ITG *nstate_, double *stiini, double *vini, double *ener, double *eei,
+                              double *enerini, ITG *istep, ITG *iinc, double *springarea,
+                              double *reltime, ITG *calcul_fn, ITG *calcul_cauchy,
+                              ITG *iener, ITG *ikin, ITG *ne0, double *thicke,
+                              double *emeini, double *pslavsurf, double *pmastsurf, ITG *mortar,
+                              double *clearini, ITG *nea, ITG *neb, ITG *ielprop, double *prop,
+                              double *dfn, ITG *idesvar, ITG *nodedesi,
+                              double *fn0, double *sti, ITG *icoordinate,
+                              double *dxstiff, ITG *ialdesi, double *xdesi));
 
-void FORTRAN(resultsnoddir,(ITG *nk,double *v,ITG *nactdof,double *b,
-       ITG *ipompc,ITG *nodempc,double *coefmpc,ITG *nmpc,ITG *mi));
+void FORTRAN(resultsnoddir, (ITG * nk, double *v, ITG *nactdof, double *b,
+                             ITG *ipompc, ITG *nodempc, double *coefmpc, ITG *nmpc, ITG *mi));
 
-void FORTRAN(resultsp,(ITG *nk,ITG *nactdoh,double *v,double *sol,
-		       ITG *mi));
+void FORTRAN(resultsp, (ITG * nk, ITG *nactdoh, double *v, double *sol,
+                        ITG *mi));
 
-void  FORTRAN(resultsprint,(double *co,ITG *nk,ITG *kon,ITG *ipkon,
-       char *lakon,ITG *ne,double *v,double *stn,ITG *inum,double *stx,
-       ITG *ielorien,ITG *norien,double *orab,double *t1,ITG *ithermal,
-       char *filab,double *een,ITG *iperturb,double *fn,ITG *nactdof,
-       ITG *iout,double *vold,ITG *nodeboun,ITG *ndirboun,ITG *nboun,
-       ITG *nmethod,double *ttime,double *xstate,double *epn,ITG *mi,
-       ITG *nstate_,double *ener,double *enern,double *xstaten,double *eei,
-       char *set,ITG *nset,ITG *istartset,ITG *iendset,ITG *ialset,ITG *nprint,
-       char *prlab,char *prset,double *qfx,double *qfn,double *trab,ITG *inotr,
-       ITG *ntrans,ITG *nelemload,ITG *nload,ITG *ikin,ITG *ielmat,
-       double *thicke,double *eme,double *emn,double *rhcon,ITG *nrhcon,
-       double *shcon,ITG *nshcon,double *cocon,ITG *ncocon,ITG *ntmat_,
-       char *sideload,ITG *icfd,ITG *inomat,double *pslavsurf,
-       ITG *islavact,double *cdn,ITG *mortar,ITG *islavnode,ITG *nslavnode,
-       ITG *ntie,ITG *islavsurf,double *time,ITG *ielprop,double *prop,
-       double *veold,ITG *ne0,ITG *nmpc,ITG *ipompc,ITG *nodempc,
-       char *labmpc,double *energyini,double *energy,char *orname,
-       double *xload,ITG *itiefac,double *pmastsurf,double *springarea,
-       char *tieset,ITG *ipobody,ITG *ibody,double *xbody,ITG *nbody));
+void FORTRAN(resultsprint, (double *co, ITG *nk, ITG *kon, ITG *ipkon,
+                            char *lakon, ITG *ne, double *v, double *stn, ITG *inum, double *stx,
+                            ITG *ielorien, ITG *norien, double *orab, double *t1, ITG *ithermal,
+                            char *filab, double *een, ITG *iperturb, double *fn, ITG *nactdof,
+                            ITG *iout, double *vold, ITG *nodeboun, ITG *ndirboun, ITG *nboun,
+                            ITG *nmethod, double *ttime, double *xstate, double *epn, ITG *mi,
+                            ITG *nstate_, double *ener, double *enern, double *xstaten, double *eei,
+                            char *set, ITG *nset, ITG *istartset, ITG *iendset, ITG *ialset, ITG *nprint,
+                            char *prlab, char *prset, double *qfx, double *qfn, double *trab, ITG *inotr,
+                            ITG *ntrans, ITG *nelemload, ITG *nload, ITG *ikin, ITG *ielmat,
+                            double *thicke, double *eme, double *emn, double *rhcon, ITG *nrhcon,
+                            double *shcon, ITG *nshcon, double *cocon, ITG *ncocon, ITG *ntmat_,
+                            char *sideload, ITG *icfd, ITG *inomat, double *pslavsurf,
+                            ITG *islavact, double *cdn, ITG *mortar, ITG *islavnode, ITG *nslavnode,
+                            ITG *ntie, ITG *islavsurf, double *time, ITG *ielprop, double *prop,
+                            double *veold, ITG *ne0, ITG *nmpc, ITG *ipompc, ITG *nodempc,
+                            char *labmpc, double *energyini, double *energy, char *orname,
+                            double *xload, ITG *itiefac, double *pmastsurf, double *springarea,
+                            char *tieset, ITG *ipobody, ITG *ibody, double *xbody, ITG *nbody));
 
-void resultsstr(double *co,ITG *nk,ITG *kon,ITG *ipkon,char *lakon,
-             ITG *ne,double *v,double *stn,ITG *inum,
-             double *stx,
-             double *elcon,ITG *nelcon,double *rhcon,ITG *nrhcon,
-             double *alcon,ITG *nalcon,double *alzero,ITG *ielmat,
-             ITG *ielorien,ITG *norien,double *orab,ITG *ntmat_,
-             double *t0,double *t1,ITG *ithermal,double *prestr,
-             ITG *iprestr,char *filab,double *eme,double *emn,
-             double *een,ITG *iperturb,double *f,double *fn,ITG *nactdof,
-             ITG *iout,double *qa,
-             double *vold,double *b,ITG *nodeboun,ITG *ndirboun,
-             double *xboun,ITG *nboun,ITG *ipompc,ITG *nodempc,
-             double *coefmpc,char *labmpc,ITG *nmpc,ITG *nmethod,
-             double *vmax,ITG *neq,double *veold,double *accold,
-             double *beta,double *gamma,double *dtime,double *time,
-             double *ttime,double *plicon,
-             ITG *nplicon,double *plkcon,ITG *nplkcon,
-             double *xstateini,double *xstiff,double *xstate,ITG *npmat_,
-             double *epl,char *matname,ITG *mi,ITG *ielas,
-             ITG *icmd,ITG *ncmat_,ITG *nstate_,double *stiini,
-             double *vini,ITG *ikboun,ITG *ilboun,double *ener,
-             double *enern,double *emeini,double *xstaten,double *eei,
-             double *enerini,double *cocon,ITG *ncocon,char *set,
-             ITG *nset,ITG *istartset,
-             ITG *iendset,ITG *ialset,ITG *nprint,char *prlab,
-             char *prset,double *qfx,double *qfn,double *trab,
-             ITG *inotr,ITG *ntrans,double *fmpc,ITG *nelemload,
-             ITG *nload,ITG *ikmpc,ITG *ilmpc,ITG *istep,ITG *iinc,
-             double *springarea,double *reltime,ITG *ne0,double *xforc,
-             ITG *nforc,double *thicke,
-             double *shcon,ITG *nshcon,char *sideload,double *xload,
-             double *xloadold,ITG *icfd,ITG *inomat,double *pslavsurf,
-             double *pmastsurf,ITG *mortar,ITG *islavact,double *cdn,
-             ITG *islavnode,ITG *nslavnode,ITG *ntie,double *clearini,
-             ITG *islavsurf,ITG *ielprop,double *prop,double *energyini,
-             double *energy,ITG *kscale,ITG *nener,
-             char *orname,ITG *network,ITG *neapar,ITG *nebpar,
-	     ITG *ipobody,ITG *ibody,double *xbody,ITG *nbody);
-             
-void results_se(double *co,ITG *nk,ITG *kon,ITG *ipkon,char *lakon,
-             ITG *ne,double *v,double *stn,ITG *inum,
-             double *stx,
-             double *elcon,ITG *nelcon,double *rhcon,ITG *nrhcon,
-             double *alcon,ITG *nalcon,double *alzero,ITG *ielmat,
-             ITG *ielorien,ITG *norien,double *orab,ITG *ntmat_,
-             double *t0,double *t1,ITG *ithermal,double *prestr,
-             ITG *iprestr,char *filab,double *eme,double *emn,
-             double *een,ITG *iperturb,double *f,double *fn,ITG *nactdof,
-             ITG *iout,double *qa,
-             double *vold,double *b,ITG *nodeboun,ITG *ndirboun,
-             double *xboun,ITG *nboun,ITG *ipompc,ITG *nodempc,
-             double *coefmpc,char *labmpc,ITG *nmpc,ITG *nmethod,
-             double *vmax,ITG *neq,double *veold,double *accold,
-             double *beta,double *gamma,double *dtime,double *time,
-             double *ttime,double *plicon,
-             ITG *nplicon,double *plkcon,ITG *nplkcon,
-             double *xstateini,double *xstiff,double *xstate,ITG *npmat_,
-             double *epl,char *matname,ITG *mi,ITG *ielas,
-             ITG *icmd,ITG *ncmat_,ITG *nstate_,double *stiini,
-             double *vini,ITG *ikboun,ITG *ilboun,double *ener,
-             double *enern,double *emeini,double *xstaten,double *eei,
-             double *enerini,double *cocon,ITG *ncocon,char *set,
-             ITG *nset,ITG *istartset,
-             ITG *iendset,ITG *ialset,ITG *nprint,char *prlab,
-             char *prset,double *qfx,double *qfn,double *trab,
-             ITG *inotr,ITG *ntrans,double *fmpc,ITG *nelemload,
-             ITG *nload,ITG *ikmpc,ITG *ilmpc,ITG *istep,ITG *iinc,
-             double *springarea,double *reltime,ITG *ne0,double *xforc,
-             ITG *nforc,double *thicke,
-             double *shcon,ITG *nshcon,char *sideload,double *xload,
-             double *xloadold,ITG *icfd,ITG *inomat,double *pslavsurf,
-             double *pmastsurf,ITG *mortar,ITG *islavact,double *cdn,
-             ITG *islavnode,ITG *nslavnode,ITG *ntie,double *clearini,
-             ITG *islavsurf,ITG *ielprop,double *prop,double *energyini,
-             double *energy,double *df,double *distmin,
-             ITG *ndesi,ITG *nodedesi,double *sti,
-             ITG *nkon,ITG *jqs,ITG *irows,ITG *nactdofinv,
-             ITG *icoordinate,double *dxstiff,ITG *istartdesi,
-             ITG *ialdesi,double *xdesi,ITG *ieigenfrequency,
-             double *fint,ITG *ishapeenergy,char *typeboun);
+void resultsstr(double *co, ITG *nk, ITG *kon, ITG *ipkon, char *lakon,
+                ITG *ne, double *v, double *stn, ITG *inum,
+                double *stx,
+                double *elcon, ITG *nelcon, double *rhcon, ITG *nrhcon,
+                double *alcon, ITG *nalcon, double *alzero, ITG *ielmat,
+                ITG *ielorien, ITG *norien, double *orab, ITG *ntmat_,
+                double *t0, double *t1, ITG *ithermal, double *prestr,
+                ITG *iprestr, char *filab, double *eme, double *emn,
+                double *een, ITG *iperturb, double *f, double *fn, ITG *nactdof,
+                ITG *iout, double *qa,
+                double *vold, double *b, ITG *nodeboun, ITG *ndirboun,
+                double *xboun, ITG *nboun, ITG *ipompc, ITG *nodempc,
+                double *coefmpc, char *labmpc, ITG *nmpc, ITG *nmethod,
+                double *vmax, ITG *neq, double *veold, double *accold,
+                double *beta, double *gamma, double *dtime, double *time,
+                double *ttime, double *plicon,
+                ITG *nplicon, double *plkcon, ITG *nplkcon,
+                double *xstateini, double *xstiff, double *xstate, ITG *npmat_,
+                double *epl, char *matname, ITG *mi, ITG *ielas,
+                ITG *icmd, ITG *ncmat_, ITG *nstate_, double *stiini,
+                double *vini, ITG *ikboun, ITG *ilboun, double *ener,
+                double *enern, double *emeini, double *xstaten, double *eei,
+                double *enerini, double *cocon, ITG *ncocon, char *set,
+                ITG *nset, ITG *istartset,
+                ITG *iendset, ITG *ialset, ITG *nprint, char *prlab,
+                char *prset, double *qfx, double *qfn, double *trab,
+                ITG *inotr, ITG *ntrans, double *fmpc, ITG *nelemload,
+                ITG *nload, ITG *ikmpc, ITG *ilmpc, ITG *istep, ITG *iinc,
+                double *springarea, double *reltime, ITG *ne0, double *xforc,
+                ITG *nforc, double *thicke,
+                double *shcon, ITG *nshcon, char *sideload, double *xload,
+                double *xloadold, ITG *icfd, ITG *inomat, double *pslavsurf,
+                double *pmastsurf, ITG *mortar, ITG *islavact, double *cdn,
+                ITG *islavnode, ITG *nslavnode, ITG *ntie, double *clearini,
+                ITG *islavsurf, ITG *ielprop, double *prop, double *energyini,
+                double *energy, ITG *kscale, ITG *nener,
+                char *orname, ITG *network, ITG *neapar, ITG *nebpar,
+                ITG *ipobody, ITG *ibody, double *xbody, ITG *nbody);
 
-void FORTRAN(resultst,(ITG *nk,ITG *nactdoh,double *v,double *sol,ITG *ipompc,
-		       ITG *nodempc,double *coefmpc,ITG *nmpc,ITG *mi));
+void results_se(double *co, ITG *nk, ITG *kon, ITG *ipkon, char *lakon,
+                ITG *ne, double *v, double *stn, ITG *inum,
+                double *stx,
+                double *elcon, ITG *nelcon, double *rhcon, ITG *nrhcon,
+                double *alcon, ITG *nalcon, double *alzero, ITG *ielmat,
+                ITG *ielorien, ITG *norien, double *orab, ITG *ntmat_,
+                double *t0, double *t1, ITG *ithermal, double *prestr,
+                ITG *iprestr, char *filab, double *eme, double *emn,
+                double *een, ITG *iperturb, double *f, double *fn, ITG *nactdof,
+                ITG *iout, double *qa,
+                double *vold, double *b, ITG *nodeboun, ITG *ndirboun,
+                double *xboun, ITG *nboun, ITG *ipompc, ITG *nodempc,
+                double *coefmpc, char *labmpc, ITG *nmpc, ITG *nmethod,
+                double *vmax, ITG *neq, double *veold, double *accold,
+                double *beta, double *gamma, double *dtime, double *time,
+                double *ttime, double *plicon,
+                ITG *nplicon, double *plkcon, ITG *nplkcon,
+                double *xstateini, double *xstiff, double *xstate, ITG *npmat_,
+                double *epl, char *matname, ITG *mi, ITG *ielas,
+                ITG *icmd, ITG *ncmat_, ITG *nstate_, double *stiini,
+                double *vini, ITG *ikboun, ITG *ilboun, double *ener,
+                double *enern, double *emeini, double *xstaten, double *eei,
+                double *enerini, double *cocon, ITG *ncocon, char *set,
+                ITG *nset, ITG *istartset,
+                ITG *iendset, ITG *ialset, ITG *nprint, char *prlab,
+                char *prset, double *qfx, double *qfn, double *trab,
+                ITG *inotr, ITG *ntrans, double *fmpc, ITG *nelemload,
+                ITG *nload, ITG *ikmpc, ITG *ilmpc, ITG *istep, ITG *iinc,
+                double *springarea, double *reltime, ITG *ne0, double *xforc,
+                ITG *nforc, double *thicke,
+                double *shcon, ITG *nshcon, char *sideload, double *xload,
+                double *xloadold, ITG *icfd, ITG *inomat, double *pslavsurf,
+                double *pmastsurf, ITG *mortar, ITG *islavact, double *cdn,
+                ITG *islavnode, ITG *nslavnode, ITG *ntie, double *clearini,
+                ITG *islavsurf, ITG *ielprop, double *prop, double *energyini,
+                double *energy, double *df, double *distmin,
+                ITG *ndesi, ITG *nodedesi, double *sti,
+                ITG *nkon, ITG *jqs, ITG *irows, ITG *nactdofinv,
+                ITG *icoordinate, double *dxstiff, ITG *istartdesi,
+                ITG *ialdesi, double *xdesi, ITG *ieigenfrequency,
+                double *fint, ITG *ishapeenergy, char *typeboun);
 
-void FORTRAN(resultstherm,(double *co,ITG *kon,ITG *ipkon,
-       char *lakon,double *v,
-       double *elcon,ITG *nelcon,double *rhcon,ITG *nrhcon,ITG *ielmat,
-       ITG *ielorien,ITG *norien,double *orab,ITG *ntmat_,double *t0,
-       ITG *iperturb,double *fn,double *shcon,ITG *nshcon,ITG *iout,
-       double *qa,double *vold,ITG *ipompc,ITG *nodempc,
-       double *coefmpc,ITG *nmpc,double *dtime,
-       double *time,double *ttime,double *plkcon,ITG *nplkcon,double *xstateini,
-       double *xstiff,double *xstate,ITG *npmat_,char *matname,
-       ITG *mi,ITG *ncmat_,ITG *nstate_,double *cocon,ITG *ncocon,
-       double *qfx,ITG *ikmpc,ITG *ilmpc,ITG *istep,
-       ITG *iinc,double *springarea,ITG *calcul_fn,ITG *calcul_qa,ITG *nal,
-       ITG *nea,ITG *neb,ITG *ithermal,ITG *nelemload,ITG *nload,
-       ITG *nmethod,double *reltime,char *sideload,double *xload,
-       double *xloadold,double *pslavsurf,double *pmastsurf,ITG *mortar,
-       double *clearini,double *plicon,ITG *nplicon,ITG *ielprop,
-       double *prop,ITG *iponoel,ITG *inoel,ITG *network,ITG *ipobody,
-       double *xbodyact,ITG *ibody));
+void FORTRAN(resultst, (ITG * nk, ITG *nactdoh, double *v, double *sol, ITG *ipompc,
+                        ITG *nodempc, double *coefmpc, ITG *nmpc, ITG *mi));
+
+void FORTRAN(resultstherm, (double *co, ITG *kon, ITG *ipkon,
+                            char *lakon, double *v,
+                            double *elcon, ITG *nelcon, double *rhcon, ITG *nrhcon, ITG *ielmat,
+                            ITG *ielorien, ITG *norien, double *orab, ITG *ntmat_, double *t0,
+                            ITG *iperturb, double *fn, double *shcon, ITG *nshcon, ITG *iout,
+                            double *qa, double *vold, ITG *ipompc, ITG *nodempc,
+                            double *coefmpc, ITG *nmpc, double *dtime,
+                            double *time, double *ttime, double *plkcon, ITG *nplkcon, double *xstateini,
+                            double *xstiff, double *xstate, ITG *npmat_, char *matname,
+                            ITG *mi, ITG *ncmat_, ITG *nstate_, double *cocon, ITG *ncocon,
+                            double *qfx, ITG *ikmpc, ITG *ilmpc, ITG *istep,
+                            ITG *iinc, double *springarea, ITG *calcul_fn, ITG *calcul_qa, ITG *nal,
+                            ITG *nea, ITG *neb, ITG *ithermal, ITG *nelemload, ITG *nload,
+                            ITG *nmethod, double *reltime, char *sideload, double *xload,
+                            double *xloadold, double *pslavsurf, double *pmastsurf, ITG *mortar,
+                            double *clearini, double *plicon, ITG *nplicon, ITG *ielprop,
+                            double *prop, ITG *iponoel, ITG *inoel, ITG *network, ITG *ipobody,
+                            double *xbodyact, ITG *ibody));
 
 void *resultsthermemmt(ITG *i);
 
@@ -4134,959 +4143,959 @@ void *resultsthermmt(ITG *i);
 
 void *resultsthermmt_se(ITG *i);
 
-void resultsinduction(double *co,ITG *nk,ITG *kon,ITG *ipkon,char *lakon,
-             ITG *ne,double *v,double *stn,ITG *inum,
-             double *elcon,ITG *nelcon,double *rhcon,ITG *nrhcon,
-             double *alcon,ITG *nalcon,double *alzero,ITG *ielmat,
-             ITG *ielorien,ITG *norien,double *orab,ITG *ntmat_,
-             double *t0,double *t1,ITG *ithermal,double *prestr,
-             ITG *iprestr,char *filab,double *eme,double *emn,
-             double *een,ITG *iperturb,double *f,double *fn,ITG *nactdof,
-             ITG *iout,double *qa,
-             double *vold,double *b,ITG *nodeboun,ITG *ndirboun,
-             double *xboun,ITG *nboun,ITG *ipompc,ITG *nodempc,
-             double *coefmpc,char *labmpc,ITG *nmpc,ITG *nmethod,
-             double *vmax,ITG *neq,double *veold,double *accold,
-             double *beta,double *gamma,double *dtime,double *time,
-             double *ttime,double *plicon,
-             ITG *nplicon,double *plkcon,ITG *nplkcon,
-             double *xstateini,double *xstiff,double *xstate,ITG *npmat_,
-             double *epl,char *matname,ITG *mi,ITG *ielas,
-             ITG *icmd,ITG *ncmat_,ITG *nstate_,double *sti,
-             double *vini,ITG *ikboun,ITG *ilboun,double *ener,
-             double *enern,double *emeini,double *xstaten,double *eei,
-             double *enerini,double *cocon,ITG *ncocon,char *set,
-             ITG *nset,ITG *istartset,
-             ITG *iendset,ITG *ialset,ITG *nprint,char *prlab,
-             char *prset,double *qfx,double *qfn,double *trab,
-             ITG *inotr,ITG *ntrans,double *fmpc,ITG *nelemload,
-             ITG *nload,ITG *ikmpc,ITG *ilmpc,ITG *istep,ITG *iinc,
-             double *springarea,double *reltime,ITG *ne0,double *xforc,
-             ITG *nforc,double *thicke,
-             double *shcon,ITG *nshcon,char *sideload,double *xload,
-             double *xloadold,ITG *icfd,ITG *inomat,double *h0,
-             ITG *islavnode,ITG *nslavnode,ITG *ntie,ITG *ielprop,
-             double *prop,ITG *iactive,double *energyini,double *energy,
-             ITG *iponoel,ITG *inoel,char *orname,ITG *network,
-	     ITG *ipobody,double *xbody,ITG *ibody,ITG *nbody);
+void resultsinduction(double *co, ITG *nk, ITG *kon, ITG *ipkon, char *lakon,
+                      ITG *ne, double *v, double *stn, ITG *inum,
+                      double *elcon, ITG *nelcon, double *rhcon, ITG *nrhcon,
+                      double *alcon, ITG *nalcon, double *alzero, ITG *ielmat,
+                      ITG *ielorien, ITG *norien, double *orab, ITG *ntmat_,
+                      double *t0, double *t1, ITG *ithermal, double *prestr,
+                      ITG *iprestr, char *filab, double *eme, double *emn,
+                      double *een, ITG *iperturb, double *f, double *fn, ITG *nactdof,
+                      ITG *iout, double *qa,
+                      double *vold, double *b, ITG *nodeboun, ITG *ndirboun,
+                      double *xboun, ITG *nboun, ITG *ipompc, ITG *nodempc,
+                      double *coefmpc, char *labmpc, ITG *nmpc, ITG *nmethod,
+                      double *vmax, ITG *neq, double *veold, double *accold,
+                      double *beta, double *gamma, double *dtime, double *time,
+                      double *ttime, double *plicon,
+                      ITG *nplicon, double *plkcon, ITG *nplkcon,
+                      double *xstateini, double *xstiff, double *xstate, ITG *npmat_,
+                      double *epl, char *matname, ITG *mi, ITG *ielas,
+                      ITG *icmd, ITG *ncmat_, ITG *nstate_, double *sti,
+                      double *vini, ITG *ikboun, ITG *ilboun, double *ener,
+                      double *enern, double *emeini, double *xstaten, double *eei,
+                      double *enerini, double *cocon, ITG *ncocon, char *set,
+                      ITG *nset, ITG *istartset,
+                      ITG *iendset, ITG *ialset, ITG *nprint, char *prlab,
+                      char *prset, double *qfx, double *qfn, double *trab,
+                      ITG *inotr, ITG *ntrans, double *fmpc, ITG *nelemload,
+                      ITG *nload, ITG *ikmpc, ITG *ilmpc, ITG *istep, ITG *iinc,
+                      double *springarea, double *reltime, ITG *ne0, double *xforc,
+                      ITG *nforc, double *thicke,
+                      double *shcon, ITG *nshcon, char *sideload, double *xload,
+                      double *xloadold, ITG *icfd, ITG *inomat, double *h0,
+                      ITG *islavnode, ITG *nslavnode, ITG *ntie, ITG *ielprop,
+                      double *prop, ITG *iactive, double *energyini, double *energy,
+                      ITG *iponoel, ITG *inoel, char *orname, ITG *network,
+                      ITG *ipobody, double *xbody, ITG *ibody, ITG *nbody);
 
-void FORTRAN(resultsv1,(ITG *nk,ITG *nactdoh,double *v,double *sol,ITG *ipompc,
-			ITG *nodempc,double *coefmpc,ITG *nmpc,ITG *mi));
+void FORTRAN(resultsv1, (ITG * nk, ITG *nactdoh, double *v, double *sol, ITG *ipompc,
+                         ITG *nodempc, double *coefmpc, ITG *nmpc, ITG *mi));
 
-void FORTRAN(resultsv2,(ITG *nk,ITG *nactdoh,double *v,double *sol,
-			ITG *ipompc,ITG *nodempc,double *coefmpc,ITG *nmpc,
-			ITG *mi));
+void FORTRAN(resultsv2, (ITG * nk, ITG *nactdoh, double *v, double *sol,
+                         ITG *ipompc, ITG *nodempc, double *coefmpc, ITG *nmpc,
+                         ITG *mi));
 
-void FORTRAN(rhs,(double *co,ITG *nk,ITG *kon,ITG *ipkon,char *lakon,
-               ITG *ne,ITG *ipompc,ITG *nodempc,double *coefmpc,
-               ITG *nmpc,ITG *nodeforc,ITG *ndirforc,
-               double *xforc,ITG *nforc,ITG *nelemload,char *sideload,
-               double *xload,ITG *nload,double *xbody,ITG *ipobody,
-               ITG *nbody,double *cgr,double *bb,ITG *nactdof,ITG *neq,
-               ITG *nmethod,ITG *ikmpc,ITG *ilmpc,
-               double *elcon,ITG *nelcon,double *rhcon,ITG *nrhcon,
-               double *alcon,ITG *nalcon,double *alzero,ITG *ielmat,
-               ITG *ielorien,ITG *norien,double *orab,ITG *ntmat_,
-               double *t0,double *t1,ITG *ithermal,
-               ITG *iprestr,double *vold,ITG *iperturb,ITG *iexpl,
-               double *plicon,ITG *nplicon,double *plkcon,ITG *nplkcon,
-               ITG *npmat_,double *ttime,double *time,ITG *istep,
-               ITG *iinc,double *dtime,double *physcon,ITG *ibody,
-               double *xbodyold,double *reltime,double *veold,
-               char *matname,ITG *mi,ITG *ikactmech,ITG *nactmech,
-               ITG *ielprop,double *prop,double *sti,double *xstateini,
-               double *xstate,ITG *nstate_,ITG *ntrans,ITG *inotr,
-               double *trab,ITG *nea,ITG *neb));
+void FORTRAN(rhs, (double *co, ITG *nk, ITG *kon, ITG *ipkon, char *lakon,
+                   ITG *ne, ITG *ipompc, ITG *nodempc, double *coefmpc,
+                   ITG *nmpc, ITG *nodeforc, ITG *ndirforc,
+                   double *xforc, ITG *nforc, ITG *nelemload, char *sideload,
+                   double *xload, ITG *nload, double *xbody, ITG *ipobody,
+                   ITG *nbody, double *cgr, double *bb, ITG *nactdof, ITG *neq,
+                   ITG *nmethod, ITG *ikmpc, ITG *ilmpc,
+                   double *elcon, ITG *nelcon, double *rhcon, ITG *nrhcon,
+                   double *alcon, ITG *nalcon, double *alzero, ITG *ielmat,
+                   ITG *ielorien, ITG *norien, double *orab, ITG *ntmat_,
+                   double *t0, double *t1, ITG *ithermal,
+                   ITG *iprestr, double *vold, ITG *iperturb, ITG *iexpl,
+                   double *plicon, ITG *nplicon, double *plkcon, ITG *nplkcon,
+                   ITG *npmat_, double *ttime, double *time, ITG *istep,
+                   ITG *iinc, double *dtime, double *physcon, ITG *ibody,
+                   double *xbodyold, double *reltime, double *veold,
+                   char *matname, ITG *mi, ITG *ikactmech, ITG *nactmech,
+                   ITG *ielprop, double *prop, double *sti, double *xstateini,
+                   double *xstate, ITG *nstate_, ITG *ntrans, ITG *inotr,
+                   double *trab, ITG *nea, ITG *neb));
 
-void FORTRAN(rhsnodef,(double *co,ITG *kon,ITG *ne,ITG *ipompc,ITG *nodempc,
-             double *coefmpc,ITG *nmpc,ITG *nodeforc,ITG *ndirforc,
-             double *xforc,
-             ITG *nforc,double *fext,ITG *nactdof,ITG *nmethod,ITG *ikmpc,
-             ITG *ntmat_,ITG *iperturb,ITG *mi,ITG *ikactmech,ITG *nactmech,
-             ITG *ntrans,ITG *inotr,double *trab));
+void FORTRAN(rhsnodef, (double *co, ITG *kon, ITG *ne, ITG *ipompc, ITG *nodempc,
+                        double *coefmpc, ITG *nmpc, ITG *nodeforc, ITG *ndirforc,
+                        double *xforc,
+                        ITG *nforc, double *fext, ITG *nactdof, ITG *nmethod, ITG *ikmpc,
+                        ITG *ntmat_, ITG *iperturb, ITG *mi, ITG *ikactmech, ITG *nactmech,
+                        ITG *ntrans, ITG *inotr, double *trab));
 
-void rhsmain(double *co,ITG *nk,ITG *kon,ITG *ipkon,char *lakon,ITG *ne,
-             ITG *ipompc,ITG *nodempc,double *coefmpc,ITG *nmpc,
-             ITG *nodeforc,ITG *ndirforc,double *xforcact,ITG *nforc,
-             ITG *nelemload,char *sideload,double *xloadact,ITG *nload,
-             double *xbodyact,ITG *ipobody,ITG *nbody,double *cgr,
+void rhsmain(double *co, ITG *nk, ITG *kon, ITG *ipkon, char *lakon, ITG *ne,
+             ITG *ipompc, ITG *nodempc, double *coefmpc, ITG *nmpc,
+             ITG *nodeforc, ITG *ndirforc, double *xforcact, ITG *nforc,
+             ITG *nelemload, char *sideload, double *xloadact, ITG *nload,
+             double *xbodyact, ITG *ipobody, ITG *nbody, double *cgr,
              double *fext,
-             ITG *nactdof,ITG *neq,ITG *nmethod,ITG *ikmpc,ITG *ilmpc,
-             double *elcon,ITG *nelcon,double *rhcon,ITG *nrhcon,
+             ITG *nactdof, ITG *neq, ITG *nmethod, ITG *ikmpc, ITG *ilmpc,
+             double *elcon, ITG *nelcon, double *rhcon, ITG *nrhcon,
              double *alcon,
-             ITG *nalcon,double *alzero,ITG *ielmat,ITG *ielorien,
-             ITG *norien,
-             double *orab,ITG *ntmat_,double *t0,double *t1act,
+             ITG *nalcon, double *alzero, ITG *ielmat, ITG *ielorien,
+             ITG *   norien,
+             double *orab, ITG *ntmat_, double *t0, double *t1act,
              ITG *ithermal,
-             ITG *iprestr,double *vold,ITG *iperturb,ITG *iexpl,
+             ITG *iprestr, double *vold, ITG *iperturb, ITG *iexpl,
              double *plicon,
-             ITG *nplicon,double *plkcon,ITG *nplkcon,ITG *npmat_,
+             ITG *nplicon, double *plkcon, ITG *nplkcon, ITG *npmat_,
              double *ttime,
-             double *time,ITG *istep,ITG *iinc,double *dtime,
+             double *time, ITG *istep, ITG *iinc, double *dtime,
              double *physcon,
-             ITG *ibody,double *xbodyold,double *reltime,double *veold,
+             ITG *ibody, double *xbodyold, double *reltime, double *veold,
              char *matname,
-             ITG *mi,ITG *ikactmech,ITG *nactmech,ITG *ielprop,
+             ITG *mi, ITG *ikactmech, ITG *nactmech, ITG *ielprop,
              double *prop,
-             double *sti,double *xstateini,double *xstate,ITG *nstate_,
-             ITG *ntrans,ITG *inotr,double *trab);
+             double *sti, double *xstateini, double *xstate, ITG *nstate_,
+             ITG *ntrans, ITG *inotr, double *trab);
 
 void *rhsmt(ITG *i);
 
-void robustdesign(double *co,ITG *nk,ITG **konp,ITG **ipkonp,char **lakonp,
-		  ITG *ne,
-		  ITG *nodeboun,ITG *ndirboun,double *xboun,ITG *nboun,
-		  ITG *ipompc,ITG *nodempc,double *coefmpc,char *labmpc,
-		  ITG *nmpc,
-		  ITG *nodeforc,ITG *ndirforc,double *xforc,ITG *nforc,
-		  ITG *nelemload,char *sideload,double *xload,
-		  ITG *nload,ITG *nactdof,
-		  ITG *icol,ITG *jq,ITG **irowp,ITG *neq,ITG *nzl,
-		  ITG *nmethod,ITG *ikmpc,ITG *ilmpc,ITG *ikboun,
-		  ITG *ilboun,
-		  double *elcon,ITG *nelcon,double *rhcon,ITG *nrhcon,
-		  double *alcon,ITG *nalcon,double *alzero,ITG **ielmatp,
-		  ITG **ielorienp,ITG *norien,double *orab,ITG *ntmat_,
-		  double *t0,double *t1,double *t1old,
-		  ITG *ithermal,double *prestr,ITG *iprestr,
-		  double *vold,ITG *iperturb,double *sti,ITG *nzs,
-		  ITG *kode,char *filab,double *eme,
-		  ITG *iexpl,double *plicon,ITG *nplicon,double *plkcon,
-		  ITG *nplkcon,
-		  double **xstatep,ITG *npmat_,char *matname,ITG *isolver,
-		  ITG *mi,ITG *ncmat_,ITG *nstate_,double *cs,ITG *mcs,
-		  ITG *nkon,double **enerp,double *xbounold,
-		  double *xforcold,double *xloadold,
-		  char *amname,double *amta,ITG *namta,
-		  ITG *nam,ITG *iamforc,ITG *iamload,
-		  ITG *iamt1,ITG *iamboun,double *ttime,char *output,
-		  char *set,ITG *nset,ITG *istartset,
-		  ITG *iendset,ITG *ialset,ITG *nprint,char *prlab,
-		  char *prset,ITG *nener,double *trab,
-		  ITG *inotr,ITG *ntrans,double *fmpc,ITG *ipobody,
-		  ITG *ibody,
-		  double *xbody,ITG *nbody,double *xbodyold,double *timepar,
-		  double *thicke,char *jobnamec,char *tieset,ITG *ntie,
-		  ITG *istep,ITG *nmat,ITG *ielprop,double *prop,char *typeboun,
-		  ITG *mortar,ITG *mpcinfo,double *tietol,ITG *ics,
-		  ITG *nobject,char **objectsetp,ITG *istat,char *orname,
-		  ITG *nzsprevstep,ITG *nlabel,double *physcon,char *jobnamef,
-		  ITG *iponor2d,ITG *knor2d,ITG *ne2d,ITG *iponoel2d,
-		  ITG *inoel2d,
-		  ITG *mpcend,ITG *irobustdesign,ITG *irandomtype,
-		  double *randomval);
+void robustdesign(double *co, ITG *nk, ITG **konp, ITG **ipkonp, char **lakonp,
+                  ITG *ne,
+                  ITG *nodeboun, ITG *ndirboun, double *xboun, ITG *nboun,
+                  ITG *ipompc, ITG *nodempc, double *coefmpc, char *labmpc,
+                  ITG *nmpc,
+                  ITG *nodeforc, ITG *ndirforc, double *xforc, ITG *nforc,
+                  ITG *nelemload, char *sideload, double *xload,
+                  ITG *nload, ITG *nactdof,
+                  ITG *icol, ITG *jq, ITG **irowp, ITG *neq, ITG *nzl,
+                  ITG *nmethod, ITG *ikmpc, ITG *ilmpc, ITG *ikboun,
+                  ITG *   ilboun,
+                  double *elcon, ITG *nelcon, double *rhcon, ITG *nrhcon,
+                  double *alcon, ITG *nalcon, double *alzero, ITG **ielmatp,
+                  ITG **ielorienp, ITG *norien, double *orab, ITG *ntmat_,
+                  double *t0, double *t1, double *t1old,
+                  ITG *ithermal, double *prestr, ITG *iprestr,
+                  double *vold, ITG *iperturb, double *sti, ITG *nzs,
+                  ITG *kode, char *filab, double *eme,
+                  ITG *iexpl, double *plicon, ITG *nplicon, double *plkcon,
+                  ITG *    nplkcon,
+                  double **xstatep, ITG *npmat_, char *matname, ITG *isolver,
+                  ITG *mi, ITG *ncmat_, ITG *nstate_, double *cs, ITG *mcs,
+                  ITG *nkon, double **enerp, double *xbounold,
+                  double *xforcold, double *xloadold,
+                  char *amname, double *amta, ITG *namta,
+                  ITG *nam, ITG *iamforc, ITG *iamload,
+                  ITG *iamt1, ITG *iamboun, double *ttime, char *output,
+                  char *set, ITG *nset, ITG *istartset,
+                  ITG *iendset, ITG *ialset, ITG *nprint, char *prlab,
+                  char *prset, ITG *nener, double *trab,
+                  ITG *inotr, ITG *ntrans, double *fmpc, ITG *ipobody,
+                  ITG *   ibody,
+                  double *xbody, ITG *nbody, double *xbodyold, double *timepar,
+                  double *thicke, char *jobnamec, char *tieset, ITG *ntie,
+                  ITG *istep, ITG *nmat, ITG *ielprop, double *prop, char *typeboun,
+                  ITG *mortar, ITG *mpcinfo, double *tietol, ITG *ics,
+                  ITG *nobject, char **objectsetp, ITG *istat, char *orname,
+                  ITG *nzsprevstep, ITG *nlabel, double *physcon, char *jobnamef,
+                  ITG *iponor2d, ITG *knor2d, ITG *ne2d, ITG *iponoel2d,
+                  ITG *inoel2d,
+                  ITG *mpcend, ITG *irobustdesign, ITG *irandomtype,
+                  double *randomval);
 
-void FORTRAN(rotationvector,(double *a,double *euler));
+void FORTRAN(rotationvector, (double *a, double *euler));
 
-void FORTRAN(rotationvectorinv,(double *a,double* euler));
-       
-void FORTRAN(scalesen,(double *dgdxglob,ITG *nobject,ITG *nk,ITG *nodedesi,
-                       ITG *ndesi,char *objectset,ITG *iscaleflag,
-                       ITG *istart));
+void FORTRAN(rotationvectorinv, (double *a, double *euler));
 
-void FORTRAN(searchmidneigh,(ITG *inn,ITG *iponn,ITG *nktet_,ITG *iexternedg,
-			     ITG *ipoed,ITG *iedg,ITG *ipoeled,ITG *ieled,
-			     ITG *ifreenn,ITG *iedgmid,ITG *iedtet));
+void FORTRAN(scalesen, (double *dgdxglob, ITG *nobject, ITG *nk, ITG *nodedesi,
+                        ITG *ndesi, char *objectset, ITG *iscaleflag,
+                        ITG *istart));
 
-void sensi_coor(double *co,ITG *nk,ITG **konp,ITG **ipkonp,char **lakonp,
-             ITG *ne,
-             ITG *nodeboun,ITG *ndirboun,double *xboun,ITG *nboun,
-             ITG *ipompc,ITG *nodempc,double *coefmpc,char *labmpc,
-             ITG *nmpc,
-             ITG *nodeforc,ITG *ndirforc,double *xforc,ITG *nforc,
-             ITG *nelemload,char *sideload,double *xload,
-             ITG *nload,ITG *nactdof,
-             ITG *icol,ITG *jq,ITG **irowp,ITG *neq,ITG *nzl,
-             ITG *nmethod,ITG *ikmpc,ITG *ilmpc,ITG *ikboun,
-             ITG *ilboun,
-             double *elcon,ITG *nelcon,double *rhcon,ITG *nrhcon,
-             double *alcon,ITG *nalcon,double *alzero,ITG **ielmatp,
-             ITG **ielorienp,ITG *norien,double *orab,ITG *ntmat_,
-             double *t0,double *t1,double *t1old,
-             ITG *ithermal,double *prestr,ITG *iprestr,
-             double *vold,ITG *iperturb,double *sti,ITG *nzs,
-             ITG *kode,char *filab,double *eme,
-             ITG *iexpl,double *plicon,ITG *nplicon,double *plkcon,
-             ITG *nplkcon,
-             double **xstatep,ITG *npmat_,char *matname,ITG *isolver,
-             ITG *mi,ITG *ncmat_,ITG *nstate_,double *cs,ITG *mcs,
-             ITG *nkon,double **enerp,double *xbounold,
-             double *xforcold,double *xloadold,
-             char *amname,double *amta,ITG *namta,
-             ITG *nam,ITG *iamforc,ITG *iamload,
-             ITG *iamt1,ITG *iamboun,double *ttime,char *output,
-             char *set,ITG *nset,ITG *istartset,
-             ITG *iendset,ITG *ialset,ITG *nprint,char *prlab,
-             char *prset,ITG *nener,double *trab,
-             ITG *inotr,ITG *ntrans,double *fmpc,ITG *ipobody,ITG *ibody,
-             double *xbody,ITG *nbody,double *xbodyold,double *timepar,
-             double *thicke,char *jobnamec,char *tieset,ITG *ntie,
-             ITG *istep,ITG *nmat,ITG *ielprop,double *prop,char *typeboun,
-             ITG *mortar,ITG *mpcinfo,double *tietol,ITG *ics,
-             ITG *nobject,char **objectsetp,ITG *istat,
-             char *orname,ITG *nzsfreq,ITG *nlabel,double *physcon,
-             char *jobnamef,ITG *iponor2d,ITG *knor2d,ITG *ne2d,
-             ITG *iponoel2d,ITG *inoel2d,ITG *mpcend,
-	     double *dgdxglob,double *g0,ITG **nodedesip,ITG*ndesi,
-	     ITG *nobjectstart,double **xdesip);
+void FORTRAN(searchmidneigh, (ITG * inn, ITG *iponn, ITG *nktet_, ITG *iexternedg,
+                              ITG *ipoed, ITG *iedg, ITG *ipoeled, ITG *ieled,
+                              ITG *ifreenn, ITG *iedgmid, ITG *iedtet));
 
-void sensi_orien(double *co,ITG *nk,ITG **konp,ITG **ipkonp,char **lakonp,
-             ITG *ne,
-             ITG *nodeboun,ITG *ndirboun,double *xboun,ITG *nboun,
-             ITG *ipompc,ITG *nodempc,double *coefmpc,char *labmpc,
-             ITG *nmpc,
-             ITG *nodeforc,ITG *ndirforc,double *xforc,ITG *nforc,
-             ITG *nelemload,char *sideload,double *xload,
-             ITG *nload,ITG *nactdof,
-             ITG *icol,ITG *jq,ITG **irowp,ITG *neq,ITG *nzl,
-             ITG *nmethod,ITG *ikmpc,ITG *ilmpc,ITG *ikboun,
-             ITG *ilboun,
-             double *elcon,ITG *nelcon,double *rhcon,ITG *nrhcon,
-             double *alcon,ITG *nalcon,double *alzero,ITG **ielmatp,
-             ITG **ielorienp,ITG *norien,double *orab,ITG *ntmat_,
-             double *t0,double *t1,double *t1old,
-             ITG *ithermal,double *prestr,ITG *iprestr,
-             double *vold,ITG *iperturb,double *sti,ITG *nzs,
-             ITG *kode,char *filab,double *eme,
-             ITG *iexpl,double *plicon,ITG *nplicon,double *plkcon,
-             ITG *nplkcon,
-             double **xstatep,ITG *npmat_,char *matname,ITG *isolver,
-             ITG *mi,ITG *ncmat_,ITG *nstate_,double *cs,ITG *mcs,
-             ITG *nkon,double **enerp,double *xbounold,
-             double *xforcold,double *xloadold,
-             char *amname,double *amta,ITG *namta,
-             ITG *nam,ITG *iamforc,ITG *iamload,
-             ITG *iamt1,ITG *iamboun,double *ttime,char *output,
-             char *set,ITG *nset,ITG *istartset,
-             ITG *iendset,ITG *ialset,ITG *nprint,char *prlab,
-             char *prset,ITG *nener,double *trab,
-             ITG *inotr,ITG *ntrans,double *fmpc,ITG *ipobody,ITG *ibody,
-             double *xbody,ITG *nbody,double *xbodyold,double *timepar,
-             double *thicke,char *jobnamec,char *tieset,ITG *ntie,
-             ITG *istep,ITG *nmat,ITG *ielprop,double *prop,char *typeboun,
-             ITG *mortar,ITG *mpcinfo,double *tietol,ITG *ics,
-             ITG *nobject,char **objectsetp,ITG *istat,
-             char *orname,ITG *nzsfreq,ITG *nlabel,double *physcon,
-             char *jobnamef,ITG *iponor2d,ITG *knor2d,ITG *ne2d,
-             ITG *iponoel2d,ITG *inoel2d,ITG *mpcend);
+void sensi_coor(double *co, ITG *nk, ITG **konp, ITG **ipkonp, char **lakonp,
+                ITG *ne,
+                ITG *nodeboun, ITG *ndirboun, double *xboun, ITG *nboun,
+                ITG *ipompc, ITG *nodempc, double *coefmpc, char *labmpc,
+                ITG *nmpc,
+                ITG *nodeforc, ITG *ndirforc, double *xforc, ITG *nforc,
+                ITG *nelemload, char *sideload, double *xload,
+                ITG *nload, ITG *nactdof,
+                ITG *icol, ITG *jq, ITG **irowp, ITG *neq, ITG *nzl,
+                ITG *nmethod, ITG *ikmpc, ITG *ilmpc, ITG *ikboun,
+                ITG *   ilboun,
+                double *elcon, ITG *nelcon, double *rhcon, ITG *nrhcon,
+                double *alcon, ITG *nalcon, double *alzero, ITG **ielmatp,
+                ITG **ielorienp, ITG *norien, double *orab, ITG *ntmat_,
+                double *t0, double *t1, double *t1old,
+                ITG *ithermal, double *prestr, ITG *iprestr,
+                double *vold, ITG *iperturb, double *sti, ITG *nzs,
+                ITG *kode, char *filab, double *eme,
+                ITG *iexpl, double *plicon, ITG *nplicon, double *plkcon,
+                ITG *    nplkcon,
+                double **xstatep, ITG *npmat_, char *matname, ITG *isolver,
+                ITG *mi, ITG *ncmat_, ITG *nstate_, double *cs, ITG *mcs,
+                ITG *nkon, double **enerp, double *xbounold,
+                double *xforcold, double *xloadold,
+                char *amname, double *amta, ITG *namta,
+                ITG *nam, ITG *iamforc, ITG *iamload,
+                ITG *iamt1, ITG *iamboun, double *ttime, char *output,
+                char *set, ITG *nset, ITG *istartset,
+                ITG *iendset, ITG *ialset, ITG *nprint, char *prlab,
+                char *prset, ITG *nener, double *trab,
+                ITG *inotr, ITG *ntrans, double *fmpc, ITG *ipobody, ITG *ibody,
+                double *xbody, ITG *nbody, double *xbodyold, double *timepar,
+                double *thicke, char *jobnamec, char *tieset, ITG *ntie,
+                ITG *istep, ITG *nmat, ITG *ielprop, double *prop, char *typeboun,
+                ITG *mortar, ITG *mpcinfo, double *tietol, ITG *ics,
+                ITG *nobject, char **objectsetp, ITG *istat,
+                char *orname, ITG *nzsfreq, ITG *nlabel, double *physcon,
+                char *jobnamef, ITG *iponor2d, ITG *knor2d, ITG *ne2d,
+                ITG *iponoel2d, ITG *inoel2d, ITG *mpcend,
+                double *dgdxglob, double *g0, ITG **nodedesip, ITG *ndesi,
+                ITG *nobjectstart, double **xdesip);
 
-void FORTRAN(sensitivity_glob,(double *dgdxtot,double *dgdxtotglob,ITG *nobject,
-             ITG *ndesi,ITG *nodedesi,ITG *nk));
+void sensi_orien(double *co, ITG *nk, ITG **konp, ITG **ipkonp, char **lakonp,
+                 ITG *ne,
+                 ITG *nodeboun, ITG *ndirboun, double *xboun, ITG *nboun,
+                 ITG *ipompc, ITG *nodempc, double *coefmpc, char *labmpc,
+                 ITG *nmpc,
+                 ITG *nodeforc, ITG *ndirforc, double *xforc, ITG *nforc,
+                 ITG *nelemload, char *sideload, double *xload,
+                 ITG *nload, ITG *nactdof,
+                 ITG *icol, ITG *jq, ITG **irowp, ITG *neq, ITG *nzl,
+                 ITG *nmethod, ITG *ikmpc, ITG *ilmpc, ITG *ikboun,
+                 ITG *   ilboun,
+                 double *elcon, ITG *nelcon, double *rhcon, ITG *nrhcon,
+                 double *alcon, ITG *nalcon, double *alzero, ITG **ielmatp,
+                 ITG **ielorienp, ITG *norien, double *orab, ITG *ntmat_,
+                 double *t0, double *t1, double *t1old,
+                 ITG *ithermal, double *prestr, ITG *iprestr,
+                 double *vold, ITG *iperturb, double *sti, ITG *nzs,
+                 ITG *kode, char *filab, double *eme,
+                 ITG *iexpl, double *plicon, ITG *nplicon, double *plkcon,
+                 ITG *    nplkcon,
+                 double **xstatep, ITG *npmat_, char *matname, ITG *isolver,
+                 ITG *mi, ITG *ncmat_, ITG *nstate_, double *cs, ITG *mcs,
+                 ITG *nkon, double **enerp, double *xbounold,
+                 double *xforcold, double *xloadold,
+                 char *amname, double *amta, ITG *namta,
+                 ITG *nam, ITG *iamforc, ITG *iamload,
+                 ITG *iamt1, ITG *iamboun, double *ttime, char *output,
+                 char *set, ITG *nset, ITG *istartset,
+                 ITG *iendset, ITG *ialset, ITG *nprint, char *prlab,
+                 char *prset, ITG *nener, double *trab,
+                 ITG *inotr, ITG *ntrans, double *fmpc, ITG *ipobody, ITG *ibody,
+                 double *xbody, ITG *nbody, double *xbodyold, double *timepar,
+                 double *thicke, char *jobnamec, char *tieset, ITG *ntie,
+                 ITG *istep, ITG *nmat, ITG *ielprop, double *prop, char *typeboun,
+                 ITG *mortar, ITG *mpcinfo, double *tietol, ITG *ics,
+                 ITG *nobject, char **objectsetp, ITG *istat,
+                 char *orname, ITG *nzsfreq, ITG *nlabel, double *physcon,
+                 char *jobnamef, ITG *iponor2d, ITG *knor2d, ITG *ne2d,
+                 ITG *iponoel2d, ITG *inoel2d, ITG *mpcend);
 
-void sensitivity_out(char *jobnamec,double *dgdxtotglob,ITG *neq,
-                     ITG *nobject,double *g0);
+void FORTRAN(sensitivity_glob, (double *dgdxtot, double *dgdxtotglob, ITG *nobject,
+                                ITG *ndesi, ITG *nodedesi, ITG *nk));
 
-void setpardou(double *var1,double var2,ITG size,ITG num_cpus);
+void sensitivity_out(char *jobnamec, double *dgdxtotglob, ITG *neq,
+                     ITG *nobject, double *g0);
+
+void setpardou(double *var1, double var2, ITG size, ITG num_cpus);
 
 void *setpardoumt(ITG *i);
 
-void setparitg(ITG *iva1,ITG iva2,ITG size,ITG num_cpus);
+void setparitg(ITG *iva1, ITG iva2, ITG size, ITG num_cpus);
 
 void *setparitgmt(ITG *i);
-                  
+
 void sgenrand(unsigned long seed);
 
-void FORTRAN(shape3tri,(double *xi,double *et,double *xl,double *xsj,
-                      double *xs,double *shp,ITG *iflag));
+void FORTRAN(shape3tri, (double *xi, double *et, double *xl, double *xsj,
+                         double *xs, double *shp, ITG *iflag));
 
-void FORTRAN(shape4q,(double *xi,double *et,double *xl,double *xsj,
-                      double *xs,double *shp,ITG *iflag));
+void FORTRAN(shape4q, (double *xi, double *et, double *xl, double *xsj,
+                       double *xs, double *shp, ITG *iflag));
 
-void FORTRAN(shape4tet,(double *xi,double *et,double *ze,double *xl,
-             double *xsj,double *shp,ITG *iflag));
+void FORTRAN(shape4tet, (double *xi, double *et, double *ze, double *xl,
+                         double *xsj, double *shp, ITG *iflag));
 
-void FORTRAN(shape6tri,(double *xi,double *et,double *xl,double *xsj,
-                      double *xs,double *shp,ITG *iflag));
+void FORTRAN(shape6tri, (double *xi, double *et, double *xl, double *xsj,
+                         double *xs, double *shp, ITG *iflag));
 
-void FORTRAN(shape6w,(double *xi,double *et,double *ze,double *xl,
-             double *xsj,double *shp,ITG *iflag));
+void FORTRAN(shape6w, (double *xi, double *et, double *ze, double *xl,
+                       double *xsj, double *shp, ITG *iflag));
 
-void FORTRAN(shape8h,(double *xi,double *et,double *ze,double *xl,
-             double *xsj,double *shp,ITG *iflag));
+void FORTRAN(shape8h, (double *xi, double *et, double *ze, double *xl,
+                       double *xsj, double *shp, ITG *iflag));
 
-void FORTRAN(shape8q,(double *xi,double *et,double *xl,double *xsj,
-                      double *xs,double *shp,ITG *iflag));
+void FORTRAN(shape8q, (double *xi, double *et, double *xl, double *xsj,
+                       double *xs, double *shp, ITG *iflag));
 
-void FORTRAN(shape10tet,(double *xi,double *et,double *ze,double *xl,
-             double *xsj,double *shp,ITG *iflag));
+void FORTRAN(shape10tet, (double *xi, double *et, double *ze, double *xl,
+                          double *xsj, double *shp, ITG *iflag));
 
-void FORTRAN(shape15w,(double *xi,double *et,double *ze,double *xl,
-             double *xsj,double *shp,ITG *iflag));
+void FORTRAN(shape15w, (double *xi, double *et, double *ze, double *xl,
+                        double *xsj, double *shp, ITG *iflag));
 
-void FORTRAN(shape20h,(double *xi,double *et,double *ze,double *xl,
-             double *xsj,double *shp,ITG *iflag));
-       
-void FORTRAN(slavintpoints,(ITG *ntie,ITG *itietri,ITG *ipkon,
-        ITG *kon,char *lakon,double *straight,
-        ITG *nintpoint,ITG *koncont,double *co,double *vold,double *xo,
-        double *yo,double *zo,double *x,double *y,double *z,ITG *nx,
-        ITG *ny,ITG *nz,ITG *islavsurf,
-        ITG *islavnode,ITG *nslavnode,ITG *imastop,
-        ITG *mi,ITG *ncont,ITG *ipe,ITG *ime,double *pslavsurf,
-        ITG *i,ITG *l,ITG *ntri));
+void FORTRAN(shape20h, (double *xi, double *et, double *ze, double *xl,
+                        double *xsj, double *shp, ITG *iflag));
 
-void FORTRAN(smalldist,(double *co,double *distmin,char *lakon,
-             ITG *ipkon,ITG *kon,ITG *ne));
+void FORTRAN(slavintpoints, (ITG * ntie, ITG *itietri, ITG *ipkon,
+                             ITG *kon, char *lakon, double *straight,
+                             ITG *nintpoint, ITG *koncont, double *co, double *vold, double *xo,
+                             double *yo, double *zo, double *x, double *y, double *z, ITG *nx,
+                             ITG *ny, ITG *nz, ITG *islavsurf,
+                             ITG *islavnode, ITG *nslavnode, ITG *imastop,
+                             ITG *mi, ITG *ncont, ITG *ipe, ITG *ime, double *pslavsurf,
+                             ITG *i, ITG *l, ITG *ntri));
 
-void FORTRAN(smoothbadmid,(double *cotet,ITG *kontet,ITG *ipoeln,ITG *ieln,
-			      ITG *nbadnodes,ITG *ibadnodes,
-			      ITG *iexternedge,ITG *ipoeled,ITG *ieled,
-			      ITG *iedgmid,ITG *iedtet));
+void FORTRAN(smalldist, (double *co, double *distmin, char *lakon,
+                         ITG *ipkon, ITG *kon, ITG *ne));
 
-void FORTRAN(smoothbadvertex,(double *cotet,ITG *kontet,ITG *ipoeln,ITG *ieln,
-			      ITG *nbadnodes,ITG *ibadnodes,ITG *iponn,ITG *inn,
-			      ITG *iexternnode,ITG *ipoeled,ITG *ieled,
-			      ITG *iedgmid,ITG *iedtet));
+void FORTRAN(smoothbadmid, (double *cotet, ITG *kontet, ITG *ipoeln, ITG *ieln,
+                            ITG *nbadnodes, ITG *ibadnodes,
+                            ITG *iexternedge, ITG *ipoeled, ITG *ieled,
+                            ITG *iedgmid, ITG *iedtet));
 
-void FORTRAN(smoothingmidnodes,(double *cotet,ITG *ipoed,ITG *kontet,
-				ITG *iedtet,ITG *iedgmid,ITG *ipoeled,
-				ITG *ieled,double *qualityjac,ITG *iponn,
-				ITG *inn,double *h,ITG *iexternedg,ITG *netet_,
-				ITG *nktet_));
+void FORTRAN(smoothbadvertex, (double *cotet, ITG *kontet, ITG *ipoeln, ITG *ieln,
+                               ITG *nbadnodes, ITG *ibadnodes, ITG *iponn, ITG *inn,
+                               ITG *iexternnode, ITG *ipoeled, ITG *ieled,
+                               ITG *iedgmid, ITG *iedtet));
 
-void FORTRAN(smoothingvertexnodes,(ITG *inn,ITG *iponn,ITG *nktet,
-			ITG *iexternnode,ITG *netet_,ITG *kontet,double *cotet,
-			ITG *ipoeln,ITG *ieln,double *h,double *quality,
-			ITG *jfix));
+void FORTRAN(smoothingmidnodes, (double *cotet, ITG *ipoed, ITG *kontet,
+                                 ITG *iedtet, ITG *iedgmid, ITG *ipoeled,
+                                 ITG *ieled, double *qualityjac, ITG *iponn,
+                                 ITG *inn, double *h, ITG *iexternedg, ITG *netet_,
+                                 ITG *nktet_));
 
-void FORTRAN(smoothshock,(double *aub,double *adl,
-			     double *sol,double *aux,ITG *irow,
-			     ITG *jq,ITG *neqa,ITG *neqb,double *sa));
+void FORTRAN(smoothingvertexnodes, (ITG * inn, ITG *iponn, ITG *nktet,
+                                    ITG *iexternnode, ITG *netet_, ITG *kontet, double *cotet,
+                                    ITG *ipoeln, ITG *ieln, double *h, double *quality,
+                                    ITG *jfix));
+
+void FORTRAN(smoothshock, (double *aub, double *adl,
+                           double *sol, double *aux, ITG *irow,
+                           ITG *jq, ITG *neqa, ITG *neqb, double *sa));
 
 void *smoothshockmt(ITG *i);
 
-void FORTRAN(solveeq,(double *adbv,double *aubv,double *adl,
-		      double *b,double *sol,double *aux,ITG *irowv,
-		      ITG *jqv,ITG *neqv,ITG *maxit));
+void FORTRAN(solveeq, (double *adbv, double *aubv, double *adl,
+                       double *b, double *sol, double *aux, ITG *irowv,
+                       ITG *jqv, ITG *neqv, ITG *maxit));
 
-void solveeqmain(double *aub,double *adl,double *b,double *sol,ITG *irow,
-		 ITG *jq,ITG *neq,ITG *maxit,ITG *num_cpus);
+void solveeqmain(double *aub, double *adl, double *b, double *sol, ITG *irow,
+                 ITG *jq, ITG *neq, ITG *maxit, ITG *num_cpus);
 
-void FORTRAN(solveeqpar,(double *aub,double *adl,double *b,double *sol,
-			double *aux,ITG *irow,ITG *jq,ITG *neqa,ITG *neqb));
+void FORTRAN(solveeqpar, (double *aub, double *adl, double *b, double *sol,
+                          double *aux, ITG *irow, ITG *jq, ITG *neqa, ITG *neqb));
 
 void *solveeqparmt(ITG *i);
 
-void FORTRAN(solveexplicitly,(ITG *nef,double *vel,double *bv,double *auv,
-             ITG *ipnei,ITG *neiel,ITG *nflnei));
+void FORTRAN(solveexplicitly, (ITG * nef, double *vel, double *bv, double *auv,
+                               ITG *ipnei, ITG *neiel, ITG *nflnei));
 
-void FORTRAN(sortev,(ITG *nev,ITG *nmd,double *eigxx,ITG *cyclicsymmetry,
-                     double *xx,double *eigxr,ITG *pev,
-                     ITG *istartnmd,ITG *iendnmd,double *aa,double *bb,
-                     ITG *nevcomplex));
+void FORTRAN(sortev, (ITG * nev, ITG *nmd, double *eigxx, ITG *cyclicsymmetry,
+                      double *xx, double *eigxr, ITG *pev,
+                      ITG *istartnmd, ITG *iendnmd, double *aa, double *bb,
+                      ITG *nevcomplex));
 
-void FORTRAN(spcmatch,(double *xboun,ITG *nodeboun,ITG *ndirboun,ITG *nboun,
-               double *xbounold,ITG *nodebounold,ITG *ndirbounold,
-               ITG *nbounold,ITG *ikboun,ITG *ilboun,double *vold,
-	       double *reorder,ITG *nreorder,ITG *mi,char *typeboun));
+void FORTRAN(spcmatch, (double *xboun, ITG *nodeboun, ITG *ndirboun, ITG *nboun,
+                        double *xbounold, ITG *nodebounold, ITG *ndirbounold,
+                        ITG *nbounold, ITG *ikboun, ITG *ilboun, double *vold,
+                        double *reorder, ITG *nreorder, ITG *mi, char *typeboun));
 
-void FORTRAN(splitline,(char *text,char *textpart,ITG *n));
+void FORTRAN(splitline, (char *text, char *textpart, ITG *n));
 
-void spooles(double *ad,double *au,double *adb,double *aub,
-             double *sigma,double *b,
-             ITG *icol,ITG *irow,ITG *neq,ITG *nzs,ITG *symmtryflag,
-             ITG *inputformat,ITG *nzs3);
+void spooles(double *ad, double *au, double *adb, double *aub,
+             double *sigma, double *b,
+             ITG *icol, ITG *irow, ITG *neq, ITG *nzs, ITG *symmtryflag,
+             ITG *inputformat, ITG *nzs3);
 
-void FORTRAN(springforc_n2f,(double *xl,ITG *konl,double *vl,ITG *imat,
-             double *elcon,ITG *nelcon,double *elas,double *fnl,ITG *ncmat_,
-             ITG *ntmat_,ITG *nope,char *lakonl,double *t1l,ITG *kode,
-             double *elconloc,double *plicon,ITG *nplicon,ITG *npmat_,
-             double *senergy,ITG *iener,double *cstr,ITG *mi,
-             double *springarea,ITG *nmethod,ITG *ne0,ITG *nstate_,
-             double *xstateini,double *xstate,double *reltime,
-             ITG *ielas,double *venergy,ITG *ielorien,double *orab,
-             ITG *norien,ITG *nelem));
+void FORTRAN(springforc_n2f, (double *xl, ITG *konl, double *vl, ITG *imat,
+                              double *elcon, ITG *nelcon, double *elas, double *fnl, ITG *ncmat_,
+                              ITG *ntmat_, ITG *nope, char *lakonl, double *t1l, ITG *kode,
+                              double *elconloc, double *plicon, ITG *nplicon, ITG *npmat_,
+                              double *senergy, ITG *iener, double *cstr, ITG *mi,
+                              double *springarea, ITG *nmethod, ITG *ne0, ITG *nstate_,
+                              double *xstateini, double *xstate, double *reltime,
+                              ITG *ielas, double *venergy, ITG *ielorien, double *orab,
+                              ITG *norien, ITG *nelem));
 
-void FORTRAN(springstiff_n2f,(double *xl,double *elas,ITG *konl,double *voldl,
-             double *s,ITG *imat,double *elcon,ITG *nelcon,ITG *ncmat_,
-             ITG *ntmat_,ITG *nope,char *lakonl,double *t1l,ITG *kode,
-             double *elconloc,double *plicon,ITG *nplicon,ITG *npmat_,
-             ITG *iperturb,double *springarea,ITG *nmethod,ITG *mi,ITG *ne0,
-             ITG *nstate_,double *xstateini,double *xstate,double *reltime,
-             ITG *nasym,ITG *ielorien,double *orab,ITG *norien,ITG *nelem));
+void FORTRAN(springstiff_n2f, (double *xl, double *elas, ITG *konl, double *voldl,
+                               double *s, ITG *imat, double *elcon, ITG *nelcon, ITG *ncmat_,
+                               ITG *ntmat_, ITG *nope, char *lakonl, double *t1l, ITG *kode,
+                               double *elconloc, double *plicon, ITG *nplicon, ITG *npmat_,
+                               ITG *iperturb, double *springarea, ITG *nmethod, ITG *mi, ITG *ne0,
+                               ITG *nstate_, double *xstateini, double *xstate, double *reltime,
+                               ITG *nasym, ITG *ielorien, double *orab, ITG *norien, ITG *nelem));
 
-void steadystate(double **co,ITG *nk,ITG **kon,ITG **ipkon,char **lakon,ITG *ne,
-          ITG **nodeboun,ITG **ndirboun,double **xboun,ITG *nboun,
-          ITG **ipompcp,ITG **nodempcp,double **coefmpcp,char **labmpcp,ITG *nmpc,
-          ITG *nodeforc,ITG *ndirforc,double *xforc,ITG *nforc,
-          ITG *nelemload,char *sideload,double *xload,
-          ITG *nload,
-          ITG **nactdof,ITG *neq,ITG *nzl,ITG *icol,ITG *irow,
-          ITG *nmethod,ITG **ikmpcp,ITG **ilmpcp,ITG **ikboun,
-          ITG **ilboun,
-          double *elcon,ITG *nelcon,double *rhcon,ITG *nrhcon,
-          double *cocon,ITG *ncocon,
-          double *alcon,ITG *nalcon,double *alzero,ITG **ielmat,
-          ITG **ielorien,ITG *norien,double *orab,ITG *ntmat_,
-          double **t0,
-          double **t1,ITG *ithermal,double *prestr,ITG *iprestr,
-          double **voldp,ITG *iperturb,double *sti,ITG *nzs,
-          double *timepar,double *xmodal,
-          double **veoldp,char *amname,double *amta,
-          ITG *namta,ITG *nam,ITG *iamforc,ITG *iamload,
-          ITG **iamt1,ITG *jout,ITG *kode,char *filab,
-          double **emep,double *xforcold,double *xloadold,
-          double **t1old,ITG **iamboun,
-          double **xbounold,ITG *iexpl,double *plicon,ITG *nplicon,
-          double *plkcon,ITG *nplkcon,
-          double *xstate,ITG *npmat_,char *matname,ITG *mi,
-          ITG *ncmat_,ITG *nstate_,double **enerp,char *jobnamec,
-          double *ttime,char *set,ITG *nset,ITG *istartset,
-          ITG *iendset,ITG *ialset,ITG *nprint,char *prlab,
-          char *prset,ITG *nener,double *trab,
-          ITG **inotr,ITG *ntrans,double **fmpcp,ITG *ipobody,ITG *ibody,
-          double *xbody,ITG *nbody,double *xbodyold,ITG *istep,
-          ITG *isolver,ITG *jq,char *output,ITG *mcs,ITG *nkon,
-          ITG *ics,double *cs,ITG *mpcend,double *ctrl,
-          ITG *ikforc,ITG *ilforc,double *thicke,ITG *nmat,
-          char *typeboun,ITG *ielprop,double *prop,char *orname,
-          ITG *ndamp,double *dacon,double *t0g,double *t1g);
+void steadystate(double **co, ITG *nk, ITG **kon, ITG **ipkon, char **lakon, ITG *ne,
+                 ITG **nodeboun, ITG **ndirboun, double **xboun, ITG *nboun,
+                 ITG **ipompcp, ITG **nodempcp, double **coefmpcp, char **labmpcp, ITG *nmpc,
+                 ITG *nodeforc, ITG *ndirforc, double *xforc, ITG *nforc,
+                 ITG *nelemload, char *sideload, double *xload,
+                 ITG * nload,
+                 ITG **nactdof, ITG *neq, ITG *nzl, ITG *icol, ITG *irow,
+                 ITG *nmethod, ITG **ikmpcp, ITG **ilmpcp, ITG **ikboun,
+                 ITG **  ilboun,
+                 double *elcon, ITG *nelcon, double *rhcon, ITG *nrhcon,
+                 double *cocon, ITG *ncocon,
+                 double *alcon, ITG *nalcon, double *alzero, ITG **ielmat,
+                 ITG **ielorien, ITG *norien, double *orab, ITG *ntmat_,
+                 double **t0,
+                 double **t1, ITG *ithermal, double *prestr, ITG *iprestr,
+                 double **voldp, ITG *iperturb, double *sti, ITG *nzs,
+                 double *timepar, double *xmodal,
+                 double **veoldp, char *amname, double *amta,
+                 ITG *namta, ITG *nam, ITG *iamforc, ITG *iamload,
+                 ITG **iamt1, ITG *jout, ITG *kode, char *filab,
+                 double **emep, double *xforcold, double *xloadold,
+                 double **t1old, ITG **iamboun,
+                 double **xbounold, ITG *iexpl, double *plicon, ITG *nplicon,
+                 double *plkcon, ITG *nplkcon,
+                 double *xstate, ITG *npmat_, char *matname, ITG *mi,
+                 ITG *ncmat_, ITG *nstate_, double **enerp, char *jobnamec,
+                 double *ttime, char *set, ITG *nset, ITG *istartset,
+                 ITG *iendset, ITG *ialset, ITG *nprint, char *prlab,
+                 char *prset, ITG *nener, double *trab,
+                 ITG **inotr, ITG *ntrans, double **fmpcp, ITG *ipobody, ITG *ibody,
+                 double *xbody, ITG *nbody, double *xbodyold, ITG *istep,
+                 ITG *isolver, ITG *jq, char *output, ITG *mcs, ITG *nkon,
+                 ITG *ics, double *cs, ITG *mpcend, double *ctrl,
+                 ITG *ikforc, ITG *ilforc, double *thicke, ITG *nmat,
+                 char *typeboun, ITG *ielprop, double *prop, char *orname,
+                 ITG *ndamp, double *dacon, double *t0g, double *t1g);
 
-void FORTRAN(stop,());
+void FORTRAN(stop, ());
 
-void FORTRAN(stopwithout201,());
+void FORTRAN(stopwithout201, ());
 
-void storecontactdof(ITG *nope,ITG *nactdof,ITG *mt,ITG *konl,
-          ITG **ikactcontp,
-          ITG *nactcont,ITG *nactcont_,double *bcont,double *fnl,
-          ITG *ikmpc,ITG *nmpc,ITG *ilmpc,ITG *ipompc,ITG *nodempc,
-          double *coefmpc);
+void storecontactdof(ITG *nope, ITG *nactdof, ITG *mt, ITG *konl,
+                     ITG **ikactcontp,
+                     ITG *nactcont, ITG *nactcont_, double *bcont, double *fnl,
+                     ITG *ikmpc, ITG *nmpc, ITG *ilmpc, ITG *ipompc, ITG *nodempc,
+                     double *coefmpc);
 
-void FORTRAN(storeresidual,(ITG *nactdof,double *b,double *fn,char *filab,
-             ITG *ithermal,ITG *nk,double *sti,double *stn,
-             ITG *ipkon,ITG *inum,ITG *kon,char *lakon,
-             ITG *ne,ITG *mi,double *orab,ITG *ielorien,
-             double *co,ITG *itg,ITG *ntg,double *vold,
-             ITG *ielmat,double *thicke,ITG *ielprop,double *prop));
-     
-void FORTRAN(storecontactprop,(ITG *ne,ITG *ne0,char *lakon,ITG *kon,
-         ITG *ipkon,ITG *mi,ITG *ielmat,double *elcon,ITG *mortar,
-         double *adb,ITG *nactdof,double *springarea,ITG *ncmat_,
-         ITG *ntmat_,double *stx,double *temax));
+void FORTRAN(storeresidual, (ITG * nactdof, double *b, double *fn, char *filab,
+                             ITG *ithermal, ITG *nk, double *sti, double *stn,
+                             ITG *ipkon, ITG *inum, ITG *kon, char *lakon,
+                             ITG *ne, ITG *mi, double *orab, ITG *ielorien,
+                             double *co, ITG *itg, ITG *ntg, double *vold,
+                             ITG *ielmat, double *thicke, ITG *ielprop, double *prop));
 
-ITG strcmp1(const char *s1,const char *s2);
+void FORTRAN(storecontactprop, (ITG * ne, ITG *ne0, char *lakon, ITG *kon,
+                                ITG *ipkon, ITG *mi, ITG *ielmat, double *elcon, ITG *mortar,
+                                double *adb, ITG *nactdof, double *springarea, ITG *ncmat_,
+                                ITG *ntmat_, double *stx, double *temax));
 
-ITG strcmp2(const char *s1,const char *s2,ITG length);
+ITG strcmp1(const char *s1, const char *s2);
 
-ITG strcpy1(char *s1,const char *s2,ITG length);
+ITG strcmp2(const char *s1, const char *s2, ITG length);
 
-void stress_sen(double *co,ITG *nk,ITG *kon,ITG *ipkon,char *lakon,ITG *ne,
-       double *stn,double *elcon,ITG *nelcon,
-       double *rhcon,ITG *nrhcon,double *alcon,ITG *nalcon,double *alzero,
-       ITG *ielmat,ITG *ielorien,ITG *norien,double *orab,ITG *ntmat_,
-       double *t0,
-       double *t1,ITG *ithermal,double *prestr,ITG *iprestr,char *filab,
-       double *emn,
-       double *een,ITG *iperturb,double *f,ITG *nactdof,
-       double *vold,ITG *nodeboun,ITG *ndirboun,
-       double *xboun,ITG *nboun,ITG *ipompc,ITG *nodempc,double *coefmpc,
-       char *labmpc,ITG *nmpc,ITG *nmethod,double *cam,ITG *neq,double *veold,
-       double *accold,double *bet,double *gam,double *dtime,double *time,
-       double *ttime,double *plicon,ITG *nplicon,double *plkcon,
-       ITG *nplkcon,double *xstateini,double *xstate,ITG *npmat_,
-       double *epn,char *matname,ITG *mi,ITG *ielas,ITG *ncmat_,
-       ITG *nstate_,
-       double *stiini,double *vini,ITG *ikboun,ITG *ilboun,
-       double *enern,double *emeini,double *xstaten,double *enerini,
-       double *cocon,ITG *ncocon,char *set,ITG *nset,ITG *istartset,
-       ITG *iendset,
-       ITG *ialset,ITG *nprint,char *prlab,char *prset,double *qfx,double *qfn,
-       double *trab,
-       ITG *inotr,ITG *ntrans,double *fmpc,ITG *nelemload,ITG *nload,
-       ITG *ikmpc,ITG *ilmpc,
-       ITG *istep,ITG *iinc,double *springarea,double *reltime,ITG *ne0,
-       double *xforc,ITG *nforc,double *thicke,
-       double *shcon,ITG *nshcon,char *sideload,double *xload,
-       double *xloadold,ITG *icfd,ITG *inomat,double *pslavsurf,
-       double *pmastsurf,ITG *mortar,ITG *islavact,double *cdn,
-       ITG *islavnode,ITG *nslavnode,ITG *ntie,double *clearini,
-       ITG *islavsurf,ITG *ielprop,double *prop,double *energyini,
-       double *energy,ITG *kscale,char *orname,ITG *network,
-       ITG *nestart,ITG *neend,ITG *jqs,ITG *irows,ITG *nodedesi,
-       double *xdesi,ITG *ndesi,ITG *iobject,ITG *nobject,char *objectset,
-       double *g0,double *dgdx,ITG *idesvara,ITG *idesvarb,ITG *nasym,
-       ITG *isolver,double *distmin,ITG *nodeset,double *b);
+ITG strcpy1(char *s1, const char *s2, ITG length);
+
+void stress_sen(double *co, ITG *nk, ITG *kon, ITG *ipkon, char *lakon, ITG *ne,
+                double *stn, double *elcon, ITG *nelcon,
+                double *rhcon, ITG *nrhcon, double *alcon, ITG *nalcon, double *alzero,
+                ITG *ielmat, ITG *ielorien, ITG *norien, double *orab, ITG *ntmat_,
+                double *t0,
+                double *t1, ITG *ithermal, double *prestr, ITG *iprestr, char *filab,
+                double *emn,
+                double *een, ITG *iperturb, double *f, ITG *nactdof,
+                double *vold, ITG *nodeboun, ITG *ndirboun,
+                double *xboun, ITG *nboun, ITG *ipompc, ITG *nodempc, double *coefmpc,
+                char *labmpc, ITG *nmpc, ITG *nmethod, double *cam, ITG *neq, double *veold,
+                double *accold, double *bet, double *gam, double *dtime, double *time,
+                double *ttime, double *plicon, ITG *nplicon, double *plkcon,
+                ITG *nplkcon, double *xstateini, double *xstate, ITG *npmat_,
+                double *epn, char *matname, ITG *mi, ITG *ielas, ITG *ncmat_,
+                ITG *   nstate_,
+                double *stiini, double *vini, ITG *ikboun, ITG *ilboun,
+                double *enern, double *emeini, double *xstaten, double *enerini,
+                double *cocon, ITG *ncocon, char *set, ITG *nset, ITG *istartset,
+                ITG *iendset,
+                ITG *ialset, ITG *nprint, char *prlab, char *prset, double *qfx, double *qfn,
+                double *trab,
+                ITG *inotr, ITG *ntrans, double *fmpc, ITG *nelemload, ITG *nload,
+                ITG *ikmpc, ITG *ilmpc,
+                ITG *istep, ITG *iinc, double *springarea, double *reltime, ITG *ne0,
+                double *xforc, ITG *nforc, double *thicke,
+                double *shcon, ITG *nshcon, char *sideload, double *xload,
+                double *xloadold, ITG *icfd, ITG *inomat, double *pslavsurf,
+                double *pmastsurf, ITG *mortar, ITG *islavact, double *cdn,
+                ITG *islavnode, ITG *nslavnode, ITG *ntie, double *clearini,
+                ITG *islavsurf, ITG *ielprop, double *prop, double *energyini,
+                double *energy, ITG *kscale, char *orname, ITG *network,
+                ITG *nestart, ITG *neend, ITG *jqs, ITG *irows, ITG *nodedesi,
+                double *xdesi, ITG *ndesi, ITG *iobject, ITG *nobject, char *objectset,
+                double *g0, double *dgdx, ITG *idesvara, ITG *idesvarb, ITG *nasym,
+                ITG *isolver, double *distmin, ITG *nodeset, double *b);
 
 void *stress_senmt(ITG *i);
 
-void stress_sen_dv(double *co,ITG *nk,ITG *kon,ITG *ipkon,char *lakon,ITG *ne,
-       double *dstn,double *elcon,ITG *nelcon,
-       double *rhcon,ITG *nrhcon,double *alcon,ITG *nalcon,double *alzero,
-       ITG *ielmat,ITG *ielorien,ITG *norien,double *orab,ITG *ntmat_,
-       double *t0,double *t1,ITG *ithermal,double *prestr,ITG *iprestr,
-       char *filab,ITG *iperturb,double *dv,ITG *nmethod,double *dtime,
-       double *time,double *ttime,double *plicon,ITG *nplicon,double *plkcon,
-       ITG *nplkcon,double *xstateini,double *xstate,ITG *npmat_,char *matname,
-       ITG *mi,ITG *ielas,ITG *ncmat_,ITG *nstate_,double *stiini,double *vini,
-       double *emeini,double *enerini,ITG *istep,ITG *iinc,double *springarea,
-       double *reltime,ITG *ne0,double *thicke,double *pslavsurf,
-       double *pmastsurf,ITG *mortar,double *clearini,ITG *ielprop,
-       double *prop, 
-       ITG *kscale,ITG *iobject,double *g0,ITG *nea,ITG *neb,ITG *nasym,
-       double *distmin,double *dstx,ITG *ialnk,double *dgdu,ITG *ialeneigh, 
-       ITG *neaneigh,ITG *nebneigh,ITG *ialnneigh,ITG *naneigh,ITG *nbneigh,
-       double *stn,double *expks,char *objectset,ITG *idof,ITG *node,
-       ITG *idir,double *vold,double *dispmin);       
+void stress_sen_dv(double *co, ITG *nk, ITG *kon, ITG *ipkon, char *lakon, ITG *ne,
+                   double *dstn, double *elcon, ITG *nelcon,
+                   double *rhcon, ITG *nrhcon, double *alcon, ITG *nalcon, double *alzero,
+                   ITG *ielmat, ITG *ielorien, ITG *norien, double *orab, ITG *ntmat_,
+                   double *t0, double *t1, ITG *ithermal, double *prestr, ITG *iprestr,
+                   char *filab, ITG *iperturb, double *dv, ITG *nmethod, double *dtime,
+                   double *time, double *ttime, double *plicon, ITG *nplicon, double *plkcon,
+                   ITG *nplkcon, double *xstateini, double *xstate, ITG *npmat_, char *matname,
+                   ITG *mi, ITG *ielas, ITG *ncmat_, ITG *nstate_, double *stiini, double *vini,
+                   double *emeini, double *enerini, ITG *istep, ITG *iinc, double *springarea,
+                   double *reltime, ITG *ne0, double *thicke, double *pslavsurf,
+                   double *pmastsurf, ITG *mortar, double *clearini, ITG *ielprop,
+                   double *prop,
+                   ITG *kscale, ITG *iobject, double *g0, ITG *nea, ITG *neb, ITG *nasym,
+                   double *distmin, double *dstx, ITG *ialnk, double *dgdu, ITG *ialeneigh,
+                   ITG *neaneigh, ITG *nebneigh, ITG *ialnneigh, ITG *naneigh, ITG *nbneigh,
+                   double *stn, double *expks, char *objectset, ITG *idof, ITG *node,
+                   ITG *idir, double *vold, double *dispmin);
 
 void *stress_sen_dvmt(ITG *i);
 
-void stress_sen_dx(double *co,ITG *nk,ITG *kon,ITG *ipkon,char *lakon,ITG *ne,
-       double *dstn,double *elcon,ITG *nelcon,
-       double *rhcon,ITG *nrhcon,double *alcon,ITG *nalcon,double *alzero,
-       ITG *ielmat,ITG *ielorien,ITG *norien,double *orab,ITG *ntmat_,
-       double *t0,double *t1,ITG *ithermal,double *prestr,ITG *iprestr,
-       char *filab,ITG *iperturb,double *vold,ITG *nmethod,double *dtime, 
-       double *time,double *ttime,double *plicon,ITG *nplicon,double *plkcon,
-       ITG *nplkcon,double *xstateini,double *xstate,ITG *npmat_,char *matname,
-       ITG *mi,ITG *ielas,ITG *ncmat_,ITG *nstate_,double *stiini,double *vini,
-       double *emeini,double *enerini,ITG *istep,ITG *iinc,double *springarea,
-       double *reltime,ITG *ne0,double *thicke,double *pslavsurf,
-       double *pmastsurf,ITG *mortar,double *clearini,ITG *ielprop,double *prop,
-       ITG *kscale,ITG *iobject,char *objectset,double *g0,double *dgdx,
-       ITG *nea,ITG *neb,ITG *nasym,double *distmin,ITG*idesvar,double *dstx, 
-       ITG *ialdesi,ITG *ialeneigh,ITG *neaneigh,ITG *nebneigh,ITG *ialnneigh,
-       ITG *naneigh,ITG *nbneigh,double *stn,double *expks,ITG *ndesi);
+void stress_sen_dx(double *co, ITG *nk, ITG *kon, ITG *ipkon, char *lakon, ITG *ne,
+                   double *dstn, double *elcon, ITG *nelcon,
+                   double *rhcon, ITG *nrhcon, double *alcon, ITG *nalcon, double *alzero,
+                   ITG *ielmat, ITG *ielorien, ITG *norien, double *orab, ITG *ntmat_,
+                   double *t0, double *t1, ITG *ithermal, double *prestr, ITG *iprestr,
+                   char *filab, ITG *iperturb, double *vold, ITG *nmethod, double *dtime,
+                   double *time, double *ttime, double *plicon, ITG *nplicon, double *plkcon,
+                   ITG *nplkcon, double *xstateini, double *xstate, ITG *npmat_, char *matname,
+                   ITG *mi, ITG *ielas, ITG *ncmat_, ITG *nstate_, double *stiini, double *vini,
+                   double *emeini, double *enerini, ITG *istep, ITG *iinc, double *springarea,
+                   double *reltime, ITG *ne0, double *thicke, double *pslavsurf,
+                   double *pmastsurf, ITG *mortar, double *clearini, ITG *ielprop, double *prop,
+                   ITG *kscale, ITG *iobject, char *objectset, double *g0, double *dgdx,
+                   ITG *nea, ITG *neb, ITG *nasym, double *distmin, ITG *idesvar, double *dstx,
+                   ITG *ialdesi, ITG *ialeneigh, ITG *neaneigh, ITG *nebneigh, ITG *ialnneigh,
+                   ITG *naneigh, ITG *nbneigh, double *stn, double *expks, ITG *ndesi);
 
 void *stress_sen_dxmt(ITG *i);
 
-void FORTRAN(stressintensity,(ITG *nfront,ITG *ifrontrel,double *stress,
-			      double *xt,double *xn,double *xa,double *dk1,
-			      double *dk2,double *dk3,double *xkeq,double *phi,
-			      double *psi,double *acrack,double *shape,
-			      ITG *nstep));
+void FORTRAN(stressintensity, (ITG * nfront, ITG *ifrontrel, double *stress,
+                               double *xt, double *xn, double *xa, double *dk1,
+                               double *dk2, double *dk3, double *xkeq, double *phi,
+                               double *psi, double *acrack, double *shape,
+                               ITG *nstep));
 
-void FORTRAN(stressintensity_smoothing,(ITG *nnfront,ITG *isubsurffront,
-					ITG *istartfront,ITG *iendfront,
-					ITG *ifrontrel,double *costruc,
-					double *dist,
-					ITG *istartcrackfro,ITG *iendcrackfro,
-					double *xkeq,double *phi,ITG *nfront,
-					ITG *ncrack,double *dk,double *p,
-					ITG *idist,double *tper,ITG *nstep));
+void FORTRAN(stressintensity_smoothing, (ITG * nnfront, ITG *isubsurffront,
+                                         ITG *istartfront, ITG *iendfront,
+                                         ITG *ifrontrel, double *costruc,
+                                         double *dist,
+                                         ITG *istartcrackfro, ITG *iendcrackfro,
+                                         double *xkeq, double *phi, ITG *nfront,
+                                         ITG *ncrack, double *dk, double *p,
+                                         ITG *idist, double *tper, ITG *nstep));
 
-void stressmain(double *co,ITG *nk,ITG *kon,ITG *ipkon,char *lakon,ITG *ne,
-       double *v,double *stn,ITG *inum,double *stx,double *elcon,ITG *nelcon,
-       double *rhcon,ITG *nrhcon,double *alcon,ITG *nalcon,double *alzero,
-       ITG *ielmat,ITG *ielorien,ITG *norien,double *orab,ITG *ntmat_,
-       double *t0,
-       double *t1,ITG *ithermal,double *prestr,ITG *iprestr,char *filab,
-       double *eme,double *emn,
-       double *een,ITG *iperturb,double *f,double *fn,ITG *nactdof,ITG *iout,
-       double *qa,double *vold,ITG *nodeboun,ITG *ndirboun,
-       double *xboun,ITG *nboun,ITG *ipompc,ITG *nodempc,double *coefmpc,
-       char *labmpc,ITG *nmpc,ITG *nmethod,double *cam,ITG *neq,double *veold,
-       double *accold,double *bet,double *gam,double *dtime,double *time,
-       double *ttime,double *plicon,ITG *nplicon,double *plkcon,
-       ITG *nplkcon,double *xstateini,double *xstiff,double *xstate,ITG *npmat_,
-       double *epn,char *matname,ITG *mi,ITG *ielas,ITG *icmd,ITG *ncmat_,
-       ITG *nstate_,
-       double *stiini,double *vini,ITG *ikboun,ITG *ilboun,double *ener,
-       double *enern,double *emeini,double *xstaten,double *eei,double *enerini,
-       double *cocon,ITG *ncocon,char *set,ITG *nset,ITG *istartset,
-       ITG *iendset,
-       ITG *ialset,ITG *nprint,char *prlab,char *prset,double *qfx,double *qfn,
-       double *trab,
-       ITG *inotr,ITG *ntrans,double *fmpc,ITG *nelemload,ITG *nload,
-       ITG *ikmpc,ITG *ilmpc,
-       ITG *istep,ITG *iinc,double *springarea,double *reltime,ITG *ne0,
-       double *xforc,ITG *nforc,double *thicke,
-       double *shcon,ITG *nshcon,char *sideload,double *xload,
-       double *xloadold,ITG *icfd,ITG *inomat,double *pslavsurf,
-       double *pmastsurf,ITG *mortar,ITG *islavact,double *cdn,
-       ITG *islavnode,ITG *nslavnode,ITG *ntie,double *clearini,
-       ITG *islavsurf,ITG *ielprop,double *prop,double *energyini,
-       double *energy,double *distmin,ITG *ndesi,ITG *nodedesi,
-       ITG *nobject,char *objectset,double *g0,double *dgdx,
-       double *sti,double *df,ITG *nactdofinv,ITG *jqs,
-       ITG *irows,ITG *idisplacement,ITG *nzs,char *jobnamec,ITG *isolver,
-       ITG *icol,ITG *irow,ITG *jq,ITG *kode,double *cs,char *output,
-       ITG *istartdesi,ITG *ialdesi,double *xdesi,char *orname,
-       ITG *icoordinate,ITG *iev,double *d,double *z,double *au,double *ad,
-       double *aub,double*adb,ITG *cyclicsymmetry,ITG *nzss,ITG *nev,
-       ITG *ishapeenergy,double *fint,ITG *nlabel,ITG *igreen,ITG *nasym,
-       ITG *iponoel,ITG *inoel,ITG *nodedesiinv,double *dgdxglob,
-       double *df2,double *dgdxdy,ITG *nkon,ITG *iponod2dto3d,
-       ITG *iponk2dto3d,ITG *ics,ITG *mcs,ITG *mpcend,ITG *noddiam,
-		double *duds,
-		ITG *ipobody,ITG *ibody,double *xbody,ITG *nbody);
+void stressmain(double *co, ITG *nk, ITG *kon, ITG *ipkon, char *lakon, ITG *ne,
+                double *v, double *stn, ITG *inum, double *stx, double *elcon, ITG *nelcon,
+                double *rhcon, ITG *nrhcon, double *alcon, ITG *nalcon, double *alzero,
+                ITG *ielmat, ITG *ielorien, ITG *norien, double *orab, ITG *ntmat_,
+                double *t0,
+                double *t1, ITG *ithermal, double *prestr, ITG *iprestr, char *filab,
+                double *eme, double *emn,
+                double *een, ITG *iperturb, double *f, double *fn, ITG *nactdof, ITG *iout,
+                double *qa, double *vold, ITG *nodeboun, ITG *ndirboun,
+                double *xboun, ITG *nboun, ITG *ipompc, ITG *nodempc, double *coefmpc,
+                char *labmpc, ITG *nmpc, ITG *nmethod, double *cam, ITG *neq, double *veold,
+                double *accold, double *bet, double *gam, double *dtime, double *time,
+                double *ttime, double *plicon, ITG *nplicon, double *plkcon,
+                ITG *nplkcon, double *xstateini, double *xstiff, double *xstate, ITG *npmat_,
+                double *epn, char *matname, ITG *mi, ITG *ielas, ITG *icmd, ITG *ncmat_,
+                ITG *   nstate_,
+                double *stiini, double *vini, ITG *ikboun, ITG *ilboun, double *ener,
+                double *enern, double *emeini, double *xstaten, double *eei, double *enerini,
+                double *cocon, ITG *ncocon, char *set, ITG *nset, ITG *istartset,
+                ITG *iendset,
+                ITG *ialset, ITG *nprint, char *prlab, char *prset, double *qfx, double *qfn,
+                double *trab,
+                ITG *inotr, ITG *ntrans, double *fmpc, ITG *nelemload, ITG *nload,
+                ITG *ikmpc, ITG *ilmpc,
+                ITG *istep, ITG *iinc, double *springarea, double *reltime, ITG *ne0,
+                double *xforc, ITG *nforc, double *thicke,
+                double *shcon, ITG *nshcon, char *sideload, double *xload,
+                double *xloadold, ITG *icfd, ITG *inomat, double *pslavsurf,
+                double *pmastsurf, ITG *mortar, ITG *islavact, double *cdn,
+                ITG *islavnode, ITG *nslavnode, ITG *ntie, double *clearini,
+                ITG *islavsurf, ITG *ielprop, double *prop, double *energyini,
+                double *energy, double *distmin, ITG *ndesi, ITG *nodedesi,
+                ITG *nobject, char *objectset, double *g0, double *dgdx,
+                double *sti, double *df, ITG *nactdofinv, ITG *jqs,
+                ITG *irows, ITG *idisplacement, ITG *nzs, char *jobnamec, ITG *isolver,
+                ITG *icol, ITG *irow, ITG *jq, ITG *kode, double *cs, char *output,
+                ITG *istartdesi, ITG *ialdesi, double *xdesi, char *orname,
+                ITG *icoordinate, ITG *iev, double *d, double *z, double *au, double *ad,
+                double *aub, double *adb, ITG *cyclicsymmetry, ITG *nzss, ITG *nev,
+                ITG *ishapeenergy, double *fint, ITG *nlabel, ITG *igreen, ITG *nasym,
+                ITG *iponoel, ITG *inoel, ITG *nodedesiinv, double *dgdxglob,
+                double *df2, double *dgdxdy, ITG *nkon, ITG *iponod2dto3d,
+                ITG *iponk2dto3d, ITG *ics, ITG *mcs, ITG *mpcend, ITG *noddiam,
+                double *duds,
+                ITG *ipobody, ITG *ibody, double *xbody, ITG *nbody);
 
-void FORTRAN(subspace,(double *d,double *aa,double *bb,double *cc,
-             double *alpham,double *betam,ITG *nev,
-             double *xini,double *cd,double *cv,double *time,
-             double *rwork,ITG *lrw,ITG *k,ITG *jout,double *rpar,
-             double *bj,ITG *iwork,ITG *liw,ITG *iddebdf,double *bjp));
+void FORTRAN(subspace, (double *d, double *aa, double *bb, double *cc,
+                        double *alpham, double *betam, ITG *nev,
+                        double *xini, double *cd, double *cv, double *time,
+                        double *rwork, ITG *lrw, ITG *k, ITG *jout, double *rpar,
+                        double *bj, ITG *iwork, ITG *liw, ITG *iddebdf, double *bjp));
 
-void FORTRAN(subtracthmatrix,(ITG *neqp,double *aubh,double *adbh,
-			      double *aux,double *dp,ITG *jqp,ITG *irowp,
-			      double *b,double *theta1,double *dtimef));
+void FORTRAN(subtracthmatrix, (ITG * neqp, double *aubh, double *adbh,
+                               double *aux, double *dp, ITG *jqp, ITG *irowp,
+                               double *b, double *theta1, double *dtimef));
 
-void FORTRAN(tempload,(double *xforcold,double *xforc,double *xforcact,
-               ITG *iamforc,ITG *nforc,double *xloadold,double *xload,
-               double *xloadact,ITG *iamload,ITG *nload,ITG *ibody,
-               double *xbody,ITG *nbody,double *xbodyold,double *xbodyact,
-               double *t1old,double *t1,double *t1act,ITG *iamt1,
-               ITG *nk,double *amta,ITG *namta,ITG *nam,double *ampli,
-               double *time,double *reltime,double *ttime,double *dtime,
-               ITG *ithermal,ITG *nmethod,
-               double *xbounold,double *xboun,double *xbounact,
-               ITG *iamboun,ITG *nboun,ITG *nodeboun,
-               ITG *ndirboun,ITG *nodeforc,ITG *ndirforc,ITG *istep,
-               ITG *iint,double *co,double *vold,ITG *itg,ITG *ntg,
-               char *amname,ITG *ikboun,ITG *ilboun,ITG *nelemload,
-               char *sideload,ITG *mi,ITG *ntrans,double *trab,
-               ITG *inotr,double *veold,ITG *integerglob,
-               double *doubleglob,char *tieset,ITG *istartset,
-               ITG *iendset,ITG *ialset,ITG *ntie,ITG *nmpc,ITG *ipompc,
-               ITG *ikmpc,ITG *ilmpc,ITG *nodempc,double *coefmpc,
-               ITG *ipobody,ITG *iponoel,ITG *inoel,ITG *ipkon,ITG *kon,
-               ITG *ielprop,double *prop,ITG *ielmat,double *shcon,
-               ITG *nshcon,double *rhcon,ITG *nrhcon,double *cocon,
-	       ITG *ncocon,ITG *ntmat_,char *lakon,char *set,ITG *nset));
+void FORTRAN(tempload, (double *xforcold, double *xforc, double *xforcact,
+                        ITG *iamforc, ITG *nforc, double *xloadold, double *xload,
+                        double *xloadact, ITG *iamload, ITG *nload, ITG *ibody,
+                        double *xbody, ITG *nbody, double *xbodyold, double *xbodyact,
+                        double *t1old, double *t1, double *t1act, ITG *iamt1,
+                        ITG *nk, double *amta, ITG *namta, ITG *nam, double *ampli,
+                        double *time, double *reltime, double *ttime, double *dtime,
+                        ITG *ithermal, ITG *nmethod,
+                        double *xbounold, double *xboun, double *xbounact,
+                        ITG *iamboun, ITG *nboun, ITG *nodeboun,
+                        ITG *ndirboun, ITG *nodeforc, ITG *ndirforc, ITG *istep,
+                        ITG *iint, double *co, double *vold, ITG *itg, ITG *ntg,
+                        char *amname, ITG *ikboun, ITG *ilboun, ITG *nelemload,
+                        char *sideload, ITG *mi, ITG *ntrans, double *trab,
+                        ITG *inotr, double *veold, ITG *integerglob,
+                        double *doubleglob, char *tieset, ITG *istartset,
+                        ITG *iendset, ITG *ialset, ITG *ntie, ITG *nmpc, ITG *ipompc,
+                        ITG *ikmpc, ITG *ilmpc, ITG *nodempc, double *coefmpc,
+                        ITG *ipobody, ITG *iponoel, ITG *inoel, ITG *ipkon, ITG *kon,
+                        ITG *ielprop, double *prop, ITG *ielmat, double *shcon,
+                        ITG *nshcon, double *rhcon, ITG *nrhcon, double *cocon,
+                        ITG *ncocon, ITG *ntmat_, char *lakon, char *set, ITG *nset));
 
-void FORTRAN(tempload_em,(double *xforcold,double *xforc,double *xforcact,
-               ITG *iamforc,ITG *nforc,double *xloadold,double *xload,
-               double *xloadact,ITG *iamload,ITG *nload,ITG *ibody,
-               double *xbody,ITG *nbody,double *xbodyold,double *xbodyact,
-               double *t1old,double *t1,double *t1act,ITG *iamt1,
-               ITG *nk,double *amta,ITG *namta,ITG *nam,double *ampli,
-               double *time,double *reltime,double *ttime,double *dtime,
-               ITG *ithermal,ITG *nmethod,
-               double *xbounold,double *xboun,double *xbounact,
-               ITG *iamboun,ITG *nboun,ITG *nodeboun,
-               ITG *ndirboun,ITG *nodeforc,ITG *ndirforc,ITG *istep,
-               ITG *iint,double *co,double *vold,ITG *itg,ITG *ntg,
-               char *amname,ITG *ikboun,ITG *ilboun,ITG *nelemload,
-               char *sideload,ITG *mi,ITG *ntrans,double *trab,
-               ITG *inotr,double *veold,ITG *integerglob,
-               double *doubleglob,char *tieset,ITG *istartset,
-               ITG *iendset,ITG *ialset,ITG *ntie,ITG *nmpc,ITG *ipompc,
-               ITG *ikmpc,ITG *ilmpc,ITG *nodempc,double *coefmpc,
-               double *h0scale,ITG *inomat,ITG *ipobody,ITG *iponoel,
-               ITG *inoel,ITG *ipkon,ITG *kon,char *lakon,ITG *ielprop,
-               double *prop,ITG *ielmat,double *shcon,ITG *nshcon,
-               double *rhcon,ITG *nrhcon,ITG *ntmat_,double *cocon,
-	       ITG *ncocon,char *set,ITG *nset));
+void FORTRAN(tempload_em, (double *xforcold, double *xforc, double *xforcact,
+                           ITG *iamforc, ITG *nforc, double *xloadold, double *xload,
+                           double *xloadact, ITG *iamload, ITG *nload, ITG *ibody,
+                           double *xbody, ITG *nbody, double *xbodyold, double *xbodyact,
+                           double *t1old, double *t1, double *t1act, ITG *iamt1,
+                           ITG *nk, double *amta, ITG *namta, ITG *nam, double *ampli,
+                           double *time, double *reltime, double *ttime, double *dtime,
+                           ITG *ithermal, ITG *nmethod,
+                           double *xbounold, double *xboun, double *xbounact,
+                           ITG *iamboun, ITG *nboun, ITG *nodeboun,
+                           ITG *ndirboun, ITG *nodeforc, ITG *ndirforc, ITG *istep,
+                           ITG *iint, double *co, double *vold, ITG *itg, ITG *ntg,
+                           char *amname, ITG *ikboun, ITG *ilboun, ITG *nelemload,
+                           char *sideload, ITG *mi, ITG *ntrans, double *trab,
+                           ITG *inotr, double *veold, ITG *integerglob,
+                           double *doubleglob, char *tieset, ITG *istartset,
+                           ITG *iendset, ITG *ialset, ITG *ntie, ITG *nmpc, ITG *ipompc,
+                           ITG *ikmpc, ITG *ilmpc, ITG *nodempc, double *coefmpc,
+                           double *h0scale, ITG *inomat, ITG *ipobody, ITG *iponoel,
+                           ITG *inoel, ITG *ipkon, ITG *kon, char *lakon, ITG *ielprop,
+                           double *prop, ITG *ielmat, double *shcon, ITG *nshcon,
+                           double *rhcon, ITG *nrhcon, ITG *ntmat_, double *cocon,
+                           ITG *ncocon, char *set, ITG *nset));
 
-void FORTRAN(temploaddiff,(double *xforcold,double *xforc,double *xforcact,
-               ITG *iamforc,ITG *nforc,double *xloadold,double *xload,
-               double *xloadact,ITG *iamload,ITG *nload,ITG *ibody,
-               double *xbody,ITG *nbody,double *xbodyold,double *xbodyact,
-               double *t1old,double *t1,double *t1act,ITG *iamt1,
-               ITG *nk,double *amta,ITG *namta,ITG *nam,double *ampli,
-               double *time,double *reltime,double *ttime,double *dtime,
-               ITG *ithermal,ITG *nmethod,
-               double *xbounold,double *xboun,double *xbounact,
-               ITG *iamboun,ITG *nboun,ITG *nodeboun,
-               ITG *ndirboun,ITG *nodeforc,ITG *ndirforc,ITG *istep,
-               ITG *iint,double *co,double *vold,ITG *itg,ITG *ntg,
-               char *amname,ITG *ikboun,ITG *ilboun,ITG *nelemload,
-               char *sideload,ITG *mi,double *xforcdiff,double *xloaddiff,
-               double *xbodydiff,double *t1diff,double *xboundiff,
-               ITG *icorrect,ITG *iprescribedboundary,ITG *ntrans,
-               double *trab,ITG *inotr,double *veold,ITG *nactdof,
-               double *bcont,double *fn,ITG *ipobody,ITG *iponoel,
-               ITG *inoel,ITG *ipkon,ITG *kon,char *lakon,ITG *ielprop,
-               double *prop,ITG *ielmat,double *shcon,ITG *nshcon,
-               double *rhcon,ITG *nrhcon,ITG *ntmat_,double *cocon,
-               ITG *ncocon));
+void FORTRAN(temploaddiff, (double *xforcold, double *xforc, double *xforcact,
+                            ITG *iamforc, ITG *nforc, double *xloadold, double *xload,
+                            double *xloadact, ITG *iamload, ITG *nload, ITG *ibody,
+                            double *xbody, ITG *nbody, double *xbodyold, double *xbodyact,
+                            double *t1old, double *t1, double *t1act, ITG *iamt1,
+                            ITG *nk, double *amta, ITG *namta, ITG *nam, double *ampli,
+                            double *time, double *reltime, double *ttime, double *dtime,
+                            ITG *ithermal, ITG *nmethod,
+                            double *xbounold, double *xboun, double *xbounact,
+                            ITG *iamboun, ITG *nboun, ITG *nodeboun,
+                            ITG *ndirboun, ITG *nodeforc, ITG *ndirforc, ITG *istep,
+                            ITG *iint, double *co, double *vold, ITG *itg, ITG *ntg,
+                            char *amname, ITG *ikboun, ITG *ilboun, ITG *nelemload,
+                            char *sideload, ITG *mi, double *xforcdiff, double *xloaddiff,
+                            double *xbodydiff, double *t1diff, double *xboundiff,
+                            ITG *icorrect, ITG *iprescribedboundary, ITG *ntrans,
+                            double *trab, ITG *inotr, double *veold, ITG *nactdof,
+                            double *bcont, double *fn, ITG *ipobody, ITG *iponoel,
+                            ITG *inoel, ITG *ipkon, ITG *kon, char *lakon, ITG *ielprop,
+                            double *prop, ITG *ielmat, double *shcon, ITG *nshcon,
+                            double *rhcon, ITG *nrhcon, ITG *ntmat_, double *cocon,
+                            ITG *ncocon));
 
-void FORTRAN(temploadfem,(double *xforcold,double *xforc,double *xforcact,
-               ITG *iamforc,ITG *nforc,double *xloadold,double *xload,
-               double *xloadact,ITG *iamload,ITG *nload,ITG *ibody,
-               double *xbody,ITG *nbody,double *xbodyold,double *xbodyact,
-               double *t1old,double *t1,double *t1act,ITG *iamt1,
-               ITG *nk,double *amta,ITG *namta,ITG *nam,double *ampli,
-               double *time,double *reltime,double *ttime,double *dtime,
-               ITG *ithermal,ITG *nmethod,
-               double *xbounold,double *xboun,double *xbounact,
-               ITG *iamboun,ITG *nboun,ITG *nodeboun,
-               ITG *ndirboun,ITG *nodeforc,ITG *ndirforc,ITG *istep,
-               ITG *iITG,double *co,double *vold,ITG *itg,ITG *ntg,
-               char *amname,ITG *ikboun,ITG *ilboun,ITG *nelemload,
-               char *sideload,ITG *mi,ITG *ntrans,double *trab,
-               ITG *inotr,double *veold,ITG *ITGegerglob,
-               double *doubleglob,char *tieset,ITG *istartset,
-               ITG *iendset,ITG *ialset,ITG *ntie,ITG *nmpc,ITG *ipompc,
-               ITG *ikmpc,ITG *ilmpc,ITG *nodempc,double *coefmpc,
-	       char *set,ITG *nset));
+void FORTRAN(temploadfem, (double *xforcold, double *xforc, double *xforcact,
+                           ITG *iamforc, ITG *nforc, double *xloadold, double *xload,
+                           double *xloadact, ITG *iamload, ITG *nload, ITG *ibody,
+                           double *xbody, ITG *nbody, double *xbodyold, double *xbodyact,
+                           double *t1old, double *t1, double *t1act, ITG *iamt1,
+                           ITG *nk, double *amta, ITG *namta, ITG *nam, double *ampli,
+                           double *time, double *reltime, double *ttime, double *dtime,
+                           ITG *ithermal, ITG *nmethod,
+                           double *xbounold, double *xboun, double *xbounact,
+                           ITG *iamboun, ITG *nboun, ITG *nodeboun,
+                           ITG *ndirboun, ITG *nodeforc, ITG *ndirforc, ITG *istep,
+                           ITG *iITG, double *co, double *vold, ITG *itg, ITG *ntg,
+                           char *amname, ITG *ikboun, ITG *ilboun, ITG *nelemload,
+                           char *sideload, ITG *mi, ITG *ntrans, double *trab,
+                           ITG *inotr, double *veold, ITG *ITGegerglob,
+                           double *doubleglob, char *tieset, ITG *istartset,
+                           ITG *iendset, ITG *ialset, ITG *ntie, ITG *nmpc, ITG *ipompc,
+                           ITG *ikmpc, ITG *ilmpc, ITG *nodempc, double *coefmpc,
+                           char *set, ITG *nset));
 
-void FORTRAN(temploadmodal,(double *amta,ITG *namta,ITG *nam,double *ampli,
-         double *timemin,double *ttimemin,double *dtime,double *xbounold,
-         double *xboun,double *xbounmin,ITG *iamboun,ITG *nboun,
-         ITG *nodeboun,ITG *ndirboun,char *amname,double *reltime));
+void FORTRAN(temploadmodal, (double *amta, ITG *namta, ITG *nam, double *ampli,
+                             double *timemin, double *ttimemin, double *dtime, double *xbounold,
+                             double *xboun, double *xbounmin, ITG *iamboun, ITG *nboun,
+                             ITG *nodeboun, ITG *ndirboun, char *amname, double *reltime));
 
-void FORTRAN(thickenlayer,(ITG *ipkonf,ITG *konf,char *lakonf,double *co,
-			   double *coel,double *cotet,ITG *nef));
+void FORTRAN(thickenlayer, (ITG * ipkonf, ITG *konf, char *lakonf, double *co,
+                            double *coel, double *cotet, ITG *nef));
 
-void FORTRAN(thickness,(ITG *nobject,ITG *nodedesiboun,
-			ITG *ndesiboun,char *objectset,double *xo,double *yo,
-			double *zo,double *x,double *y,double *z,ITG *nx,
-			ITG *ny,ITG *nz,double *co,ITG *ifree,ITG *ndesia,
-			ITG *ndesib,ITG *iobject,ITG *ndesi,double *dgdxglob,
-			ITG *nk,ITG *normdesi));                       
+void FORTRAN(thickness, (ITG * nobject, ITG *nodedesiboun,
+                         ITG *ndesiboun, char *objectset, double *xo, double *yo,
+                         double *zo, double *x, double *y, double *z, ITG *nx,
+                         ITG *ny, ITG *nz, double *co, ITG *ifree, ITG *ndesia,
+                         ITG *ndesib, ITG *iobject, ITG *ndesi, double *dgdxglob,
+                         ITG *nk, ITG *normdesi));
 
-void thicknessmain(double *co,ITG *nobject,ITG *nk,
-		   ITG *nodedesi,ITG *ndesi,char *objectset,ITG *ipkon,
-		   ITG *kon,char *lakon,char *set,ITG *nset,ITG *istartset,
-		   ITG *iendset,ITG *ialset,ITG *iobject,ITG *nodedesiinv,
-		   double *dgdxglob,double *xdesi);
+void thicknessmain(double *co, ITG *nobject, ITG *nk,
+                   ITG *nodedesi, ITG *ndesi, char *objectset, ITG *ipkon,
+                   ITG *kon, char *lakon, char *set, ITG *nset, ITG *istartset,
+                   ITG *iendset, ITG *ialset, ITG *iobject, ITG *nodedesiinv,
+                   double *dgdxglob, double *xdesi);
 
 void *thicknessmt(ITG *i);
-    
-void FORTRAN(tiefaccont,(char *lakon,ITG *ipkon,ITG *kon,ITG *ntie,
-       char *tieset,ITG *nset,char *set,ITG *istartset,ITG *iendset,
-       ITG *ialset,ITG *itiefac,ITG *islavsurf,ITG *islavnode,
-       ITG *imastnode,ITG *nslavnode,ITG *nmastnode,ITG *nslavs,
-       ITG *nmasts,ITG *ifacecount,ITG *iponoels,ITG *inoels,ITG *ifreenoels,
-       ITG *mortar,ITG *ipoface,ITG *nodface,ITG *nk,double *xnoels));   
 
-void tiedcontact(ITG *ntie,char *tieset,ITG *nset,char *set,
-               ITG *istartset,ITG *iendset,ITG *ialset,
-               char *lakon,ITG *ipkon,ITG *kon,double *tietol,
-               ITG *nmpc,ITG *mpcfree,ITG *memmpc_,
-               ITG **ipompcp,char **labmpcp,ITG **ikmpcp,ITG **ilmpcp,
-               double **fmpcp,ITG **nodempcp,double **coefmpcp,
-               ITG *ithermal,double *co,double *vold,ITG *nef,
-               ITG *nmpc_,ITG *mi,ITG *nk,ITG *istep,ITG *ikboun,
-               ITG *nboun,char *kind1,char *kind2);
+void FORTRAN(tiefaccont, (char *lakon, ITG *ipkon, ITG *kon, ITG *ntie,
+                          char *tieset, ITG *nset, char *set, ITG *istartset, ITG *iendset,
+                          ITG *ialset, ITG *itiefac, ITG *islavsurf, ITG *islavnode,
+                          ITG *imastnode, ITG *nslavnode, ITG *nmastnode, ITG *nslavs,
+                          ITG *nmasts, ITG *ifacecount, ITG *iponoels, ITG *inoels, ITG *ifreenoels,
+                          ITG *mortar, ITG *ipoface, ITG *nodface, ITG *nk, double *xnoels));
 
-void FORTRAN(topocfdfem,(ITG *nelemface,char *sideface,ITG *nface,ITG *ipoface,
-			 ITG *nodface,ITG *ne,ITG *ipkon,ITG *kon,char *lakon,
-			 ITG *nk,ITG *isolidsurf,ITG *nsolidsurf,
-			 ITG *ifreestream,ITG *nfreestream,ITG *neighsolidsurf,
-			 ITG *iponoel,ITG *inoel,ITG *inoelfree,
-			 double *co,char *set,ITG *istartset,
-			 ITG *iendset,ITG *ialset,ITG *nset,ITG *iturbulent,
-			 ITG *inomat,ITG *ielmat,ITG *ipface));
+void tiedcontact(ITG *ntie, char *tieset, ITG *nset, char *set,
+                 ITG *istartset, ITG *iendset, ITG *ialset,
+                 char *lakon, ITG *ipkon, ITG *kon, double *tietol,
+                 ITG *nmpc, ITG *mpcfree, ITG *memmpc_,
+                 ITG **ipompcp, char **labmpcp, ITG **ikmpcp, ITG **ilmpcp,
+                 double **fmpcp, ITG **nodempcp, double **coefmpcp,
+                 ITG *ithermal, double *co, double *vold, ITG *nef,
+                 ITG *nmpc_, ITG *mi, ITG *nk, ITG *istep, ITG *ikboun,
+                 ITG *nboun, char *kind1, char *kind2);
 
-void FORTRAN(totalcontact,(char *tieset,ITG *ntie,ITG *ne,ITG *ipkon,ITG *kon,
-			   char *lakon,ITG *islavsurf,ITG *itiefac,
-			   double *pmastsurf,ITG *ne0,ITG *nkon0));
+void FORTRAN(topocfdfem, (ITG * nelemface, char *sideface, ITG *nface, ITG *ipoface,
+                          ITG *nodface, ITG *ne, ITG *ipkon, ITG *kon, char *lakon,
+                          ITG *nk, ITG *isolidsurf, ITG *nsolidsurf,
+                          ITG *ifreestream, ITG *nfreestream, ITG *neighsolidsurf,
+                          ITG *iponoel, ITG *inoel, ITG *inoelfree,
+                          double *co, char *set, ITG *istartset,
+                          ITG *iendset, ITG *ialset, ITG *nset, ITG *iturbulent,
+                          ITG *inomat, ITG *ielmat, ITG *ipface));
 
-void FORTRAN(transformatrix,(double *xab,double *p,double *a));
+void FORTRAN(totalcontact, (char *tieset, ITG *ntie, ITG *ne, ITG *ipkon, ITG *kon,
+                            char *lakon, ITG *islavsurf, ITG *itiefac,
+                            double *pmastsurf, ITG *ne0, ITG *nkon0));
 
-void FORTRAN(transition,(double *dgdxglob,ITG *nobject,ITG *nk,ITG *nodedesi,
-			 ITG *ndesi,char *objectset,double *xo,double *yo,
-			 double *zo,double *x,double *y,double *z,ITG *nx,
-			 ITG *ny,ITG *nz,double *co,ITG *ifree,ITG *ndesia,
-			 ITG *ndesib,ITG *nobjectstart));
+void FORTRAN(transformatrix, (double *xab, double *p, double *a));
 
-void transitionmain(double *co,double *dgdxglob,ITG *nobject,ITG *nk,
-                ITG *nodedesi,ITG *ndesi,char *objectset,ITG *ipkon,
-                ITG *kon,char *lakon,ITG *ipoface,ITG *nodface,
-                ITG *nodedesiinv,ITG* nobjectstart);
+void FORTRAN(transition, (double *dgdxglob, ITG *nobject, ITG *nk, ITG *nodedesi,
+                          ITG *ndesi, char *objectset, double *xo, double *yo,
+                          double *zo, double *x, double *y, double *z, ITG *nx,
+                          ITG *ny, ITG *nz, double *co, ITG *ifree, ITG *ndesia,
+                          ITG *ndesib, ITG *nobjectstart));
+
+void transitionmain(double *co, double *dgdxglob, ITG *nobject, ITG *nk,
+                    ITG *nodedesi, ITG *ndesi, char *objectset, ITG *ipkon,
+                    ITG *kon, char *lakon, ITG *ipoface, ITG *nodface,
+                    ITG *nodedesiinv, ITG *nobjectstart);
 
 void *transitionmt(ITG *i);
 
-void FORTRAN(trianeighbor,(ITG *ipe,ITG *ime,ITG *imastop,ITG *ncont,
-               ITG *koncont,ITG *ifreeme));
+void FORTRAN(trianeighbor, (ITG * ipe, ITG *ime, ITG *imastop, ITG *ncont,
+                            ITG *koncont, ITG *ifreeme));
 
-void FORTRAN(triangucont,(ITG *ncont,ITG *ntie,char *tieset,ITG *nset,
-			  char *set,ITG *istartset,ITG *iendset,ITG *ialset,
-			  ITG *itietri,char *lakon,ITG *ipkon,ITG *kon,
-			  ITG *koncont,char *kind1,char *kind2,double *co,
-			  ITG *nk,ITG *mortar));
+void FORTRAN(triangucont, (ITG * ncont, ITG *ntie, char *tieset, ITG *nset,
+                           char *set, ITG *istartset, ITG *iendset, ITG *ialset,
+                           ITG *itietri, char *lakon, ITG *ipkon, ITG *kon,
+                           ITG *koncont, char *kind1, char *kind2, double *co,
+                           ITG *nk, ITG *mortar));
 
-void FORTRAN(tridiagonal_nrhs,(double *a,double *b,ITG *n,ITG *m,
-             ITG *nrhs));
+void FORTRAN(tridiagonal_nrhs, (double *a, double *b, ITG *n, ITG *m,
+                                ITG *nrhs));
 
-void FORTRAN(turningdirection,(double *v,double *e1,double *e2,double *xn,
-                               ITG *mi,
-                               ITG *nk,char *turdir,char *lakon,ITG *ipkon,
-                               ITG *kon,ITG *ne,double *co));
+void FORTRAN(turningdirection, (double *v, double *e1, double *e2, double *xn,
+                                ITG *mi,
+                                ITG *nk, char *turdir, char *lakon, ITG *ipkon,
+                                ITG *kon, ITG *ne, double *co));
 
 #ifdef BAM
-void FORTRAN(uexternaldb,(ITG *lop,ITG *lrestart,double *time,double *dtime,
-                          ITG *kstep,ITG *kinc));
+void FORTRAN(uexternaldb, (ITG * lop, ITG *lrestart, double *time, double *dtime,
+                           ITG *kstep, ITG *kinc));
 #endif
 
-void FORTRAN(ufaceload,(double *co,ITG *ipkon,ITG *kon,char *lakon,
-                        ITG *nboun,ITG *nodeboun,
-                        ITG *nelemload,char *sideload,ITG *nload,
-                        ITG *ne,ITG *nk));
+void FORTRAN(ufaceload, (double *co, ITG *ipkon, ITG *kon, char *lakon,
+                         ITG *nboun, ITG *nodeboun,
+                         ITG *nelemload, char *sideload, ITG *nload,
+                         ITG *ne, ITG *nk));
 
-void FORTRAN(uinit,());
+void FORTRAN(uinit, ());
 
-void FORTRAN(uiter,(ITG *iit));
+void FORTRAN(uiter, (ITG * iit));
 
-void FORTRAN(uout,(double *v,ITG *mi,ITG *ithermal,char *filab,
-		   ITG *kode,char *output,char *jobnamec));
+void FORTRAN(uout, (double *v, ITG *mi, ITG *ithermal, char *filab,
+                    ITG *kode, char *output, char *jobnamec));
 
-void FORTRAN(updatecon,(double *vold,double *vcon,double *v,ITG *nk,
-			ITG *ithermal,ITG *turbulent,ITG *mi,
-			ITG *compressible));
+void FORTRAN(updatecon, (double *vold, double *vcon, double *v, ITG *nk,
+                         ITG *ithermal, ITG *turbulent, ITG *mi,
+                         ITG *compressible));
 
-void FORTRAN(updatecont,(ITG *koncont,ITG *ncont,double *co,double *vold,
-                         double *cg,double *straight,ITG *mi));
+void FORTRAN(updatecont, (ITG * koncont, ITG *ncont, double *co, double *vold,
+                          double *cg, double *straight, ITG *mi));
 
-void FORTRAN(updatecontpen,(ITG *koncont,ITG *ncont,double *co,double *vold,
-                         double *cg,double *straight,ITG *mi,ITG *imastnode,
-                         ITG *nmastnode,double *xmastnor,ITG *ntie,
-                         char *tieset,ITG *nset,char *set,ITG *istartset,
-                         ITG *iendset,ITG *ialset,ITG *ipkon,char *lakon,
-                         ITG *kon,double *cs,ITG *mcs,ITG *ics));
+void FORTRAN(updatecontpen, (ITG * koncont, ITG *ncont, double *co, double *vold,
+                             double *cg, double *straight, ITG *mi, ITG *imastnode,
+                             ITG *nmastnode, double *xmastnor, ITG *ntie,
+                             char *tieset, ITG *nset, char *set, ITG *istartset,
+                             ITG *iendset, ITG *ialset, ITG *ipkon, char *lakon,
+                             ITG *kon, double *cs, ITG *mcs, ITG *ics));
 
-void FORTRAN(updategeodata,(ITG *nktet,ITG *netet_,double *h,double *d,
-			    double *dmin,ITG *ipoed,ITG *iedg,double *cotet,
-			    double *planfa,double *bc,double *cg,ITG *kontet,
-			    ITG *ifac,ITG *ipofa,double *doubleglob,
-			    ITG *integerglob,ITG *ipoeln));
+void FORTRAN(updategeodata, (ITG * nktet, ITG *netet_, double *h, double *d,
+                             double *dmin, ITG *ipoed, ITG *iedg, double *cotet,
+                             double *planfa, double *bc, double *cg, ITG *kontet,
+                             ITG *ifac, ITG *ipofa, double *doubleglob,
+                             ITG *integerglob, ITG *ipoeln));
 
-void *u_calloc(size_t num,size_t size,const char *file,const int line,const char *ptr_name);
+void *u_calloc(size_t num, size_t size, const char *file, const int line, const char *ptr_name);
 
-void *u_free(void* num,const char *file,const int line,const char *ptr_name);
+void *u_free(void *num, const char *file, const int line, const char *ptr_name);
 
-void *u_malloc(size_t size,const char *file,const int line,const char *ptr_name);
+void *u_malloc(size_t size, const char *file, const int line, const char *ptr_name);
 
-void *u_realloc(void* num,size_t size,const char *file,const int line,const char *ptr_name);
+void *u_realloc(void *num, size_t size, const char *file, const int line, const char *ptr_name);
 
-void utempread(double *t1,ITG *istep,char *jobnamec);
+void utempread(double *t1, ITG *istep, char *jobnamec);
 
-void FORTRAN(varsmooth,(double *aub,double *adl,
-			     double *sol,double *aux,ITG *irow,
-			     ITG *jq,ITG *neqa,ITG *neqb,double *alpha));
+void FORTRAN(varsmooth, (double *aub, double *adl,
+                         double *sol, double *aux, ITG *irow,
+                         ITG *jq, ITG *neqa, ITG *neqb, double *alpha));
 
 void *varsmoothmt(ITG *i);
 
-void vecnodal2dof(ITG *nk,ITG *mt,ITG *nactdof,double *vecnode,double *vecdof);
+void vecnodal2dof(ITG *nk, ITG *mt, ITG *nactdof, double *vecnode, double *vecdof);
 
-void FORTRAN(velinireltoabs,(ITG *ibody,double *xbody,char *cbody,ITG *nbody,
-                             char *set,ITG *istartset,
-                             ITG *iendset,ITG *ialset,ITG *nset,
-                             double *veold,ITG *mi,ITG *ipkon,ITG *kon,
-                             char *lakon,double *co,ITG *itreated));
+void FORTRAN(velinireltoabs, (ITG * ibody, double *xbody, char *cbody, ITG *nbody,
+                              char *set, ITG *istartset,
+                              ITG *iendset, ITG *ialset, ITG *nset,
+                              double *veold, ITG *mi, ITG *ipkon, ITG *kon,
+                              char *lakon, double *co, ITG *itreated));
 
-void FORTRAN(velsolve,(ITG *nef,ITG *ipnei,double *bv,double *auv,double *adv,
-                       double *vel,double *temp,ITG *neiel));
+void FORTRAN(velsolve, (ITG * nef, ITG *ipnei, double *bv, double *auv, double *adv,
+                        double *vel, double *temp, ITG *neiel));
 
-void worparll(double *allwk,double *fnext,ITG *mt,double *fnextini,
-                   double *v,double *vini,ITG *nk,ITG *num_cpus);
+void worparll(double *allwk, double *fnext, ITG *mt, double *fnextini,
+              double *v, double *vini, ITG *nk, ITG *num_cpus);
 
 void *worparllmt(ITG *i);
 
-void writeBasisParameter(FILE *f,ITG *istep,ITG *iinc);
+void writeBasisParameter(FILE *f, ITG *istep, ITG *iinc);
 
-void FORTRAN(writeboun,(ITG *nodeboun,ITG *ndirboun,double *xboun,
-      char *typeboun,ITG *nboun));
+void FORTRAN(writeboun, (ITG * nodeboun, ITG *ndirboun, double *xboun,
+                         char *typeboun, ITG *nboun));
 
-void FORTRAN(writebv,(double *,ITG *));
+void FORTRAN(writebv, (double *, ITG *) );
 
-void FORTRAN(writecvg,(ITG *itep,ITG *iinc,ITG *icutb,ITG *iit,ITG *ne,ITG *ne0,
-                       double *ram,double *qam,double *cam,double *uam,
-                       ITG *ithermal));
+void FORTRAN(writecvg, (ITG * itep, ITG *iinc, ITG *icutb, ITG *iit, ITG *ne, ITG *ne0,
+                        double *ram, double *qam, double *cam, double *uam,
+                        ITG *ithermal));
 
-void FORTRAN(writedeigdx,(ITG *iev,double *d,ITG *ndesi,char*orname,
-                          double *dgdx));
+void FORTRAN(writedeigdx, (ITG * iev, double *d, ITG *ndesi, char *orname,
+                           double *dgdx));
 
-void FORTRAN(writedesi,(ITG *norien,char *orname));
+void FORTRAN(writedesi, (ITG * norien, char *orname));
 
-void FORTRAN(writeelem,(ITG *i,char *lakon));
+void FORTRAN(writeelem, (ITG * i, char *lakon));
 
-void FORTRAN(writeev,(double *,ITG *,double *,double *));
+void FORTRAN(writeev, (double *, ITG *, double *, double *) );
 
-void FORTRAN(writeevcomplex,(double *eigxx,ITG *nev,double *fmin,double *fmax));
+void FORTRAN(writeevcomplex, (double *eigxx, ITG *nev, double *fmin, double *fmax));
 
-void FORTRAN(writeevcs,(double *,ITG *,ITG *,double *,double *));
+void FORTRAN(writeevcs, (double *, ITG *, ITG *, double *, double *) );
 
-void FORTRAN(writeevcscomplex,(double *eigxx,ITG *nev,ITG *nm,double *fmin,
-            double *fmax));
+void FORTRAN(writeevcscomplex, (double *eigxx, ITG *nev, ITG *nm, double *fmin,
+                                double *fmax));
 
-void FORTRAN(writehe,(ITG *));
+void FORTRAN(writehe, (ITG *) );
 
-void writeheading(char *jobnamec,char *heading,ITG *nheading);
+void writeheading(char *jobnamec, char *heading, ITG *nheading);
 
-void FORTRAN(writeim,());
+void FORTRAN(writeim, ());
 
-void FORTRAN(writeinput,(char *inpc,ITG *ipoinp,ITG *inp,ITG *nline,ITG *ninp,
-                         ITG *ipoinpc));
+void FORTRAN(writeinput, (char *inpc, ITG *ipoinp, ITG *inp, ITG *nline, ITG *ninp,
+                          ITG *ipoinpc));
 
-void FORTRAN(writelm,(ITG *iter,double *lambda,ITG *nactive,ITG *nnlconst,
-                      char *objectset,ITG *nobject,ITG *ipacti,
-                      ITG *iconstacti,ITG *inameacti,ITG *nodedesi,
-		      double *dgdxglob,ITG *nk));
+void FORTRAN(writelm, (ITG * iter, double *lambda, ITG *nactive, ITG *nnlconst,
+                       char *objectset, ITG *nobject, ITG *ipacti,
+                       ITG *iconstacti, ITG *inameacti, ITG *nodedesi,
+                       double *dgdxglob, ITG *nk));
 
-void FORTRAN(writemac,(double *mac,ITG *nev,ITG *nevcomplex));
+void FORTRAN(writemac, (double *mac, ITG *nev, ITG *nevcomplex));
 
-void FORTRAN(writemaccs,(double *mac,ITG *nev,ITG* nm));
+void FORTRAN(writemaccs, (double *mac, ITG *nev, ITG *nm));
 
-void FORTRAN(writemeshinp,(ITG *kontet,ITG *netet_,double *cotet,ITG *nktet,
-                           ITG *ij,ITG *ipoed,ITG *iedg,ITG *iexternedg,
-			   double *quality));
+void FORTRAN(writemeshinp, (ITG * kontet, ITG *netet_, double *cotet, ITG *nktet,
+                            ITG *ij, ITG *ipoed, ITG *iedg, ITG *iexternedg,
+                            double *quality));
 
-void FORTRAN(writemeshinp_mesh,(ITG *kontet,ITG *netet_,double *cotet,
-				ITG *nktet,ITG *ij,ITG *ipofa,ITG *ifac,
-				ITG *iexternfa));
+void FORTRAN(writemeshinp_mesh, (ITG * kontet, ITG *netet_, double *cotet,
+                                 ITG *nktet, ITG *ij, ITG *ipofa, ITG *ifac,
+                                 ITG *iexternfa));
 
-void FORTRAN(writempc,(ITG *,ITG *,double *,char *,ITG *));
+void FORTRAN(writempc, (ITG *, ITG *, double *, char *, ITG *) );
 
-void writenewmesh(ITG *nktet,ITG *netet_,double *cotet,ITG *iquad,
-		  ITG *kontet,ITG *iedgmid,ITG *iedtet,ITG *mi,
-		  char *matname,ITG *ithermal,char *jobnamec,
-		  char *output,ITG *nmat);
+void writenewmesh(ITG *nktet, ITG *netet_, double *cotet, ITG *iquad,
+                  ITG *kontet, ITG *iedgmid, ITG *iedtet, ITG *mi,
+                  char *matname, ITG *ithermal, char *jobnamec,
+                  char *output, ITG *nmat);
 
-void FORTRAN(writeobj,(char *objectset,ITG *iobject,double *g0));
+void FORTRAN(writeobj, (char *objectset, ITG *iobject, double *g0));
 
-void writeoldmesh(ITG *nk,ITG *ne,double *co,ITG *ipkon,
-		  ITG *kon,char *lakon,ITG *mi,
-		  char *matname,ITG *ithermal,char *jobnamec,
-		  char *output,ITG *nmat);
+void writeoldmesh(ITG *nk, ITG *ne, double *co, ITG *ipkon,
+                  ITG *kon, char *lakon, ITG *mi,
+                  char *matname, ITG *ithermal, char *jobnamec,
+                  char *output, ITG *nmat);
 
-void FORTRAN(writepf,(double *d,double *bjr,double *bji,double *freq ,
-                      ITG *nev,ITG *mode,ITG *nherm));
+void FORTRAN(writepf, (double *d, double *bjr, double *bji, double *freq,
+                       ITG *nev, ITG *mode, ITG *nherm));
 
-void FORTRAN(writerandomfield,(double *d,double *relerr,ITG *imodes));
+void FORTRAN(writerandomfield, (double *d, double *relerr, ITG *imodes));
 
-void FORTRAN(writere,());
+void FORTRAN(writere, ());
 
-void FORTRAN(writerefinemesh,(ITG *kontet,ITG *netet_,double *cotet,ITG *nktet,
-                              char *jobnamec,
-                              ITG *iquad,ITG *iedtet,ITG *iedgmid,
-                              ITG *number,ITG *jfix,ITG *iparentel,
-			      ITG *nk,ITG *iwrite));
+void FORTRAN(writerefinemesh, (ITG * kontet, ITG *netet_, double *cotet, ITG *nktet,
+                               char *jobnamec,
+                               ITG *iquad, ITG *iedtet, ITG *iedgmid,
+                               ITG *number, ITG *jfix, ITG *iparentel,
+                               ITG *nk, ITG *iwrite));
 
-void FORTRAN(writesen,(double *g0,double *dgdx,ITG *ndesi,ITG *nobject,
-                       ITG *nodedesi,char *jobnamef));
+void FORTRAN(writesen, (double *g0, double *dgdx, ITG *ndesi, ITG *nobject,
+                        ITG *nodedesi, char *jobnamef));
 
-void FORTRAN(writesta,(ITG *istep,ITG *j,ITG *icutb,ITG *l,double *ttime,
-                       double *time,double *dtime));
+void FORTRAN(writesta, (ITG * istep, ITG *j, ITG *icutb, ITG *l, double *ttime,
+                        double *time, double *dtime));
 
-void FORTRAN(writestadiv,(ITG *istep,ITG *j,ITG *icutb,ITG *l,double *ttime,
-                       double *time,double *dtime));
+void FORTRAN(writestadiv, (ITG * istep, ITG *j, ITG *icutb, ITG *l, double *ttime,
+                           double *time, double *dtime));
 
-void FORTRAN(writesubmatrix,(double *submatrix,ITG *noderetain,
-             ITG *ndirretain,ITG *nretain,char *jobnamec));
+void FORTRAN(writesubmatrix, (double *submatrix, ITG *noderetain,
+                              ITG *ndirretain, ITG *nretain, char *jobnamec));
 
-void FORTRAN(writesummary,(ITG *istep,ITG *j,ITG *icutb,ITG *l,double *ttime,
-                   double *time,double *dtime));
+void FORTRAN(writesummary, (ITG * istep, ITG *j, ITG *icutb, ITG *l, double *ttime,
+                            double *time, double *dtime));
 
-void FORTRAN(writesummarydiv,(ITG *istep,ITG *j,ITG *icutb,ITG *l,double *ttime,
-                   double *time,double *dtime));
+void FORTRAN(writesummarydiv, (ITG * istep, ITG *j, ITG *icutb, ITG *l, double *ttime,
+                               double *time, double *dtime));
 
-void FORTRAN(writetetmesh,(ITG *kontet,ITG *netet_,double *cotet,
-     ITG *nktet,double *field,ITG *nfield));
-                        
-void FORTRAN(writeturdir,(double *xn,char *turdir,ITG *nev));
-                        
-void FORTRAN(writeturdircs,(double *xn,char *turdir,ITG *nev,ITG *nm));
-                        
-void FORTRAN(writeview,(ITG *ntr,double *adview,double *auview,double *fenv,
-            ITG *nzsrad,char *jobnamef));
+void FORTRAN(writetetmesh, (ITG * kontet, ITG *netet_, double *cotet,
+                            ITG *nktet, double *field, ITG *nfield));
 
-void FORTRAN(zienzhu,(double *co,ITG *nk,ITG *kon,ITG *ipkon,char *lakon,
-                      ITG *ne,double *stn,ITG *ipneigh,ITG *neigh,
-                      double *sti,ITG *mi));
+void FORTRAN(writeturdir, (double *xn, char *turdir, ITG *nev));
 
-void FORTRAN(znaupd,(ITG *ido,char *bmat,ITG *n,char *which,ITG *nev,
-             double *tol,double *resid,ITG *ncv,double *z,ITG *ldz,
-             ITG *iparam,ITG *ipntr,double *workd,double *workl,
-             ITG *lworkl,double *rwork,ITG *info));
+void FORTRAN(writeturdircs, (double *xn, char *turdir, ITG *nev, ITG *nm));
 
-void FORTRAN(zneupd,(ITG *rvec,char *howmny,ITG *select,double *d,
-             double *z,ITG *ldz,double *sigma,
-             double *workev,char *bmat,ITG *neq,char *which,
-             ITG *nev,double *tol,double *resid,ITG *ncv,double *v,
-             ITG *ldv,ITG *iparam,ITG *ipntr,double *workd,
-             double *workl,ITG *lworkl,double *rwork,ITG *info));
+void FORTRAN(writeview, (ITG * ntr, double *adview, double *auview, double *fenv,
+                         ITG *nzsrad, char *jobnamef));
+
+void FORTRAN(zienzhu, (double *co, ITG *nk, ITG *kon, ITG *ipkon, char *lakon,
+                       ITG *ne, double *stn, ITG *ipneigh, ITG *neigh,
+                       double *sti, ITG *mi));
+
+void FORTRAN(znaupd, (ITG * ido, char *bmat, ITG *n, char *which, ITG *nev,
+                      double *tol, double *resid, ITG *ncv, double *z, ITG *ldz,
+                      ITG *iparam, ITG *ipntr, double *workd, double *workl,
+                      ITG *lworkl, double *rwork, ITG *info));
+
+void FORTRAN(zneupd, (ITG * rvec, char *howmny, ITG *select, double *d,
+                      double *z, ITG *ldz, double *sigma,
+                      double *workev, char *bmat, ITG *neq, char *which,
+                      ITG *nev, double *tol, double *resid, ITG *ncv, double *v,
+                      ITG *ldv, ITG *iparam, ITG *ipntr, double *workd,
+                      double *workl, ITG *lworkl, double *rwork, ITG *info));
 
 #ifdef CALCULIX_EXTERNAL_BEHAVIOURS_SUPPORT
 
@@ -5111,14 +5120,14 @@ typedef struct
   // interface
   CalculixInterface i;
   // function pointer
-  const void* ptr;
-}  CalculixExternalBehaviour;
+  const void *ptr;
+} CalculixExternalBehaviour;
 /*!
  * \return the description of an external beahviour
  * \param[in] n : external behaviour name
  */
-const CalculixExternalBehaviour*
-calculix_searchExternalBehaviour(const char*);
+const CalculixExternalBehaviour *
+calculix_searchExternalBehaviour(const char *);
 /*!
  * \param[in] n: material name
  */

--- a/adapter/CCXHelpers.c
+++ b/adapter/CCXHelpers.c
@@ -8,164 +8,147 @@
  *********************************************************************************************/
 
 #include "CCXHelpers.h"
+#include <assert.h>
 #include <stdlib.h>
 #include <string.h>
-#include <assert.h>
 
-char* toNodeSetName( char const * name )
+char *toNodeSetName(char const *name)
 {
-	char * prefix = "N";
-	char * suffix = "N";
-	return concat( prefix, name, suffix );
+  char *prefix = "N";
+  char *suffix = "N";
+  return concat(prefix, name, suffix);
 }
 
-char* toFaceSetName( char const * name )
+char *toFaceSetName(char const *name)
 {
-	char * prefix = "S";
-	char * suffix = "T";
-	return concat( prefix, name, suffix );
+  char *prefix = "S";
+  char *suffix = "T";
+  return concat(prefix, name, suffix);
 }
 
-ITG getSetID( char const * setName, char const * set, ITG nset )
+ITG getSetID(char const *setName, char const *set, ITG nset)
 {
 
-	ITG i;
-	ITG nameLength = 81;
+  ITG i;
+  ITG nameLength = 81;
 
-	for( i = 0 ; i < nset ; i++ )
-	{
-		if( strcmp1( &set[i * nameLength], setName ) == 0 )
-		{
-			printf("Set ID Found \n");
-			return i;
-		}
-	}
-	// Set not found:
+  for (i = 0; i < nset; i++) {
+    if (strcmp1(&set[i * nameLength], setName) == 0) {
+      printf("Set ID Found \n");
+      return i;
+    }
+  }
+  // Set not found:
 
-	if( setName[0] == (char) 'N' )
-	{
-		printf("Set ID NOT Found \n");
-		nodeSetNotFoundError( setName );
-	}
-	else if ( setName[0] == (char) 'S' )
-	{
-		printf("Set ID NOT Found \n");
-		faceSetNotFoundError( setName );
-	}
+  if (setName[0] == (char) 'N') {
+    printf("Set ID NOT Found \n");
+    nodeSetNotFoundError(setName);
+  } else if (setName[0] == (char) 'S') {
+    printf("Set ID NOT Found \n");
+    faceSetNotFoundError(setName);
+  }
   unreachableError();
   return -1;
 }
 
-ITG getNumSetElements( ITG setID, ITG * istartset, ITG * iendset )
+ITG getNumSetElements(ITG setID, ITG *istartset, ITG *iendset)
 {
-	return iendset[setID] - istartset[setID] + 1;
+  return iendset[setID] - istartset[setID] + 1;
 }
 
-void getSurfaceElementsAndFaces( ITG setID, ITG * ialset, ITG * istartset, ITG * iendset, ITG * elements, ITG * faces )
+void getSurfaceElementsAndFaces(ITG setID, ITG *ialset, ITG *istartset, ITG *iendset, ITG *elements, ITG *faces)
 {
 
-	ITG i, k = 0;
+  ITG i, k = 0;
 
-	for( i = istartset[setID]-1 ; i < iendset[setID] ; i++ )
-	{
-		elements[k] = ialset[i] / 10;
-		faces[k] = ialset[i] % 10;
-		k++;
-	}
+  for (i = istartset[setID] - 1; i < iendset[setID]; i++) {
+    elements[k] = ialset[i] / 10;
+    faces[k]    = ialset[i] % 10;
+    k++;
+  }
 }
 
-void getNodeCoordinates( ITG * nodes, ITG numNodes, int dim, double * co, double * v, int mt, double * coordinates )
+void getNodeCoordinates(ITG *nodes, ITG numNodes, int dim, double *co, double *v, int mt, double *coordinates)
 {
 
-	ITG i, j;
+  ITG i, j;
 
-	for( i = 0 ; i < numNodes ; i++ )
-	{
-		int nodeIdx = nodes[i] - 1;
-		//The displacements are added to the coordinates such that in case of a simulation restart the displaced coordinates are used for initializing the coupling interface instead of the initial coordinates
-		for( j = 0 ; j < dim ; j++ )
-    {
+  for (i = 0; i < numNodes; i++) {
+    int nodeIdx = nodes[i] - 1;
+    //The displacements are added to the coordinates such that in case of a simulation restart the displaced coordinates are used for initializing the coupling interface instead of the initial coordinates
+    for (j = 0; j < dim; j++) {
       coordinates[i * dim + j] = co[nodeIdx * 3 + j] + v[nodeIdx * mt + j + 1];
     }
-	}
+  }
 }
 
-void getNodeTemperatures( ITG * nodes, ITG numNodes, double * v, int mt, double * temperatures )
+void getNodeTemperatures(ITG *nodes, ITG numNodes, double *v, int mt, double *temperatures)
 {
 
-	// CalculiX variable mt = 4 : temperature + 3 displacements (depends on the type of analysis)
-	ITG i;
+  // CalculiX variable mt = 4 : temperature + 3 displacements (depends on the type of analysis)
+  ITG i;
 
-	for( i = 0 ; i < numNodes ; i++ )
-	{
-		int nodeIdx = nodes[i] - 1;
-		temperatures[i] = v[nodeIdx * mt];
-	}
+  for (i = 0; i < numNodes; i++) {
+    int nodeIdx     = nodes[i] - 1;
+    temperatures[i] = v[nodeIdx * mt];
+  }
 }
 
-void getNodeForces( ITG * nodes, ITG numNodes, int dim, double * fn, ITG mt, double * forces )
+void getNodeForces(ITG *nodes, ITG numNodes, int dim, double *fn, ITG mt, double *forces)
 {
-	ITG i, j;
+  ITG i, j;
 
-	for ( i = 0 ; i < numNodes ; i++ )
-	{
-		int nodeIdx = nodes[i] - 1;
-		for( j = 0 ; j < dim ; j++ )
-    {
+  for (i = 0; i < numNodes; i++) {
+    int nodeIdx = nodes[i] - 1;
+    for (j = 0; j < dim; j++) {
       forces[dim * i + j] = fn[nodeIdx * mt + j + 1];
     }
-	}
+  }
 }
 
-void getNodeDisplacements( ITG * nodes, ITG numNodes, int dim, double * v, ITG mt, double * displacements )
+void getNodeDisplacements(ITG *nodes, ITG numNodes, int dim, double *v, ITG mt, double *displacements)
 {
 
-	// CalculiX variable mt = 4 : temperature + 3 displacements (depends on the type of analysis)
-	// where 0 index corresponds to temp; 1, 2, 3 indices correspond to the displacements, respectively
-	ITG i, j;
+  // CalculiX variable mt = 4 : temperature + 3 displacements (depends on the type of analysis)
+  // where 0 index corresponds to temp; 1, 2, 3 indices correspond to the displacements, respectively
+  ITG i, j;
 
-	for( i = 0 ; i < numNodes ; i++ )
-	{
-		int nodeIdx = nodes[i] - 1; //The node Id starts with 1, not with 0, therefore, decrement is necessary
-		for( j = 0 ; j < dim ; j++ )
-  	{
+  for (i = 0; i < numNodes; i++) {
+    int nodeIdx = nodes[i] - 1; //The node Id starts with 1, not with 0, therefore, decrement is necessary
+    for (j = 0; j < dim; j++) {
       displacements[dim * i + j] = v[nodeIdx * mt + j + 1];
     }
-	}
+  }
 }
 
-void getNodeDisplacementDeltas( ITG * nodes, ITG numNodes, int dim, double * v, double * v_init, ITG mt, double * displacementDeltas )
+void getNodeDisplacementDeltas(ITG *nodes, ITG numNodes, int dim, double *v, double *v_init, ITG mt, double *displacementDeltas)
 {
 
-	// CalculiX variable mt = 4 : temperature + 3 displacements (depends on the type of analysis)
-	// where 0 index corresponds to temp; 1, 2, 3 indices correspond to the displacements, respectively
-	ITG i, j;
+  // CalculiX variable mt = 4 : temperature + 3 displacements (depends on the type of analysis)
+  // where 0 index corresponds to temp; 1, 2, 3 indices correspond to the displacements, respectively
+  ITG i, j;
 
-	for( i = 0 ; i < numNodes ; i++ )
-	{
-		int nodeIdx = nodes[i] - 1; //The node Id starts with 1, not with 0, therefore, decrement is necessary
-		for( j = 0 ; j < dim ; j++ )
-    {
+  for (i = 0; i < numNodes; i++) {
+    int nodeIdx = nodes[i] - 1; //The node Id starts with 1, not with 0, therefore, decrement is necessary
+    for (j = 0; j < dim; j++) {
       displacementDeltas[dim * i + j] = v[nodeIdx * mt + j + 1] - v_init[nodeIdx * mt + j + 1];
     }
-	}
+  }
 }
 
-void getNodeVelocities( ITG * nodes, ITG numNodes, int dim, double * ve, ITG mt, double * velocities )
+void getNodeVelocities(ITG *nodes, ITG numNodes, int dim, double *ve, ITG mt, double *velocities)
 {
 
-	// CalculiX variable mt = 4 : temperature rate + 3 velocities (depends on the type of analysis)
-	// where 0 index corresponds to temp rate; 1, 2, 3 indices correspond to the velocities, respectively
-	ITG i, j;
+  // CalculiX variable mt = 4 : temperature rate + 3 velocities (depends on the type of analysis)
+  // where 0 index corresponds to temp rate; 1, 2, 3 indices correspond to the velocities, respectively
+  ITG i, j;
 
-	for( i = 0 ; i < numNodes ; i++ )
-	{
-		int nodeIdx = nodes[i] - 1; //The node Id starts with 1, not with 0, therefore, decrement is necessary
-		for( j = 0 ; j < dim ; j++ )
-    {
+  for (i = 0; i < numNodes; i++) {
+    int nodeIdx = nodes[i] - 1; //The node Id starts with 1, not with 0, therefore, decrement is necessary
+    for (j = 0; j < dim; j++) {
       velocities[dim * i + j] = ve[nodeIdx * mt + j + 1];
     }
-	}
+  }
 }
 
 /*
@@ -182,44 +165,38 @@ void getNodeVelocities( ITG * nodes, ITG numNodes, int dim, double * ve, ITG mt,
    }
  */
 
-void getTetraFaceCenters( ITG * elements, ITG * faces, ITG numElements, ITG * kon, ITG * ipkon, double * co, double * faceCenters )
+void getTetraFaceCenters(ITG *elements, ITG *faces, ITG numElements, ITG *kon, ITG *ipkon, double *co, double *faceCenters)
 {
 
-	// Assume all tetra elements -- maybe implement checking later...
+  // Assume all tetra elements -- maybe implement checking later...
 
-	// Node numbering for faces of tetrahedral elements (in the documentation the number is + 1)
-	// Numbering is the same for first and second order elements
-	int faceNodes[4][3] = { { 0,1,2 }, { 0,3,1 }, { 1,3,2 }, { 2,3,0 } };
+  // Node numbering for faces of tetrahedral elements (in the documentation the number is + 1)
+  // Numbering is the same for first and second order elements
+  int faceNodes[4][3] = {{0, 1, 2}, {0, 3, 1}, {1, 3, 2}, {2, 3, 0}};
 
-	ITG i, j;
+  ITG i, j;
 
-	for( i = 0 ; i < numElements ; i++ )
-	{
+  for (i = 0; i < numElements; i++) {
 
-		ITG faceIdx = faces[i] - 1;
-		ITG elementIdx = elements[i] - 1;
-		double x = 0, y = 0, z = 0;
+    ITG    faceIdx    = faces[i] - 1;
+    ITG    elementIdx = elements[i] - 1;
+    double x = 0, y = 0, z = 0;
 
-		for( j = 0 ; j < 3 ; j++ )
-		{
+    for (j = 0; j < 3; j++) {
 
-			ITG nodeNum = faceNodes[faceIdx][j];
-			ITG nodeID = kon[ipkon[elementIdx] + nodeNum];
-			ITG nodeIdx = ( nodeID - 1 ) * 3;
-			// The nodeIdx is already multiplied by 3, therefore it must be divided by 3 ONLY when checking if coordinates match getNodeCoordinates
+      ITG nodeNum = faceNodes[faceIdx][j];
+      ITG nodeID  = kon[ipkon[elementIdx] + nodeNum];
+      ITG nodeIdx = (nodeID - 1) * 3;
+      // The nodeIdx is already multiplied by 3, therefore it must be divided by 3 ONLY when checking if coordinates match getNodeCoordinates
 
-			x += co[nodeIdx + 0];
-			y += co[nodeIdx + 1];
-			z += co[nodeIdx + 2];
-
-		}
-		faceCenters[i * 3 + 0] = x / 3;
-		faceCenters[i * 3 + 1] = y / 3;
-		faceCenters[i * 3 + 2] = z / 3;
-
-	}
-
-
+      x += co[nodeIdx + 0];
+      y += co[nodeIdx + 1];
+      z += co[nodeIdx + 2];
+    }
+    faceCenters[i * 3 + 0] = x / 3;
+    faceCenters[i * 3 + 1] = y / 3;
+    faceCenters[i * 3 + 2] = z / 3;
+  }
 }
 
 /*
@@ -231,439 +208,394 @@ void getTetraFaceCenters( ITG * elements, ITG * faces, ITG numElements, ITG * ko
    }
  */
 
-
-void getTetraFaceNodes( ITG * elements, ITG * faces, ITG * nodes, ITG numElements, ITG numNodes, ITG * kon, ITG * ipkon, int * tetraFaceNodes )
+void getTetraFaceNodes(ITG *elements, ITG *faces, ITG *nodes, ITG numElements, ITG numNodes, ITG *kon, ITG *ipkon, int *tetraFaceNodes)
 {
-	// Assume all tetra elements -- maybe implement checking later...
+  // Assume all tetra elements -- maybe implement checking later...
 
-	// Node numbering for faces of tetrahedral elements (in the documentation the number is + 1)
-	int faceNodes[4][3] = { { 0,1,2 }, { 0,3,1 }, { 1,3,2 }, { 2,3,0 } };
+  // Node numbering for faces of tetrahedral elements (in the documentation the number is + 1)
+  int faceNodes[4][3] = {{0, 1, 2}, {0, 3, 1}, {1, 3, 2}, {2, 3, 0}};
 
-	ITG i, j, k;
+  ITG i, j, k;
 
+  for (i = 0; i < numElements; i++) {
 
+    ITG faceIdx    = faces[i] - 1;
+    ITG elementIdx = elements[i] - 1;
 
-	for( i = 0 ; i < numElements ; i++ )
-	{
+    for (j = 0; j < 3; j++) {
 
-		ITG faceIdx = faces[i] - 1;
-		ITG elementIdx = elements[i] - 1;
+      ITG nodeNum = faceNodes[faceIdx][j];
+      ITG nodeID  = kon[ipkon[elementIdx] + nodeNum];
 
-		for( j = 0 ; j < 3 ; j++ )
-		{
+      for (k = 0; k < numNodes; k++) {
 
-			ITG nodeNum = faceNodes[faceIdx][j];
-			ITG nodeID = kon[ipkon[elementIdx] + nodeNum];
-
-			for( k = 0 ; k < numNodes ; k++ )
-			{
-
-				if( nodes[k] == nodeID )
-				{
-					tetraFaceNodes[i*3 + j] = k;
-				}
-			}
-
-		}
-	}
+        if (nodes[k] == nodeID) {
+          tetraFaceNodes[i * 3 + j] = k;
+        }
+      }
+    }
+  }
 }
 
-void getXloadIndices( char const * loadType, ITG * elementIDs, ITG * faceIDs, ITG numElements, ITG nload, ITG * nelemload, char const * sideload, ITG * xloadIndices )
+void getXloadIndices(char const *loadType, ITG *elementIDs, ITG *faceIDs, ITG numElements, ITG nload, ITG *nelemload, char const *sideload, ITG *xloadIndices)
 {
 
-	ITG i, k;
-	int nameLength = 20;
-	char faceLabel[] = { 'x', 'x', '\0' };
+  ITG  i, k;
+  int  nameLength  = 20;
+  char faceLabel[] = {'x', 'x', '\0'};
 
-	/* Face number is prefixed with 'S' if it is DFLUX boundary condition
+  /* Face number is prefixed with 'S' if it is DFLUX boundary condition
 	 * and with 'F' if it is a FILM boundary condition */
-	if( strcmp( loadType, "DFLUX" ) == 0 )
-	{
-		faceLabel[0] = (char) 'S';
-	}
-	else if( strcmp( loadType, "FILM" ) == 0 )
-	{
-		faceLabel[0] = (char) 'F';
-	}
+  if (strcmp(loadType, "DFLUX") == 0) {
+    faceLabel[0] = (char) 'S';
+  } else if (strcmp(loadType, "FILM") == 0) {
+    faceLabel[0] = (char) 'F';
+  }
 
-	for( k = 0 ; k < numElements ; k++ )
-	{
+  for (k = 0; k < numElements; k++) {
 
-		ITG faceID = faceIDs[k];
-		ITG elementID = elementIDs[k];
-		faceLabel[1] = faceID + '0';
-		int found = 0;
+    ITG faceID    = faceIDs[k];
+    ITG elementID = elementIDs[k];
+    faceLabel[1]  = faceID + '0';
+    int found     = 0;
 
-		for( i = 0 ; i < nload ; i++ )
-		{
-			if( elementID == nelemload[i * 2] && strcmp1( &sideload[i * nameLength], faceLabel ) == 0 )
-			{
-				xloadIndices[k] = 2 * i;
-				found = 1;
-				break;
-			}
-		}
+    for (i = 0; i < nload; i++) {
+      if (elementID == nelemload[i * 2] && strcmp1(&sideload[i * nameLength], faceLabel) == 0) {
+        xloadIndices[k] = 2 * i;
+        found           = 1;
+        break;
+      }
+    }
 
-		// xload index not found:
-		if( !found && strcmp( loadType, "DFLUX" ) == 0 )
-		{
-			missingDfluxBCError();
-		}
-		else if ( !found && strcmp( loadType, "FILM" ) == 0 )
-		{
-			missingFilmBCError();
-		}
-
-
-	}
+    // xload index not found:
+    if (!found && strcmp(loadType, "DFLUX") == 0) {
+      missingDfluxBCError();
+    } else if (!found && strcmp(loadType, "FILM") == 0) {
+      missingFilmBCError();
+    }
+  }
 }
 
 // Get the indices for the xboun array, corresponding to the temperature or displacement DOF of the nodes passed to the function
-void getXbounIndices( ITG * nodes, ITG numNodes, int nboun, int * ikboun, int * ilboun, int * xbounIndices, enum CouplingDataType couplDataType )
+void getXbounIndices(ITG *nodes, ITG numNodes, int nboun, int *ikboun, int *ilboun, int *xbounIndices, enum CouplingDataType couplDataType)
 {
-	ITG i;
+  ITG i;
 
-	switch( couplDataType )
-	{
-	case TEMPERATURE:
-		for( i = 0 ; i < numNodes ; i++ )
-		{
-			int idof = 8 * ( nodes[i] - 1 ) + 0; // 0 for temperature DOF
-			int k;
-			FORTRAN( nident, ( ikboun, &idof, &nboun, &k ) );
-			k -= 1; // Adjust because of FORTRAN indices
-			int m = ilboun[k] - 1; // Adjust because of FORTRAN indices
-			xbounIndices[i] = m;
-		}
-		// See documentation ccx_2.13.pdf for the definition of ikboun and ilboun
+  switch (couplDataType) {
+  case TEMPERATURE:
+    for (i = 0; i < numNodes; i++) {
+      int idof = 8 * (nodes[i] - 1) + 0; // 0 for temperature DOF
+      int k;
+      FORTRAN(nident, (ikboun, &idof, &nboun, &k));
+      k -= 1;                          // Adjust because of FORTRAN indices
+      int m           = ilboun[k] - 1; // Adjust because of FORTRAN indices
+      xbounIndices[i] = m;
+    }
+    // See documentation ccx_2.13.pdf for the definition of ikboun and ilboun
 
-		for( i = 0 ; i < numNodes ; i++ )
-		{
-			if( xbounIndices[i] < 0 )
-			{
-				missingTemperatureBCError();
-			}
-		}
+    for (i = 0; i < numNodes; i++) {
+      if (xbounIndices[i] < 0) {
+        missingTemperatureBCError();
+      }
+    }
     break;
-	case DISPLACEMENTS:
-		for( i = 0 ; i < numNodes ; i++ )
-		{
-			int idof_x = 8 * ( nodes[i] - 1 ) + 1; // x-component of displacement
-			int idof_y = 8 * ( nodes[i] - 1 ) + 2; // y-component of displacement
-			int idof_z = 8 * ( nodes[i] - 1 ) + 3; // z-component of displacement
-			int kx, ky, kz;
-			FORTRAN( nident, ( ikboun, &idof_x, &nboun, &kx ) );
-			FORTRAN( nident, ( ikboun, &idof_y, &nboun, &ky ) );
-			FORTRAN( nident, ( ikboun, &idof_z, &nboun, &kz ) );
-			xbounIndices[3 * i] = ilboun[kx - 1] - 1;
-			xbounIndices[3 * i + 1] = ilboun[ky - 1] - 1;
-			xbounIndices[3 * i + 2] = ilboun[kz - 1] - 1;
-		}
+  case DISPLACEMENTS:
+    for (i = 0; i < numNodes; i++) {
+      int idof_x = 8 * (nodes[i] - 1) + 1; // x-component of displacement
+      int idof_y = 8 * (nodes[i] - 1) + 2; // y-component of displacement
+      int idof_z = 8 * (nodes[i] - 1) + 3; // z-component of displacement
+      int kx, ky, kz;
+      FORTRAN(nident, (ikboun, &idof_x, &nboun, &kx));
+      FORTRAN(nident, (ikboun, &idof_y, &nboun, &ky));
+      FORTRAN(nident, (ikboun, &idof_z, &nboun, &kz));
+      xbounIndices[3 * i]     = ilboun[kx - 1] - 1;
+      xbounIndices[3 * i + 1] = ilboun[ky - 1] - 1;
+      xbounIndices[3 * i + 2] = ilboun[kz - 1] - 1;
+    }
 
-		// TODO This warning is not triggered if there are other BC (e.g. fixed nodes)
-		for( i = 0 ; i < 3 * numNodes; i++ )
-		{
-			if( xbounIndices[i] < 0 )
-			{
-				missingDisplacementBCError();
-			}
-		}
+    // TODO This warning is not triggered if there are other BC (e.g. fixed nodes)
+    for (i = 0; i < 3 * numNodes; i++) {
+      if (xbounIndices[i] < 0) {
+        missingDisplacementBCError();
+      }
+    }
     break;
   default:
     unreachableError();
-	}
+  }
 }
 
 // Get the indices for the xforc array, corresponding to the force DOFs of the nodes passed to the function
-void getXforcIndices( ITG * nodes, ITG numNodes, int nforc, int * ikforc, int * ilforc, int * xforcIndices )
+void getXforcIndices(ITG *nodes, ITG numNodes, int nforc, int *ikforc, int *ilforc, int *xforcIndices)
 {
-	ITG i;
+  ITG i;
 
-	for( i = 0 ; i < numNodes ; i++ )
-	{
-		//x-direction
-		int idof = 8 * ( nodes[i] - 1 ) + 1; // 1 for x force DOF
-		int k;
-		FORTRAN( nident, ( ikforc, &idof, &nforc, &k ) );
-		k -= 1; // Adjust because of FORTRAN indices
-		int m = ilforc[k] - 1; // Adjust because of FORTRAN indices
-		xforcIndices[3 * i] = m;
+  for (i = 0; i < numNodes; i++) {
+    //x-direction
+    int idof = 8 * (nodes[i] - 1) + 1; // 1 for x force DOF
+    int k;
+    FORTRAN(nident, (ikforc, &idof, &nforc, &k));
+    k -= 1;                              // Adjust because of FORTRAN indices
+    int m               = ilforc[k] - 1; // Adjust because of FORTRAN indices
+    xforcIndices[3 * i] = m;
 
-		//y-direction
-		idof = 8 * ( nodes[i] - 1 ) + 2; // 2 for y force DOF
-		FORTRAN( nident, ( ikforc, &idof, &nforc, &k ) );
-		k -= 1; // Adjust because of FORTRAN indices
-		m = ilforc[k] - 1; // Adjust because of FORTRAN indices
-		xforcIndices[3 * i + 1] = m;
+    //y-direction
+    idof = 8 * (nodes[i] - 1) + 2; // 2 for y force DOF
+    FORTRAN(nident, (ikforc, &idof, &nforc, &k));
+    k -= 1;                                  // Adjust because of FORTRAN indices
+    m                       = ilforc[k] - 1; // Adjust because of FORTRAN indices
+    xforcIndices[3 * i + 1] = m;
 
-		//z-direction
-		idof = 8 * ( nodes[i] - 1 ) + 3; // 3 for z force DOF
-		FORTRAN( nident, ( ikforc, &idof, &nforc, &k ) );
-		k -= 1; // Adjust because of FORTRAN indices
-		m = ilforc[k] - 1; // Adjust because of FORTRAN indices
-		xforcIndices[3 * i + 2] = m;
-	}
-	// See documentation ccx_2.10.pdf for the definition of ikforc and ilforc
+    //z-direction
+    idof = 8 * (nodes[i] - 1) + 3; // 3 for z force DOF
+    FORTRAN(nident, (ikforc, &idof, &nforc, &k));
+    k -= 1;                                  // Adjust because of FORTRAN indices
+    m                       = ilforc[k] - 1; // Adjust because of FORTRAN indices
+    xforcIndices[3 * i + 2] = m;
+  }
+  // See documentation ccx_2.10.pdf for the definition of ikforc and ilforc
 
-	for( i = 0 ; i < numNodes ; i++ )
-	{
-		if( xforcIndices[i] < 0 )
-		{
-			missingForceError();
-		}
-	}
+  for (i = 0; i < numNodes; i++) {
+    if (xforcIndices[i] < 0) {
+      missingForceError();
+    }
+  }
 }
 
-
-int getXloadIndexOffset( enum xloadVariable xloadVar )
+int getXloadIndexOffset(enum xloadVariable xloadVar)
 {
-	/*
+  /*
 	 * xload is the CalculiX array where the DFLUX and FILM boundary conditions are stored
 	 * the array has two components:
 	 * - the first component corresponds to the flux value and the heat transfer coefficient
 	 * - the second component corresponds to the sink temperature
 	 * */
-	switch( xloadVar )
-	{
-	case DFLUX:
-		return 0;
-	case FILM_H:
-		return 0;
-	case FILM_T:
-		return 1;
+  switch (xloadVar) {
+  case DFLUX:
+    return 0;
+  case FILM_H:
+    return 0;
+  case FILM_T:
+    return 1;
   default:
     unreachableError();
     return -1;
-	}
+  }
 }
 
-void setXload( double * xload, int * xloadIndices, double * values, int numValues, enum xloadVariable xloadVar )
+void setXload(double *xload, int *xloadIndices, double *values, int numValues, enum xloadVariable xloadVar)
 {
-	ITG i;
-	int indexOffset = getXloadIndexOffset( xloadVar );
+  ITG i;
+  int indexOffset = getXloadIndexOffset(xloadVar);
 
-	for( i = 0 ; i < numValues ; i++ )
-	{
-		xload[xloadIndices[i] + indexOffset] = values[i];
-	}
+  for (i = 0; i < numValues; i++) {
+    xload[xloadIndices[i] + indexOffset] = values[i];
+  }
 }
 
-void setFaceFluxes( double * fluxes, ITG numFaces, int * xloadIndices, double * xload )
+void setFaceFluxes(double *fluxes, ITG numFaces, int *xloadIndices, double *xload)
 {
-	setXload( xload, xloadIndices, fluxes, numFaces, DFLUX );
+  setXload(xload, xloadIndices, fluxes, numFaces, DFLUX);
 }
 
-void setFaceHeatTransferCoefficients( double * coefficients, ITG numFaces, int * xloadIndices, double * xload )
+void setFaceHeatTransferCoefficients(double *coefficients, ITG numFaces, int *xloadIndices, double *xload)
 {
-	setXload( xload, xloadIndices, coefficients, numFaces, FILM_H );
+  setXload(xload, xloadIndices, coefficients, numFaces, FILM_H);
 }
 
-void setFaceSinkTemperatures( double * sinkTemperatures, ITG numFaces, int * xloadIndices, double * xload )
+void setFaceSinkTemperatures(double *sinkTemperatures, ITG numFaces, int *xloadIndices, double *xload)
 {
-	setXload( xload, xloadIndices, sinkTemperatures, numFaces, FILM_T );
+  setXload(xload, xloadIndices, sinkTemperatures, numFaces, FILM_T);
 }
 
-void setNodeTemperatures( double * temperatures, ITG numNodes, int * xbounIndices, double * xboun )
+void setNodeTemperatures(double *temperatures, ITG numNodes, int *xbounIndices, double *xboun)
 {
-	ITG i;
+  ITG i;
 
-	for( i = 0 ; i < numNodes ; i++ )
-	{
-		xboun[xbounIndices[i]] = temperatures[i];
-	}
+  for (i = 0; i < numNodes; i++) {
+    xboun[xbounIndices[i]] = temperatures[i];
+  }
 }
 
-void setNodeForces( double * forces, ITG numNodes, int dim, int * xforcIndices, double * xforc )
+void setNodeForces(double *forces, ITG numNodes, int dim, int *xforcIndices, double *xforc)
 {
-	ITG i, j;
+  ITG i, j;
 
-	for ( i = 0 ; i < numNodes ; i++ )
-	{
-		for( j = 0 ; j < dim ; j++ )
-    {
+  for (i = 0; i < numNodes; i++) {
+    for (j = 0; j < dim; j++) {
       xforc[xforcIndices[3 * i + j]] = forces[dim * i + j];
     }
-	}
+  }
 }
 
-void setNodeDisplacements( double * displacements, ITG numNodes, int dim, int * xbounIndices, double * xboun )
+void setNodeDisplacements(double *displacements, ITG numNodes, int dim, int *xbounIndices, double *xboun)
 {
-	ITG i, j;
+  ITG i, j;
 
-	for( i = 0 ; i < numNodes ; i++ )
-	{
-		for( j = 0 ; j < dim ; j++ )
-    {
+  for (i = 0; i < numNodes; i++) {
+    for (j = 0; j < dim; j++) {
       xboun[xbounIndices[3 * i + j]] = displacements[dim * i + j];
     }
-	}
+  }
 }
 
-bool isSteadyStateSimulation( ITG * nmethod )
+bool isSteadyStateSimulation(ITG *nmethod)
 {
-	return *nmethod == 1;
+  return *nmethod == 1;
 }
 
-char* concat( char const * prefix, char const * string, char const * suffix )
+char *concat(char const *prefix, char const *string, char const *suffix)
 {
-	int nameLength = strlen( string ) + strlen( prefix ) + strlen( suffix ) + 1;
-	char * result = malloc( nameLength );
-	strcpy( result, prefix );
-	strcat( result, string );
-	strcat( result, suffix );
-	return result;
+  int   nameLength = strlen(string) + strlen(prefix) + strlen(suffix) + 1;
+  char *result     = malloc(nameLength);
+  strcpy(result, prefix);
+  strcat(result, string);
+  strcat(result, suffix);
+  return result;
 }
 
-bool startsWith(const char * string, const char * prefix)
+bool startsWith(const char *string, const char *prefix)
 {
-    char sc, pc;
-    do {
-        sc =*string++;
-        pc =*prefix++;
-        if (pc == '\0') return true;
-    } while (sc == pc);
-    return false;
+  char sc, pc;
+  do {
+    sc = *string++;
+    pc = *prefix++;
+    if (pc == '\0')
+      return true;
+  } while (sc == pc);
+  return false;
 }
 
-bool isEqual(const char * lhs, const char * rhs)
+bool isEqual(const char *lhs, const char *rhs)
 {
   return strcmp(lhs, rhs) == 0;
 }
 
 bool isDoubleEqual(const double a, const double b)
 {
-	return fabs(a - b) < 1.e-14;
+  return fabs(a - b) < 1.e-14;
 }
 
 bool isQuasi2D3D(const int quasi2D3D)
 {
-	return quasi2D3D == 1;
+  return quasi2D3D == 1;
 }
 
-void setDoubleArrayZero(double * values, const int length, const int dim)
+void setDoubleArrayZero(double *values, const int length, const int dim)
 {
-	ITG i, j;
+  ITG i, j;
 
-	for ( i = 0; i < length; i++ )
-	{
-		for ( j = 0; j < dim; j++ )
-		{
-			values[i*dim + j] = 0.0;
-		}
-	}
+  for (i = 0; i < length; i++) {
+    for (j = 0; j < dim; j++) {
+      values[i * dim + j] = 0.0;
+    }
+  }
 }
 
-void printVectorData(const double * values, const int nv, const int dim)
+void printVectorData(const double *values, const int nv, const int dim)
 {
-	ITG i, j;
+  ITG i, j;
 
-	for ( i = 0; i < nv; i++ )
-	{
-		printf("[");
-		for ( j = 0; j < dim; j++ )
-		{
-			printf("%f, ", values[i*dim + j]);
-		}
-		printf("]\n");
-	}
+  for (i = 0; i < nv; i++) {
+    printf("[");
+    for (j = 0; j < dim; j++) {
+      printf("%f, ", values[i * dim + j]);
+    }
+    printf("]\n");
+  }
 }
 
-
-void mapData2Dto3DVector(const double * values2D, const int * mapping2D3D, const int numNodes3D, double * values3D)
+void mapData2Dto3DVector(const double *values2D, const int *mapping2D3D, const int numNodes3D, double *values3D)
 {
-	ITG id, i;
+  ITG id, i;
 
-	for ( i = 0; i < numNodes3D; i++ )
-	{
-		id = mapping2D3D[i];
-		values3D[i*3] = values2D[id*2]*0.5;
-		values3D[i*3 + 1] = values2D[id*2 + 1]*0.5;
-		values3D[i*3 + 2] = 0;
-	}
+  for (i = 0; i < numNodes3D; i++) {
+    id                  = mapping2D3D[i];
+    values3D[i * 3]     = values2D[id * 2] * 0.5;
+    values3D[i * 3 + 1] = values2D[id * 2 + 1] * 0.5;
+    values3D[i * 3 + 2] = 0;
+  }
 }
 
-void mapData3Dto2DVector(const double * values3D, const int * mapping2D3D, const int numNodes3D, double * values2D)
+void mapData3Dto2DVector(const double *values3D, const int *mapping2D3D, const int numNodes3D, double *values2D)
 {
-	ITG id, i;
+  ITG id, i;
 
-	for ( i = 0; i < numNodes3D; i++ )
-	{
-		id = mapping2D3D[i];
-		values2D[id*2] += values3D[i*3]*0.5;
-		values2D[id*2 + 1] += values3D[i*3 + 1]*0.5;
-	}
+  for (i = 0; i < numNodes3D; i++) {
+    id = mapping2D3D[i];
+    values2D[id * 2] += values3D[i * 3] * 0.5;
+    values2D[id * 2 + 1] += values3D[i * 3 + 1] * 0.5;
+  }
 }
 
-void mapData2Dto3DScalar(const double * values2D, const int * mapping2D3D, const int numNodes3D, double * values3D)
+void mapData2Dto3DScalar(const double *values2D, const int *mapping2D3D, const int numNodes3D, double *values3D)
 {
-	ITG id, i;
+  ITG id, i;
 
-	for ( i = 0; i < numNodes3D; i++ )
-	{
-		id = mapping2D3D[i];
-		values3D[i] = values2D[id]*0.5;
-	}
+  for (i = 0; i < numNodes3D; i++) {
+    id          = mapping2D3D[i];
+    values3D[i] = values2D[id] * 0.5;
+  }
 }
 
-void mapData3Dto2DScalar(const double * values3D, const int * mapping2D3D, const int numNodes3D, double * values2D)
+void mapData3Dto2DScalar(const double *values3D, const int *mapping2D3D, const int numNodes3D, double *values2D)
 {
-	ITG id, i;
+  ITG id, i;
 
-	for ( i = 0; i < numNodes3D; i++ )
-	{
-		id = mapping2D3D[i];
-		values2D[id] += values3D[i]*0.5;
-	}
+  for (i = 0; i < numNodes3D; i++) {
+    id = mapping2D3D[i];
+    values2D[id] += values3D[i] * 0.5;
+  }
 }
 
 /* Errors messages */
 
-void nodeSetNotFoundError( char const * setName )
+void nodeSetNotFoundError(char const *setName)
 {
-	printf( "ERROR: Set %s does not exist! Please check that the interface names are correct and that .nam file is provided.\n", setName );
-	fflush( stdout );
-	exit( EXIT_FAILURE );
+  printf("ERROR: Set %s does not exist! Please check that the interface names are correct and that .nam file is provided.\n", setName);
+  fflush(stdout);
+  exit(EXIT_FAILURE);
 }
 
-void faceSetNotFoundError( char const * setName )
+void faceSetNotFoundError(char const *setName)
 {
-	printf( "ERROR: Set %s does not exist! Please check the following: \n 1) If nearest projection mapping is required, check that the interface names are correct and that .sur file is provided.\n 2) If nearest-projection mapping is not required, remove 'nodes-mesh-mesh-connectivity' and replace with 'nodes-mesh' in the config.yml file", setName );
-	fflush( stdout );
-	exit( EXIT_FAILURE );
+  printf("ERROR: Set %s does not exist! Please check the following: \n 1) If nearest projection mapping is required, check that the interface names are correct and that .sur file is provided.\n 2) If nearest-projection mapping is not required, remove 'nodes-mesh-mesh-connectivity' and replace with 'nodes-mesh' in the config.yml file", setName);
+  fflush(stdout);
+  exit(EXIT_FAILURE);
 }
 
 void missingTemperatureBCError()
 {
-	printf( "ERROR: Cannot apply temperature BC to one or more interface nodes.  Please make sure that a temperature boundary condition is set for the interface, when using a Dirichlet coupling BC.\n" );
-	exit( EXIT_FAILURE );
+  printf("ERROR: Cannot apply temperature BC to one or more interface nodes.  Please make sure that a temperature boundary condition is set for the interface, when using a Dirichlet coupling BC.\n");
+  exit(EXIT_FAILURE);
 }
 
 void missingForceError()
 {
-	printf( "ERROR: Cannot apply forces to one or more interface nodes.\n" );
-	exit( EXIT_FAILURE );
+  printf("ERROR: Cannot apply forces to one or more interface nodes.\n");
+  exit(EXIT_FAILURE);
 }
 
 void missingDisplacementBCError()
 {
-	printf( "ERROR: Cannot apply displacement to one or more interface nodes. Please make sure that a single point constraint in each direction is set for all interface nodes.\n" );
-	exit( EXIT_FAILURE );
+  printf("ERROR: Cannot apply displacement to one or more interface nodes. Please make sure that a single point constraint in each direction is set for all interface nodes.\n");
+  exit(EXIT_FAILURE);
 }
 
 void missingDfluxBCError()
 {
-	printf( "ERROR: Cannot apply DFLUX BC to one or more interface elements.  Please make sure that a .dfl file is provided for the interface, when using a Neumann coupling BC.\n" );
-	exit( EXIT_FAILURE );
+  printf("ERROR: Cannot apply DFLUX BC to one or more interface elements.  Please make sure that a .dfl file is provided for the interface, when using a Neumann coupling BC.\n");
+  exit(EXIT_FAILURE);
 }
 
 void missingFilmBCError()
 {
-	printf( "ERROR: Cannot apply FILM BC to one or more interface elements.  Please make sure that a .flm file is provided for the interface, when using a Robin coupling BC.\n" );
-	exit( EXIT_FAILURE );
+  printf("ERROR: Cannot apply FILM BC to one or more interface elements.  Please make sure that a .flm file is provided for the interface, when using a Robin coupling BC.\n");
+  exit(EXIT_FAILURE);
 }
 
 void unreachableError()
 {
-	printf( "ERROR: The preCICE adapter just entered an unreachable state. Something is very wrong!\n" );
-	exit( EXIT_FAILURE );
+  printf("ERROR: The preCICE adapter just entered an unreachable state. Something is very wrong!\n");
+  exit(EXIT_FAILURE);
 }

--- a/adapter/CCXHelpers.h
+++ b/adapter/CCXHelpers.h
@@ -10,10 +10,10 @@
 #ifndef CCXHELPERS_H
 #define CCXHELPERS_H
 
-#include <stdio.h>
 #include <math.h>
-#include <stdlib.h>
 #include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
 #include "../CalculiX.h"
 
 /*
@@ -26,7 +26,9 @@
 /**
  * @brief Possible variables in xload (CalculiX variable for the load)
  */
-enum xloadVariable { DFLUX, FILM_H, FILM_T };
+enum xloadVariable { DFLUX,
+                     FILM_H,
+                     FILM_T };
 
 /**
  * @brief Type of coupling data
@@ -39,21 +41,29 @@ enum xloadVariable { DFLUX, FILM_H, FILM_T };
  *  Velocities - FSI data to be written (by the Calculix adapter)
  *  Positions - FSI data to be written (by the Calculix adapter)
  */
-enum CouplingDataType { TEMPERATURE, HEAT_FLUX, SINK_TEMPERATURE, HEAT_TRANSFER_COEFF, FORCES, DISPLACEMENTS, DISPLACEMENTDELTAS, VELOCITIES, POSITIONS };
+enum CouplingDataType { TEMPERATURE,
+                        HEAT_FLUX,
+                        SINK_TEMPERATURE,
+                        HEAT_TRANSFER_COEFF,
+                        FORCES,
+                        DISPLACEMENTS,
+                        DISPLACEMENTDELTAS,
+                        VELOCITIES,
+                        POSITIONS };
 
 /**
  * @brief Returns node set name with internal CalculiX format
  * Prepends and appends an N: e.g. If the input name is "interface",
  * it returns NinterfaceN
  */
-char* toNodeSetName( char const * name );
+char *toNodeSetName(char const *name);
 
 /**
  * @brief Returns face set name with internal CalculiX format
  * Prepends an S and appends a T: e.g. If the input name is "interface",
  * it returns SinterfaceT
  */
-char* toFaceSetName( char const * name );
+char *toFaceSetName(char const *name);
 
 /**
  * @brief Returns id of a set given its name
@@ -61,12 +71,12 @@ char* toFaceSetName( char const * name );
  * @param set: CalculiX array for all the set names
  * @param nset: CalculiX variable for the number of sets
  */
-ITG getSetID( char const * setName, char const * set, ITG nset );
+ITG getSetID(char const *setName, char const *set, ITG nset);
 
 /**
  * @brief Returns number of elements in a set
  */
-ITG getNumSetElements( ITG setID, ITG * istartset, ITG * iendset );
+ITG getNumSetElements(ITG setID, ITG *istartset, ITG *iendset);
 
 /**
  * @brief Gets the element and face IDs given a set ID
@@ -77,7 +87,7 @@ ITG getNumSetElements( ITG setID, ITG * istartset, ITG * iendset );
  * @param elements: output element IDs
  * @param faces: output face IDs (local IDs: e.g. 1, 2, 3, 4 for tetrahedral elements)
  */
-void getSurfaceElementsAndFaces( ITG setID, ITG * ialset, ITG * istartset, ITG * iendset, ITG * elements, ITG * faces );
+void getSurfaceElementsAndFaces(ITG setID, ITG *ialset, ITG *istartset, ITG *iendset, ITG *elements, ITG *faces);
 
 /**
  * @brief Gets the coordinates of a list of input node IDs
@@ -88,7 +98,7 @@ void getSurfaceElementsAndFaces( ITG setID, ITG * ialset, ITG * istartset, ITG *
  * @param mt: CalculiX variable describing the number of solution variables in the solution array v
  * @param coordinates: output array with the coordinates of the input nodes
  */
-void getNodeCoordinates( ITG * nodes, ITG numNodes, int dim, double * co, double * v, int mt, double * coordinates );
+void getNodeCoordinates(ITG *nodes, ITG numNodes, int dim, double *co, double *v, int mt, double *coordinates);
 
 /**
  * @brief getNodeTemperatures
@@ -99,7 +109,7 @@ void getNodeCoordinates( ITG * nodes, ITG numNodes, int dim, double * co, double
  * @param mt: CalculiX variable describing the number of solution variables in the solution array v
  * @param temperatures: output array with the temperatures of the input nodes
  */
-void getNodeTemperatures( ITG * nodes, ITG numNodes, double * v, int mt, double * temperatures );
+void getNodeTemperatures(ITG *nodes, ITG numNodes, double *v, int mt, double *temperatures);
 
 /**
  * @brief getNodeForces
@@ -109,7 +119,7 @@ void getNodeTemperatures( ITG * nodes, ITG numNodes, double * v, int mt, double 
  * @param mt: CalculiX variable describing the number of force variables in fn
  * @param forces: output array with the forces of the input nodes
  */
-void getNodeForces( ITG * nodes, ITG numNodes, int dim, double * fn, ITG mt, double * forces );
+void getNodeForces(ITG *nodes, ITG numNodes, int dim, double *fn, ITG mt, double *forces);
 
 /**
  * @brief getNodeDisplacements
@@ -120,7 +130,7 @@ void getNodeForces( ITG * nodes, ITG numNodes, int dim, double * fn, ITG mt, dou
  * @param mt: CalculiX variable describing the number of solution variables in the solution array v
  * @param displacements: output array with the displacements in preCICE-conform order of the input nodes
  */
-void getNodeDisplacements( ITG * nodes, ITG numNodes, int dim, double * v, ITG mt, double * displacements );
+void getNodeDisplacements(ITG *nodes, ITG numNodes, int dim, double *v, ITG mt, double *displacements);
 
 /**
  * @brief getNodeVelocities
@@ -131,7 +141,7 @@ void getNodeDisplacements( ITG * nodes, ITG numNodes, int dim, double * v, ITG m
  * @param mt: CalculiX variable describing the number of solution variables in the solution array v
  * @param velocities: output array with the velocities in preCICE-conform order of the input nodes
  */
-void getNodeVelocities( ITG * nodes, ITG numNodes, int dim, double * ve, ITG mt, double * velocities );
+void getNodeVelocities(ITG *nodes, ITG numNodes, int dim, double *ve, ITG mt, double *velocities);
 
 /**
  * @brief getNodeDisplacementDeltas
@@ -143,7 +153,7 @@ void getNodeVelocities( ITG * nodes, ITG numNodes, int dim, double * ve, ITG mt,
  * @param mt: CalculiX variable describing the number of solution variables in the solution array v
  * @param displacementDeltas: output array with the displacementDeltas in preCICE-conform order of the input nodes
  */
-void getNodeDisplacementDeltas( ITG * nodes, ITG numNodes, int dim, double * v, double * v_init, ITG mt, double * displacementDeltas );
+void getNodeDisplacementDeltas(ITG *nodes, ITG numNodes, int dim, double *v, double *v_init, ITG mt, double *displacementDeltas);
 
 /**
  * @brief Computes the center of one of the faces of a tetrahedral element
@@ -155,7 +165,7 @@ void getNodeDisplacementDeltas( ITG * nodes, ITG numNodes, int dim, double * v, 
  * @param co: CalculiX array with the coordinates of all the nodes
  * @param faceCenters: output array with the face centers of the input element faces
  */
-void getTetraFaceCenters( ITG * elements, ITG * faces, ITG numElements, ITG * kon, ITG * ipkon, double * co, double * faceCenters );
+void getTetraFaceCenters(ITG *elements, ITG *faces, ITG numElements, ITG *kon, ITG *ipkon, double *co, double *faceCenters);
 
 /**
  * @brief Gets a list of node IDs from a list of input element faces
@@ -168,7 +178,7 @@ void getTetraFaceCenters( ITG * elements, ITG * faces, ITG numElements, ITG * ko
  * @param ipkon: CalculiX array (see description in ccx_2.10.pdf)
  * @param tetraFaceNodes: output list of node IDs that belong to the input element faces
  */
-void getTetraFaceNodes( ITG * elements, ITG * faces, ITG * nodes, ITG numElements, ITG numNodes, ITG * kon, ITG * ipkon, int * tetraFaceNodes );
+void getTetraFaceNodes(ITG *elements, ITG *faces, ITG *nodes, ITG numElements, ITG numNodes, ITG *kon, ITG *ipkon, int *tetraFaceNodes);
 
 /**
  * @brief Gets the indices of the xload where the DFLUX and FILM boundary conditions must be applied
@@ -181,7 +191,7 @@ void getTetraFaceNodes( ITG * elements, ITG * faces, ITG * nodes, ITG numElement
  * @param sideload: CalculiX array containing the faces to which the DFLUX or FILM boundary conditions are applied
  * @param xloadIndices: output list of indices of the xload array
  */
-void getXloadIndices( char const * loadType, ITG * elementIDs, ITG * faceIDs, ITG numElements, ITG nload, ITG * nelemload, char const * sideload, ITG * xloadIndices );
+void getXloadIndices(char const *loadType, ITG *elementIDs, ITG *faceIDs, ITG numElements, ITG nload, ITG *nelemload, char const *sideload, ITG *xloadIndices);
 
 /**
  * @brief Gets the indices of the xboun array where the boundary conditions must be applied
@@ -193,7 +203,7 @@ void getXloadIndices( char const * loadType, ITG * elementIDs, ITG * faceIDs, IT
  * @param xbounIndices: output list of indices of the xboun array
  * @param couplDataType: indicates whether indices must be for temperature or displacement BC
  */
-void getXbounIndices( ITG * nodes, ITG numNodes, int nboun, int * ikboun, int * ilboun, int * xbounIndices, enum CouplingDataType couplDataType );
+void getXbounIndices(ITG *nodes, ITG numNodes, int nboun, int *ikboun, int *ilboun, int *xbounIndices, enum CouplingDataType couplDataType);
 
 /**
  * @brief Gets the indices of the xforc array where the forces must be applied
@@ -204,7 +214,7 @@ void getXbounIndices( ITG * nodes, ITG numNodes, int nboun, int * ikboun, int * 
  * @param ilforc: CalculiX auxiliary array for dealing with the indices of the point loads
  * @param xforcIndices: output list of indices of the xforc array
  */
-void getXforcIndices( ITG * nodes, ITG numNodes, int nforc, int * ikforc, int * ilforc, int * xforcIndices );
+void getXforcIndices(ITG *nodes, ITG numNodes, int nforc, int *ikforc, int *ilforc, int *xforcIndices);
 
 /**
  * @brief Modifies the values of a DFLUX or FILM boundary condition
@@ -214,7 +224,7 @@ void getXforcIndices( ITG * nodes, ITG numNodes, int nforc, int * ikforc, int * 
  * @param numValues: number of boundary values provided
  * @param xloadVar: variable that is actually modified: DFLUX for heat flux, FILM_H for heat transfer coeff, FILM_T for sink temperature
  */
-void setXload( double * xload, int * xloadIndices, double * values, int numValues, enum xloadVariable xloadVar );
+void setXload(double *xload, int *xloadIndices, double *values, int numValues, enum xloadVariable xloadVar);
 
 /**
  * @brief Calls setXload to update the flux values at the specified indices
@@ -223,7 +233,7 @@ void setXload( double * xload, int * xloadIndices, double * values, int numValue
  * @param xloadIndices: indices of the xload array where the values must be updated
  * @param xload: CalculiX array for the loads
  */
-void setFaceFluxes( double * fluxes, ITG numFaces, int * xloadIndices, double * xload );
+void setFaceFluxes(double *fluxes, ITG numFaces, int *xloadIndices, double *xload);
 
 /**
  * @brief Calls setXload to update the heat transfer coefficients at the specified indices
@@ -232,7 +242,7 @@ void setFaceFluxes( double * fluxes, ITG numFaces, int * xloadIndices, double * 
  * @param xloadIndices: indices of the xload array where the values must be updated
  * @param xload: CalculiX array for the loads
  */
-void setFaceHeatTransferCoefficients( double * coefficients, ITG numFaces, int * xloadIndices, double * xload );
+void setFaceHeatTransferCoefficients(double *coefficients, ITG numFaces, int *xloadIndices, double *xload);
 
 /**
  * @brief Calls setXload to update the sink temperature at the specified indices
@@ -241,7 +251,7 @@ void setFaceHeatTransferCoefficients( double * coefficients, ITG numFaces, int *
  * @param xloadIndices: indices of the xload array where the values must be updated
  * @param xload: CalculiX array for the loads
  */
-void setFaceSinkTemperatures( double * sinkTemperatures, ITG numFaces, int * xloadIndices, double * xload );
+void setFaceSinkTemperatures(double *sinkTemperatures, ITG numFaces, int *xloadIndices, double *xload);
 
 /**
  * @brief Modifies the values of the temperature boundary condition
@@ -250,7 +260,7 @@ void setFaceSinkTemperatures( double * sinkTemperatures, ITG numFaces, int * xlo
  * @param xbounIndices: indices of the xboun array to modify
  * @param xboun: CalculiX array containing temperature and displacement boundary values
  */
-void setNodeTemperatures( double * temperatures, ITG numNodes, int * xbounIndices, double * xboun );
+void setNodeTemperatures(double *temperatures, ITG numNodes, int *xbounIndices, double *xboun);
 
 /**
  * @brief Modifies the values of the concentrated loads (point forces) applied to the structure
@@ -261,7 +271,7 @@ void setNodeTemperatures( double * temperatures, ITG numNodes, int * xbounIndice
  * @param xforcIndices: indices of the xforc array to modify
  * @param xforc: CalculiX array containing the (componentwise) assigned force values
  */
-void setNodeForces( double * forces, ITG numNodes, int dim, int * xforcIndices, double * xforc );
+void setNodeForces(double *forces, ITG numNodes, int dim, int *xforcIndices, double *xforc);
 
 /**
  * @brief Modifies the values of the displacements at the interface, as a Dirichlet boundary condition
@@ -271,13 +281,13 @@ void setNodeForces( double * forces, ITG numNodes, int dim, int * xforcIndices, 
  * @param xbounIndices: indices of the xboun array to modify
  * @param xboun: CalculiX array containing temperature and displacement boundary values
  */
-void setNodeDisplacements( double * displacements, ITG numNodes, int dim, int * xbounIndices, double * xboun );
+void setNodeDisplacements(double *displacements, ITG numNodes, int dim, int *xbounIndices, double *xboun);
 
 /**
  * @brief Returns whether it is a steady-state simulation based on the value of nmethod
  * @param nmethod: CalculiX variable with information regarding the type of analysis
  */
-bool isSteadyStateSimulation( ITG * nmethod );
+bool isSteadyStateSimulation(ITG *nmethod);
 
 /**
  * @brief Concatenates prefix + string + suffix
@@ -285,21 +295,21 @@ bool isSteadyStateSimulation( ITG * nmethod );
  * @param string
  * @param suffix
  */
-char * concat(char const * prefix, char const * string, char const * suffix);
+char *concat(char const *prefix, char const *string, char const *suffix);
 
 /**
  * @brief Checks wheather one zero-terminated string is prefixed by another
  * @param string the string to inspect
  * @param prefix the prefix to look for
  */
-bool startsWith(const char * string, const char * prefix);
+bool startsWith(const char *string, const char *prefix);
 
 /**
  * @brief Checks wheather two zero-terminated strings are identical
  * @param lhs the left-hand string
  * @param rhs the right-hand string
  */
-bool isEqual(const char * lhs, const char * rhs);
+bool isEqual(const char *lhs, const char *rhs);
 
 /**
  * @brief Checks wheather two doubles are identical
@@ -320,7 +330,7 @@ bool isQuasi2D3D(const int quasi2D3D);
  * @param length is the number of elements in array
  * @param dim is the dimension of the array data
  */
-void setDoubleArrayZero(double * values, const int length, const int dim);
+void setDoubleArrayZero(double *values, const int length, const int dim);
 
 /**
  * @brief Maps vector data from 2D mesh nodes to 3D mesh nodes
@@ -329,7 +339,7 @@ void setDoubleArrayZero(double * values, const int length, const int dim);
  * @param numNodes3D the number of nodes on 3D mesh
  * @param values3D is the array of vector values on 3D mesh nodes
  */
-void mapData2Dto3DVector(const double * values2D, const int * mapping2D3D, const int numNodes3D, double * values3D);
+void mapData2Dto3DVector(const double *values2D, const int *mapping2D3D, const int numNodes3D, double *values3D);
 
 /**
  * @brief Maps vector data from 3D mesh nodes to 2D mesh nodes
@@ -338,7 +348,7 @@ void mapData2Dto3DVector(const double * values2D, const int * mapping2D3D, const
  * @param numNodes3D the number of nodes on 3D mesh
  * @param values2D is the array of vector values on 2D mesh nodes
  */
-void mapData3Dto2DVector(const double * values3D, const int * mapping2D3D, const int numNodes3D, double * values2D);
+void mapData3Dto2DVector(const double *values3D, const int *mapping2D3D, const int numNodes3D, double *values2D);
 
 /**
  * @brief Maps data from 2D mesh nodes to 3D mesh nodes
@@ -347,7 +357,7 @@ void mapData3Dto2DVector(const double * values3D, const int * mapping2D3D, const
  * @param numNodes3D the number of nodes on 3D mesh
  * @param values3D is the array of values on 3D mesh nodes
  */
-void mapData2Dto3DScalar(const double * values2D, const int * mapping2D3D, const int numNodes3D, double * values3D);
+void mapData2Dto3DScalar(const double *values2D, const int *mapping2D3D, const int numNodes3D, double *values3D);
 
 /**
  * @brief Maps vector data from 3D mesh nodes to 2D mesh nodes
@@ -356,7 +366,7 @@ void mapData2Dto3DScalar(const double * values2D, const int * mapping2D3D, const
  * @param numNodes3D the number of nodes on 3D mesh
  * @param values2D is the array of values on 2D mesh nodes
  */
-void mapData3Dto2DScalar(const double * values3D, const int * mapping2D3D, const int numNodes3D, double * values2D);
+void mapData3Dto2DScalar(const double *values3D, const int *mapping2D3D, const int numNodes3D, double *values2D);
 
 /**
  * @brief Prints contents of a multi-dimension array
@@ -364,7 +374,7 @@ void mapData3Dto2DScalar(const double * values3D, const int * mapping2D3D, const
  * @param length is the number of elements in array
  * @param dim is the dimension of the array data
  */
-void printVectorData(const double * values, const int nv, const int dim);
+void printVectorData(const double *values, const int nv, const int dim);
 
 /* Error messages */
 
@@ -372,13 +382,13 @@ void printVectorData(const double * values, const int nv, const int dim);
  * @brief Terminate program if a node set is not defined for the interface (e.g. missing interface.nam file)
  * @param setName
  */
-void nodeSetNotFoundError( char const * setName );
+void nodeSetNotFoundError(char const *setName);
 
 /**
  * @brief Terminate program if a face set is not defined for the interface (e.g. missing interface.sur file)
  * @param setName
  */
-void faceSetNotFoundError( char const * setName );
+void faceSetNotFoundError(char const *setName);
 
 /**
  * @brief Terminate program if a temperature BC is not defined when using Dirichlet BC for coupling (e.g. missing line under *BOUNDARY)

--- a/adapter/ConfigReader.cpp
+++ b/adapter/ConfigReader.cpp
@@ -8,122 +8,100 @@
  *********************************************************************************************/
 
 #include "ConfigReader.hpp"
+#include <algorithm>
+#include <cassert>
+#include <cstdlib>
+#include <cstring>
+#include <iostream>
+#include <iterator>
 #include "ConfigReader.h"
 #include "yaml-cpp/yaml.h"
-#include <iostream>
-#include <cstring>
-#include <cassert>
-#include <algorithm>
-#include <cstdlib>
-#include <iterator>
 
-
-void ConfigReader_Read(char const * configFilename, char const * participantName, AdapterConfig * adapterConfig)
+void ConfigReader_Read(char const *configFilename, char const *participantName, AdapterConfig *adapterConfig)
 {
-	YAML::Node config = YAML::LoadFile( configFilename );
+  YAML::Node config = YAML::LoadFile(configFilename);
 
-  adapterConfig->preciceConfigFilename = strdup( config["precice-config-file"].as<std::string>().c_str() );
+  adapterConfig->preciceConfigFilename = strdup(config["precice-config-file"].as<std::string>().c_str());
 
-	int numInterfaces = config["participants"][participantName]["interfaces"].size();
-  	adapterConfig->numInterfaces = numInterfaces;
-  	adapterConfig->interfaces = (InterfaceConfig*) calloc( numInterfaces, sizeof( InterfaceConfig ) );
+  int numInterfaces            = config["participants"][participantName]["interfaces"].size();
+  adapterConfig->numInterfaces = numInterfaces;
+  adapterConfig->interfaces    = (InterfaceConfig *) calloc(numInterfaces, sizeof(InterfaceConfig));
 
-	for( int i = 0 ; i < numInterfaces ; i++ )
-	{
-    InterfaceConfig * currentInterfacePointer = adapterConfig->interfaces;
-    std::advance( currentInterfacePointer, i );
-    new ( currentInterfacePointer ) InterfaceConfig();
-    InterfaceConfig& interface = *currentInterfacePointer;
+  for (int i = 0; i < numInterfaces; i++) {
+    InterfaceConfig *currentInterfacePointer = adapterConfig->interfaces;
+    std::advance(currentInterfacePointer, i);
+    new (currentInterfacePointer) InterfaceConfig();
+    InterfaceConfig &interface = *currentInterfacePointer;
 
-		if( config["participants"][participantName]["interfaces"][i]["nodes-mesh"] )
-		{
-			interface.nodesMeshName = strdup( config["participants"][participantName]["interfaces"][i]["nodes-mesh"].as<std::string>().c_str() );
-			interface.map = 0;
-		}
-		else if ( config["participants"][participantName]["interfaces"][i]["nodes-mesh-with-connectivity"] ) 
-		{
-			interface.nodesMeshName = strdup( config["participants"][participantName]["interfaces"][i]["nodes-mesh-with-connectivity"].as<std::string>().c_str() );
-			interface.map = 1;
-		}
-		else
-		{
-			interface.nodesMeshName = NULL;
-		}
+    if (config["participants"][participantName]["interfaces"][i]["nodes-mesh"]) {
+      interface.nodesMeshName = strdup(config["participants"][participantName]["interfaces"][i]["nodes-mesh"].as<std::string>().c_str());
+      interface.map           = 0;
+    } else if (config["participants"][participantName]["interfaces"][i]["nodes-mesh-with-connectivity"]) {
+      interface.nodesMeshName = strdup(config["participants"][participantName]["interfaces"][i]["nodes-mesh-with-connectivity"].as<std::string>().c_str());
+      interface.map           = 1;
+    } else {
+      interface.nodesMeshName = NULL;
+    }
 
-		if( config["participants"][participantName]["interfaces"][i]["faces-mesh"] )
-		{
-			interface.facesMeshName = strdup( config["participants"][participantName]["interfaces"][i]["faces-mesh"].as<std::string>().c_str() );
-		}
-		else
-		{
-			interface.facesMeshName = NULL;
-		}
-		
-		if( config["participants"][participantName]["interfaces"][i]["mesh"] )
-		{
-			interface.facesMeshName = strdup( config["participants"][participantName]["interfaces"][i]["mesh"].as<std::string>().c_str() );
-		}
+    if (config["participants"][participantName]["interfaces"][i]["faces-mesh"]) {
+      interface.facesMeshName = strdup(config["participants"][participantName]["interfaces"][i]["faces-mesh"].as<std::string>().c_str());
+    } else {
+      interface.facesMeshName = NULL;
+    }
 
-		std::string patchName = config["participants"][participantName]["interfaces"][i]["patch"].as<std::string>();
-		std::transform( patchName.begin(), patchName.end(), patchName.begin(), toupper );
-		interface.patchName = strdup( patchName.c_str() );
+    if (config["participants"][participantName]["interfaces"][i]["mesh"]) {
+      interface.facesMeshName = strdup(config["participants"][participantName]["interfaces"][i]["mesh"].as<std::string>().c_str());
+    }
 
-		interface.numWriteData = config["participants"][participantName]["interfaces"][i]["write-data"].size();
-		interface.numReadData = config["participants"][participantName]["interfaces"][i]["read-data"].size();
+    std::string patchName = config["participants"][participantName]["interfaces"][i]["patch"].as<std::string>();
+    std::transform(patchName.begin(), patchName.end(), patchName.begin(), toupper);
+    interface.patchName = strdup(patchName.c_str());
 
-		if( config["participants"][participantName]["interfaces"][i]["write-data"] )
-		{
-			if( interface.numWriteData == 0 )
-			{
-				// write-data is a string
-				interface.numWriteData = 1;
-				interface.writeDataNames = (char**) malloc( sizeof( char* ) * interface.numWriteData );
-				interface.writeDataNames[0] = strdup( config["participants"][participantName]["interfaces"][i]["write-data"].as<std::string>().c_str() );
-			}
-			else
-			{
-				// write-data is an array
-				interface.writeDataNames = (char**) malloc( sizeof( char* ) * interface.numWriteData );
+    interface.numWriteData = config["participants"][participantName]["interfaces"][i]["write-data"].size();
+    interface.numReadData  = config["participants"][participantName]["interfaces"][i]["read-data"].size();
 
-				for( int j = 0 ; j < interface.numWriteData ; j++ )
-				{
-					interface.writeDataNames[j] = strdup( config["participants"][participantName]["interfaces"][i]["write-data"][j].as<std::string>().c_str() );
-				}
-			}
-		}
+    if (config["participants"][participantName]["interfaces"][i]["write-data"]) {
+      if (interface.numWriteData == 0) {
+        // write-data is a string
+        interface.numWriteData      = 1;
+        interface.writeDataNames    = (char **) malloc(sizeof(char *) * interface.numWriteData);
+        interface.writeDataNames[0] = strdup(config["participants"][participantName]["interfaces"][i]["write-data"].as<std::string>().c_str());
+      } else {
+        // write-data is an array
+        interface.writeDataNames = (char **) malloc(sizeof(char *) * interface.numWriteData);
 
-		if( config["participants"][participantName]["interfaces"][i]["read-data"] )
-		{
-			if( interface.numReadData == 0 )
-			{
-				// read-data is a string
-				interface.numReadData = 1;
-				interface.readDataNames = (char**) malloc( sizeof( char* ) * interface.numReadData );
-				interface.readDataNames[0] = strdup( config["participants"][participantName]["interfaces"][i]["read-data"].as<std::string>().c_str() );
-			}
-			else
-			{
-				// read-data is an array
-				interface.readDataNames = (char**) malloc( sizeof( char* ) * interface.numReadData );
+        for (int j = 0; j < interface.numWriteData; j++) {
+          interface.writeDataNames[j] = strdup(config["participants"][participantName]["interfaces"][i]["write-data"][j].as<std::string>().c_str());
+        }
+      }
+    }
 
-				for( int j = 0 ; j < interface.numReadData ; j++ )
-				{
-					interface.readDataNames[j] = strdup( config["participants"][participantName]["interfaces"][i]["read-data"][j].as<std::string>().c_str() );
-				}
-			}	
-		}
-	}
+    if (config["participants"][participantName]["interfaces"][i]["read-data"]) {
+      if (interface.numReadData == 0) {
+        // read-data is a string
+        interface.numReadData      = 1;
+        interface.readDataNames    = (char **) malloc(sizeof(char *) * interface.numReadData);
+        interface.readDataNames[0] = strdup(config["participants"][participantName]["interfaces"][i]["read-data"].as<std::string>().c_str());
+      } else {
+        // read-data is an array
+        interface.readDataNames = (char **) malloc(sizeof(char *) * interface.numReadData);
+
+        for (int j = 0; j < interface.numReadData; j++) {
+          interface.readDataNames[j] = strdup(config["participants"][participantName]["interfaces"][i]["read-data"][j].as<std::string>().c_str());
+        }
+      }
+    }
+  }
 }
 
-
-void AdapterConfig_Free(AdapterConfig * adapterConfig)
+void AdapterConfig_Free(AdapterConfig *adapterConfig)
 {
   assert(adapterConfig != NULL);
   free(adapterConfig->preciceConfigFilename);
 
   int i;
   for (i = 0; i < adapterConfig->numInterfaces; ++i) {
-    InterfaceConfig * interface = &adapterConfig->interfaces[i];
+    InterfaceConfig *interface = &adapterConfig->interfaces[i];
 
     // Owning char arrays
     free(interface->facesMeshName);
@@ -131,12 +109,12 @@ void AdapterConfig_Free(AdapterConfig * adapterConfig)
     free(interface->patchName);
 
     // Owning arrays of char arrays
-    char ** writeDataNamesEnd = interface->writeDataNames;
+    char **writeDataNamesEnd = interface->writeDataNames;
     std::advance(writeDataNamesEnd, interface->numWriteData);
     std::for_each(interface->writeDataNames, writeDataNamesEnd, free);
     free(interface->writeDataNames);
 
-    char ** readDataNamesEnd = interface->readDataNames;
+    char **readDataNamesEnd = interface->readDataNames;
     std::advance(readDataNamesEnd, interface->numReadData);
     std::for_each(interface->readDataNames, readDataNamesEnd, free);
     free(interface->readDataNames);

--- a/adapter/ConfigReader.h
+++ b/adapter/ConfigReader.h
@@ -11,20 +11,20 @@
 #define CONFIGREADER_H
 
 typedef struct InterfaceConfig {
-	char * facesMeshName;
-	char * nodesMeshName;
-	char * patchName;
-	int map;
-	int numWriteData;
-	int numReadData;
-	char ** writeDataNames;
-	char ** readDataNames;
+  char * facesMeshName;
+  char * nodesMeshName;
+  char * patchName;
+  int    map;
+  int    numWriteData;
+  int    numReadData;
+  char **writeDataNames;
+  char **readDataNames;
 } InterfaceConfig;
 
 typedef struct AdapterConfig {
-  int numInterfaces;
-  InterfaceConfig * interfaces;
-  char * preciceConfigFilename;
+  int              numInterfaces;
+  InterfaceConfig *interfaces;
+  char *           preciceConfigFilename;
 } AdapterConfig;
 
 /**  Reads the Adapter Config
@@ -36,7 +36,7 @@ typedef struct AdapterConfig {
  * @param[inout] adapterConfig a pointer to write the configuration to
  *
  */
-void ConfigReader_Read(char const * configFilename, char const * participantName, AdapterConfig * adapterConfig);
+void ConfigReader_Read(char const *configFilename, char const *participantName, AdapterConfig *adapterConfig);
 
 /** Frees all internal data held by an adapterConfig
  *
@@ -45,6 +45,6 @@ void ConfigReader_Read(char const * configFilename, char const * participantName
  * @postcondition all memory held by the struct adapterConfig is freed
  * @note This function does not free the pointer adapterConfig 
  */
-void AdapterConfig_Free(AdapterConfig * adapterConfig);
+void AdapterConfig_Free(AdapterConfig *adapterConfig);
 
 #endif

--- a/adapter/ConfigReader.hpp
+++ b/adapter/ConfigReader.hpp
@@ -12,9 +12,7 @@
 
 extern "C" {
 
-	#include "ConfigReader.h"
-
+#include "ConfigReader.h"
 }
-
 
 #endif

--- a/adapter/PreciceInterface.c
+++ b/adapter/PreciceInterface.c
@@ -7,25 +7,25 @@
  *                                                                                            *
  *********************************************************************************************/
 
-#include <stdlib.h>
-#include <assert.h>
 #include "PreciceInterface.h"
-#include "ConfigReader.h"
+#include <assert.h>
+#include <stdlib.h>
 #include "CCXHelpers.h"
+#include "ConfigReader.h"
 #include "precice/SolverInterfaceC.h"
 
-void Precice_Setup( char * configFilename, char * participantName, SimulationData * sim )
+void Precice_Setup(char *configFilename, char *participantName, SimulationData *sim)
 {
   assert(sim != NULL);
   assert(configFilename != NULL);
   assert(participantName != NULL);
 
-	printf( "Setting up preCICE participant %s, using config file: %s\n", participantName, configFilename );
-	fflush( stdout );
+  printf("Setting up preCICE participant %s, using config file: %s\n", participantName, configFilename);
+  fflush(stdout);
 
-	// Read the YAML config file
+  // Read the YAML config file
   AdapterConfig adapterConfig;
-	ConfigReader_Read( configFilename, participantName, &adapterConfig);
+  ConfigReader_Read(configFilename, participantName, &adapterConfig);
 
   assert(adapterConfig.interfaces != NULL);
   assert(adapterConfig.preciceConfigFilename != NULL);
@@ -33,555 +33,506 @@ void Precice_Setup( char * configFilename, char * participantName, SimulationDat
 
   sim->numPreciceInterfaces = adapterConfig.numInterfaces;
 
-	// Create the solver interface and configure it - Alex: Calculix is always a serial participant (MPI size 1, rank 0)
-	precicec_createSolverInterface( participantName, adapterConfig.preciceConfigFilename, 0, 1 );
+  // Create the solver interface and configure it - Alex: Calculix is always a serial participant (MPI size 1, rank 0)
+  precicec_createSolverInterface(participantName, adapterConfig.preciceConfigFilename, 0, 1);
 
-	// Create interfaces as specified in the config file
-	sim->preciceInterfaces = (struct PreciceInterface**) calloc( adapterConfig.numInterfaces, sizeof( PreciceInterface* ) );
+  // Create interfaces as specified in the config file
+  sim->preciceInterfaces = (struct PreciceInterface **) calloc(adapterConfig.numInterfaces, sizeof(PreciceInterface *));
 
-	int i;
-	for( i = 0 ; i < adapterConfig.numInterfaces; i++ )
-	{
-    InterfaceConfig * config = adapterConfig.interfaces + i;
-		sim->preciceInterfaces[i] = malloc( sizeof( PreciceInterface ) );
-		PreciceInterface_Create( sim->preciceInterfaces[i], sim, config );
-	}
+  int i;
+  for (i = 0; i < adapterConfig.numInterfaces; i++) {
+    InterfaceConfig *config   = adapterConfig.interfaces + i;
+    sim->preciceInterfaces[i] = malloc(sizeof(PreciceInterface));
+    PreciceInterface_Create(sim->preciceInterfaces[i], sim, config);
+  }
 
   // At this point we are done with the configuration
   AdapterConfig_Free(&adapterConfig);
 
-	// Initialize variables needed for the coupling
-	NNEW( sim->coupling_init_v, double, sim->mt * sim->nk );
+  // Initialize variables needed for the coupling
+  NNEW(sim->coupling_init_v, double, sim->mt * sim->nk);
 
-	// Initialize preCICE
-	sim->precice_dt = precicec_initialize();
+  // Initialize preCICE
+  sim->precice_dt = precicec_initialize();
 
   // Initialize coupling data
-	Precice_InitializeData( sim );
+  Precice_InitializeData(sim);
 }
 
-void Precice_InitializeData( SimulationData * sim )
+void Precice_InitializeData(SimulationData *sim)
 {
-	printf( "Initializing coupling data\n" );
-	fflush( stdout );
+  printf("Initializing coupling data\n");
+  fflush(stdout);
 
-	Precice_WriteCouplingData( sim );
-	precicec_initialize_data();
-  Precice_ReadCouplingData( sim );
+  Precice_WriteCouplingData(sim);
+  precicec_initialize_data();
+  Precice_ReadCouplingData(sim);
 }
 
-void Precice_AdjustSolverTimestep( SimulationData * sim )
+void Precice_AdjustSolverTimestep(SimulationData *sim)
 {
-	if( isSteadyStateSimulation( sim->nmethod ) )
-	{
-		printf( "Adjusting time step for steady-state step\n" );
-		fflush( stdout );
+  if (isSteadyStateSimulation(sim->nmethod)) {
+    printf("Adjusting time step for steady-state step\n");
+    fflush(stdout);
 
-		// For steady-state simulations, we will always compute the converged steady-state solution in one coupling step
-		*sim->theta = 0;
-		*sim->tper = 1;
-		*sim->dtheta = 1;
+    // For steady-state simulations, we will always compute the converged steady-state solution in one coupling step
+    *sim->theta  = 0;
+    *sim->tper   = 1;
+    *sim->dtheta = 1;
 
-		// Set the solver time step to be the same as the coupling time step
-		sim->solver_dt = sim->precice_dt;
-	}
-	else
-	{
-		printf( "Adjusting time step for transient step\n" );
-		printf( "precice_dt dtheta = %f, dtheta = %f, solver_dt = %f\n", sim->precice_dt / *sim->tper, *sim->dtheta, fmin( sim->precice_dt, *sim->dtheta * *sim->tper ) );
-		fflush( stdout );
+    // Set the solver time step to be the same as the coupling time step
+    sim->solver_dt = sim->precice_dt;
+  } else {
+    printf("Adjusting time step for transient step\n");
+    printf("precice_dt dtheta = %f, dtheta = %f, solver_dt = %f\n", sim->precice_dt / *sim->tper, *sim->dtheta, fmin(sim->precice_dt, *sim->dtheta * *sim->tper));
+    fflush(stdout);
 
-		// Compute the normalized time step used by CalculiX
-		*sim->dtheta = fmin( sim->precice_dt / *sim->tper, *sim->dtheta );
+    // Compute the normalized time step used by CalculiX
+    *sim->dtheta = fmin(sim->precice_dt / *sim->tper, *sim->dtheta);
 
-		// Compute the non-normalized time step used by preCICE
-		sim->solver_dt = ( *sim->dtheta ) * ( *sim->tper );
-	}
+    // Compute the non-normalized time step used by preCICE
+    sim->solver_dt = (*sim->dtheta) * (*sim->tper);
+  }
 }
 
-void Precice_Advance( SimulationData * sim )
+void Precice_Advance(SimulationData *sim)
 {
-	printf( "Adapter calling advance()...\n" );
-	fflush( stdout );
+  printf("Adapter calling advance()...\n");
+  fflush(stdout);
 
-	sim->precice_dt = precicec_advance( sim->solver_dt );
+  sim->precice_dt = precicec_advance(sim->solver_dt);
 }
 
 bool Precice_IsCouplingOngoing()
 {
-	return precicec_isCouplingOngoing();
+  return precicec_isCouplingOngoing();
 }
 
 bool Precice_IsReadCheckpointRequired()
 {
-	return precicec_isActionRequired( "read-iteration-checkpoint" );
+  return precicec_isActionRequired("read-iteration-checkpoint");
 }
 
 bool Precice_IsWriteCheckpointRequired()
 {
-	return precicec_isActionRequired( "write-iteration-checkpoint" );
+  return precicec_isActionRequired("write-iteration-checkpoint");
 }
 
 void Precice_FulfilledReadCheckpoint()
 {
-	precicec_markActionFulfilled( "read-iteration-checkpoint" );
+  precicec_markActionFulfilled("read-iteration-checkpoint");
 }
 
 void Precice_FulfilledWriteCheckpoint()
 {
-	precicec_markActionFulfilled( "write-iteration-checkpoint" );
+  precicec_markActionFulfilled("write-iteration-checkpoint");
 }
 
-void Precice_ReadIterationCheckpoint( SimulationData * sim, double * v )
+void Precice_ReadIterationCheckpoint(SimulationData *sim, double *v)
 {
 
-	printf( "Adapter reading checkpoint...\n" );
-	fflush( stdout );
+  printf("Adapter reading checkpoint...\n");
+  fflush(stdout);
 
-	// Reload time
-	*( sim->theta ) = sim->coupling_init_theta;
+  // Reload time
+  *(sim->theta) = sim->coupling_init_theta;
 
-	// Reload step size
-	*( sim->dtheta ) = sim->coupling_init_dtheta;
+  // Reload step size
+  *(sim->dtheta) = sim->coupling_init_dtheta;
 
-	// Reload solution vector v
-	memcpy( v, sim->coupling_init_v, sizeof( double ) * sim->mt * sim->nk );
+  // Reload solution vector v
+  memcpy(v, sim->coupling_init_v, sizeof(double) * sim->mt * sim->nk);
 }
 
-void Precice_WriteIterationCheckpoint( SimulationData * sim, double * v )
+void Precice_WriteIterationCheckpoint(SimulationData *sim, double *v)
 {
 
-	printf( "Adapter writing checkpoint...\n" );
-	fflush( stdout );
+  printf("Adapter writing checkpoint...\n");
+  fflush(stdout);
 
-	// Save time
-	sim->coupling_init_theta = *( sim->theta );
+  // Save time
+  sim->coupling_init_theta = *(sim->theta);
 
-	// Save step size
-	sim->coupling_init_dtheta = *( sim->dtheta );
+  // Save step size
+  sim->coupling_init_dtheta = *(sim->dtheta);
 
-	// Save solution vector v
-	memcpy( sim->coupling_init_v, v, sizeof( double ) * sim->mt * sim->nk );
+  // Save solution vector v
+  memcpy(sim->coupling_init_v, v, sizeof(double) * sim->mt * sim->nk);
 }
 
-void Precice_ReadCouplingData( SimulationData * sim )
+void Precice_ReadCouplingData(SimulationData *sim)
 {
 
-	printf( "Adapter reading coupling data...\n" );
-	fflush( stdout );
+  printf("Adapter reading coupling data...\n");
+  fflush(stdout);
 
-	PreciceInterface ** interfaces = sim->preciceInterfaces;
-	int numInterfaces = sim->numPreciceInterfaces;
-	int i, j;
+  PreciceInterface **interfaces    = sim->preciceInterfaces;
+  int                numInterfaces = sim->numPreciceInterfaces;
+  int                i, j;
 
-	if( precicec_isReadDataAvailable() )
-	{
-		for( i = 0 ; i < numInterfaces ; i++ )
-		{
+  if (precicec_isReadDataAvailable()) {
+    for (i = 0; i < numInterfaces; i++) {
 
-			for( j = 0 ; j < interfaces[i]->numReadData ; j++ )
-			{
+      for (j = 0; j < interfaces[i]->numReadData; j++) {
 
-				switch( interfaces[i]->readData[j] )
-				{
-				case TEMPERATURE:
-					// Read and set temperature BC
-          if ( isQuasi2D3D(interfaces[i]->quasi2D3D) )
-          {
-            precicec_readBlockScalarData( interfaces[i]->temperatureDataID, interfaces[i]->num2DNodes, interfaces[i]->preciceNodeIDs, interfaces[i]->node2DScalarData );
+        switch (interfaces[i]->readData[j]) {
+        case TEMPERATURE:
+          // Read and set temperature BC
+          if (isQuasi2D3D(interfaces[i]->quasi2D3D)) {
+            precicec_readBlockScalarData(interfaces[i]->temperatureDataID, interfaces[i]->num2DNodes, interfaces[i]->preciceNodeIDs, interfaces[i]->node2DScalarData);
             mapData2Dto3DScalar(interfaces[i]->node2DScalarData, interfaces[i]->mapping2D3D, interfaces[i]->numNodes, interfaces[i]->nodeScalarData);
+          } else {
+            precicec_readBlockScalarData(interfaces[i]->temperatureDataID, interfaces[i]->numNodes, interfaces[i]->preciceNodeIDs, interfaces[i]->nodeScalarData);
           }
-          else
-          {
-            precicec_readBlockScalarData( interfaces[i]->temperatureDataID, interfaces[i]->numNodes, interfaces[i]->preciceNodeIDs, interfaces[i]->nodeScalarData );
-          }
-					setNodeTemperatures( interfaces[i]->nodeScalarData, interfaces[i]->numNodes, interfaces[i]->xbounIndices, sim->xboun );
-					printf( "Reading TEMPERATURE coupling data with ID '%d'. \n",interfaces[i]->temperatureDataID );
-					break;
-				case HEAT_FLUX:
-					// Read and set heat flux BC
-					precicec_readBlockScalarData( interfaces[i]->fluxDataID, interfaces[i]->numElements, interfaces[i]->preciceFaceCenterIDs, interfaces[i]->faceCenterData );
-					setFaceFluxes( interfaces[i]->faceCenterData, interfaces[i]->numElements, interfaces[i]->xloadIndices, sim->xload );
-					printf( "Reading HEAT_FLUX coupling data with ID '%d'. \n",interfaces[i]->fluxDataID );
-					break;
-				case SINK_TEMPERATURE:
-					// Read and set sink temperature in convective film BC
-					precicec_readBlockScalarData( interfaces[i]->kDeltaTemperatureReadDataID, interfaces[i]->numElements, interfaces[i]->preciceFaceCenterIDs, interfaces[i]->faceCenterData );
-					setFaceSinkTemperatures( interfaces[i]->faceCenterData, interfaces[i]->numElements, interfaces[i]->xloadIndices, sim->xload );
-					printf( "Reading SINK_TEMPERATURE coupling data with ID '%d'. \n",interfaces[i]->kDeltaTemperatureReadDataID );
-					break;
-				case HEAT_TRANSFER_COEFF:
-					// Read and set heat transfer coefficient in convective film BC
-					precicec_readBlockScalarData( interfaces[i]->kDeltaReadDataID, interfaces[i]->numElements, interfaces[i]->preciceFaceCenterIDs, interfaces[i]->faceCenterData );
-					setFaceHeatTransferCoefficients( interfaces[i]->faceCenterData, interfaces[i]->numElements, interfaces[i]->xloadIndices, sim->xload );
-					printf( "Reading HEAT_TRANSFER_COEFF coupling data with ID '%d'. \n",interfaces[i]->kDeltaReadDataID );
-					break;
+          setNodeTemperatures(interfaces[i]->nodeScalarData, interfaces[i]->numNodes, interfaces[i]->xbounIndices, sim->xboun);
+          printf("Reading TEMPERATURE coupling data with ID '%d'. \n", interfaces[i]->temperatureDataID);
+          break;
+        case HEAT_FLUX:
+          // Read and set heat flux BC
+          precicec_readBlockScalarData(interfaces[i]->fluxDataID, interfaces[i]->numElements, interfaces[i]->preciceFaceCenterIDs, interfaces[i]->faceCenterData);
+          setFaceFluxes(interfaces[i]->faceCenterData, interfaces[i]->numElements, interfaces[i]->xloadIndices, sim->xload);
+          printf("Reading HEAT_FLUX coupling data with ID '%d'. \n", interfaces[i]->fluxDataID);
+          break;
+        case SINK_TEMPERATURE:
+          // Read and set sink temperature in convective film BC
+          precicec_readBlockScalarData(interfaces[i]->kDeltaTemperatureReadDataID, interfaces[i]->numElements, interfaces[i]->preciceFaceCenterIDs, interfaces[i]->faceCenterData);
+          setFaceSinkTemperatures(interfaces[i]->faceCenterData, interfaces[i]->numElements, interfaces[i]->xloadIndices, sim->xload);
+          printf("Reading SINK_TEMPERATURE coupling data with ID '%d'. \n", interfaces[i]->kDeltaTemperatureReadDataID);
+          break;
+        case HEAT_TRANSFER_COEFF:
+          // Read and set heat transfer coefficient in convective film BC
+          precicec_readBlockScalarData(interfaces[i]->kDeltaReadDataID, interfaces[i]->numElements, interfaces[i]->preciceFaceCenterIDs, interfaces[i]->faceCenterData);
+          setFaceHeatTransferCoefficients(interfaces[i]->faceCenterData, interfaces[i]->numElements, interfaces[i]->xloadIndices, sim->xload);
+          printf("Reading HEAT_TRANSFER_COEFF coupling data with ID '%d'. \n", interfaces[i]->kDeltaReadDataID);
+          break;
         case FORCES:
-					// Read and set forces as concentrated loads (Neumann BC)
-          if ( isQuasi2D3D(interfaces[i]->quasi2D3D) )
-          {
-            precicec_readBlockVectorData( interfaces[i]->forcesDataID, interfaces[i]->num2DNodes, interfaces[i]->preciceNodeIDs, interfaces[i]->node2DVectorData );
+          // Read and set forces as concentrated loads (Neumann BC)
+          if (isQuasi2D3D(interfaces[i]->quasi2D3D)) {
+            precicec_readBlockVectorData(interfaces[i]->forcesDataID, interfaces[i]->num2DNodes, interfaces[i]->preciceNodeIDs, interfaces[i]->node2DVectorData);
             mapData2Dto3DVector(interfaces[i]->node2DVectorData, interfaces[i]->mapping2D3D, interfaces[i]->numNodes, interfaces[i]->nodeVectorData);
+          } else {
+            precicec_readBlockVectorData(interfaces[i]->forcesDataID, interfaces[i]->numNodes, interfaces[i]->preciceNodeIDs, interfaces[i]->nodeVectorData);
           }
-          else
-          {
-            precicec_readBlockVectorData( interfaces[i]->forcesDataID, interfaces[i]->numNodes, interfaces[i]->preciceNodeIDs, interfaces[i]->nodeVectorData );
-          }
-					setNodeForces( interfaces[i]->nodeVectorData, interfaces[i]->numNodes, interfaces[i]->dimCCX, interfaces[i]->xforcIndices, sim->xforc);
-					printf( "Reading FORCES coupling data with ID '%d'. \n",interfaces[i]->forcesDataID );
-					break;
-				case DISPLACEMENTS:
-					// Read and set displacements as single point constraints (Dirichlet BC)
-          if ( isQuasi2D3D(interfaces[i]->quasi2D3D) )
-          {
-            precicec_readBlockVectorData( interfaces[i]->displacementsDataID, interfaces[i]->num2DNodes, interfaces[i]->preciceNodeIDs, interfaces[i]->node2DVectorData );
+          setNodeForces(interfaces[i]->nodeVectorData, interfaces[i]->numNodes, interfaces[i]->dimCCX, interfaces[i]->xforcIndices, sim->xforc);
+          printf("Reading FORCES coupling data with ID '%d'. \n", interfaces[i]->forcesDataID);
+          break;
+        case DISPLACEMENTS:
+          // Read and set displacements as single point constraints (Dirichlet BC)
+          if (isQuasi2D3D(interfaces[i]->quasi2D3D)) {
+            precicec_readBlockVectorData(interfaces[i]->displacementsDataID, interfaces[i]->num2DNodes, interfaces[i]->preciceNodeIDs, interfaces[i]->node2DVectorData);
             mapData2Dto3DVector(interfaces[i]->node2DVectorData, interfaces[i]->mapping2D3D, interfaces[i]->numNodes, interfaces[i]->nodeVectorData);
+          } else {
+            precicec_readBlockVectorData(interfaces[i]->displacementsDataID, interfaces[i]->numNodes, interfaces[i]->preciceNodeIDs, interfaces[i]->nodeVectorData);
           }
-          else
-          {
-            precicec_readBlockVectorData( interfaces[i]->displacementsDataID, interfaces[i]->numNodes, interfaces[i]->preciceNodeIDs, interfaces[i]->nodeVectorData );
-          }
-					setNodeDisplacements( interfaces[i]->nodeVectorData, interfaces[i]->numNodes, interfaces[i]->dimCCX, interfaces[i]->xbounIndices, sim->xboun );
-					printf( "Reading DISPLACEMENTS coupling data with ID '%d'. \n",interfaces[i]->displacementsDataID );
-					break;
-				case DISPLACEMENTDELTAS:
-					printf( "DisplacementDeltas cannot be used as read data\n" );
-					fflush( stdout );
-					exit( EXIT_FAILURE );
-					break;
-				case VELOCITIES:
-					printf( "Velocities cannot be used as read data\n" );
-					fflush( stdout );
-					exit( EXIT_FAILURE );
-					break;
-				case POSITIONS:
-					printf( "Positions cannot be used as read data.\n" );
-					fflush( stdout );
-					exit( EXIT_FAILURE );
-					break;
-				}
-			}
-		}
-	}
+          setNodeDisplacements(interfaces[i]->nodeVectorData, interfaces[i]->numNodes, interfaces[i]->dimCCX, interfaces[i]->xbounIndices, sim->xboun);
+          printf("Reading DISPLACEMENTS coupling data with ID '%d'. \n", interfaces[i]->displacementsDataID);
+          break;
+        case DISPLACEMENTDELTAS:
+          printf("DisplacementDeltas cannot be used as read data\n");
+          fflush(stdout);
+          exit(EXIT_FAILURE);
+          break;
+        case VELOCITIES:
+          printf("Velocities cannot be used as read data\n");
+          fflush(stdout);
+          exit(EXIT_FAILURE);
+          break;
+        case POSITIONS:
+          printf("Positions cannot be used as read data.\n");
+          fflush(stdout);
+          exit(EXIT_FAILURE);
+          break;
+        }
+      }
+    }
+  }
 }
 
-void Precice_WriteCouplingData( SimulationData * sim )
+void Precice_WriteCouplingData(SimulationData *sim)
 {
 
-	printf( "Adapter writing coupling data...\n" );
-	fflush( stdout );
+  printf("Adapter writing coupling data...\n");
+  fflush(stdout);
 
-	PreciceInterface ** interfaces = sim->preciceInterfaces;
-	int numInterfaces = sim->numPreciceInterfaces;
-  int i, j;
-  int iset;
+  PreciceInterface **interfaces    = sim->preciceInterfaces;
+  int                numInterfaces = sim->numPreciceInterfaces;
+  int                i, j;
+  int                iset;
 
-	if( precicec_isWriteDataRequired( sim->solver_dt ) || precicec_isActionRequired( "write-initial-data" ) )
-	{
-		for( i = 0 ; i < numInterfaces ; i++ )
-		{
+  if (precicec_isWriteDataRequired(sim->solver_dt) || precicec_isActionRequired("write-initial-data")) {
+    for (i = 0; i < numInterfaces; i++) {
       // Prepare data
-      double * KDelta = NULL;
-      double * T = NULL;
-			for( j = 0 ; j < interfaces[i]->numWriteData ; j++ )
-			{
+      double *KDelta = NULL;
+      double *T      = NULL;
+      for (j = 0; j < interfaces[i]->numWriteData; j++) {
         enum CouplingDataType type = interfaces[i]->writeData[j];
         if (type == SINK_TEMPERATURE || type == HEAT_TRANSFER_COEFF) {
           if (KDelta == NULL) {
             int iset = interfaces[i]->faceSetID + 1; // Adjust index before calling Fortran function
-            KDelta = malloc( interfaces[i]->numElements * sizeof( double ) );
-            T = malloc( interfaces[i]->numElements * sizeof( double ) );
-            FORTRAN( getkdeltatemp, ( sim->co,
-                          sim->ntmat_,
-                          sim->vold,
-                          sim->cocon,
-                          sim->ncocon,
-                          &iset,
-                          sim->istartset,
-                          sim->iendset,
-                          sim->ipkon,
-                          *sim->lakon,
-                          sim->kon,
-                          sim->ialset,
-                          sim->ielmat,
-                          sim->mi,
-                          KDelta,
-                          T
-                          )
-                );
+            KDelta   = malloc(interfaces[i]->numElements * sizeof(double));
+            T        = malloc(interfaces[i]->numElements * sizeof(double));
+            FORTRAN(getkdeltatemp, (sim->co,
+                                    sim->ntmat_,
+                                    sim->vold,
+                                    sim->cocon,
+                                    sim->ncocon,
+                                    &iset,
+                                    sim->istartset,
+                                    sim->iendset,
+                                    sim->ipkon,
+                                    *sim->lakon,
+                                    sim->kon,
+                                    sim->ialset,
+                                    sim->ielmat,
+                                    sim->mi,
+                                    KDelta,
+                                    T));
           }
         }
       }
-      
-      // Write data
-			for( j = 0 ; j < interfaces[i]->numWriteData ; j++ )
-			{
 
-				switch( interfaces[i]->writeData[j] )
-				{
-				case TEMPERATURE:
-					getNodeTemperatures( interfaces[i]->nodeIDs, interfaces[i]->numNodes, sim->vold, sim->mt, interfaces[i]->nodeScalarData );
-          if ( isQuasi2D3D(interfaces[i]->quasi2D3D) )
-          {
+      // Write data
+      for (j = 0; j < interfaces[i]->numWriteData; j++) {
+
+        switch (interfaces[i]->writeData[j]) {
+        case TEMPERATURE:
+          getNodeTemperatures(interfaces[i]->nodeIDs, interfaces[i]->numNodes, sim->vold, sim->mt, interfaces[i]->nodeScalarData);
+          if (isQuasi2D3D(interfaces[i]->quasi2D3D)) {
             setDoubleArrayZero(interfaces[i]->node2DScalarData, interfaces[i]->num2DNodes, 1);
             mapData3Dto2DScalar(interfaces[i]->nodeScalarData, interfaces[i]->mapping2D3D, interfaces[i]->numNodes, interfaces[i]->node2DScalarData);
-            precicec_writeBlockScalarData( interfaces[i]->temperatureDataID, interfaces[i]->num2DNodes, interfaces[i]->preciceNodeIDs, interfaces[i]->node2DScalarData );
+            precicec_writeBlockScalarData(interfaces[i]->temperatureDataID, interfaces[i]->num2DNodes, interfaces[i]->preciceNodeIDs, interfaces[i]->node2DScalarData);
+          } else {
+            precicec_writeBlockScalarData(interfaces[i]->temperatureDataID, interfaces[i]->numNodes, interfaces[i]->preciceNodeIDs, interfaces[i]->nodeScalarData);
           }
-          else
-          {
-            precicec_writeBlockScalarData( interfaces[i]->temperatureDataID, interfaces[i]->numNodes, interfaces[i]->preciceNodeIDs, interfaces[i]->nodeScalarData );
-          }
-					printf( "Writing TEMPERATURE coupling data with ID '%d'. \n",interfaces[i]->temperatureDataID );
-					break;
-				case HEAT_FLUX:
-					iset = interfaces[i]->faceSetID + 1; // Adjust index before calling Fortran function
-					FORTRAN( getflux, ( sim->co,
-										sim->ntmat_,
-										sim->vold,
-										sim->cocon,
-										sim->ncocon,
-										&iset,
-										sim->istartset,
-										sim->iendset,
-										sim->ipkon,
-										*sim->lakon,
-										sim->kon,
-										sim->ialset,
-										sim->ielmat,
-										sim->mi,
-										interfaces[i]->faceCenterData
-										)
-							 );
-					precicec_writeBlockScalarData( interfaces[i]->fluxDataID, interfaces[i]->numElements, interfaces[i]->preciceFaceCenterIDs, interfaces[i]->faceCenterData );
-					printf( "Writing HEAT_FLUX coupling data with ID '%d'. \n",interfaces[i]->fluxDataID );
-					break;
-				case SINK_TEMPERATURE:
-					precicec_writeBlockScalarData( interfaces[i]->kDeltaTemperatureWriteDataID, interfaces[i]->numElements, interfaces[i]->preciceFaceCenterIDs, T );
-					printf( "Writing SINK_TEMPERATURE coupling data with ID '%d'. \n",interfaces[i]->kDeltaTemperatureWriteDataID );
-					break;
-				case HEAT_TRANSFER_COEFF:
-					precicec_writeBlockScalarData( interfaces[i]->kDeltaWriteDataID, interfaces[i]->numElements, interfaces[i]->preciceFaceCenterIDs, KDelta );
-					printf( "Writing HEAT_TRANSFER_COEFF coupling data with ID '%d'. \n",interfaces[i]->kDeltaWriteDataID );
-					break;
-				case DISPLACEMENTS:
-					getNodeDisplacements( interfaces[i]->nodeIDs, interfaces[i]->numNodes, interfaces[i]->dimCCX, sim->vold, sim->mt, interfaces[i]->nodeVectorData );
-          if ( isQuasi2D3D(interfaces[i]->quasi2D3D) )
-          {
+          printf("Writing TEMPERATURE coupling data with ID '%d'. \n", interfaces[i]->temperatureDataID);
+          break;
+        case HEAT_FLUX:
+          iset = interfaces[i]->faceSetID + 1; // Adjust index before calling Fortran function
+          FORTRAN(getflux, (sim->co,
+                            sim->ntmat_,
+                            sim->vold,
+                            sim->cocon,
+                            sim->ncocon,
+                            &iset,
+                            sim->istartset,
+                            sim->iendset,
+                            sim->ipkon,
+                            *sim->lakon,
+                            sim->kon,
+                            sim->ialset,
+                            sim->ielmat,
+                            sim->mi,
+                            interfaces[i]->faceCenterData));
+          precicec_writeBlockScalarData(interfaces[i]->fluxDataID, interfaces[i]->numElements, interfaces[i]->preciceFaceCenterIDs, interfaces[i]->faceCenterData);
+          printf("Writing HEAT_FLUX coupling data with ID '%d'. \n", interfaces[i]->fluxDataID);
+          break;
+        case SINK_TEMPERATURE:
+          precicec_writeBlockScalarData(interfaces[i]->kDeltaTemperatureWriteDataID, interfaces[i]->numElements, interfaces[i]->preciceFaceCenterIDs, T);
+          printf("Writing SINK_TEMPERATURE coupling data with ID '%d'. \n", interfaces[i]->kDeltaTemperatureWriteDataID);
+          break;
+        case HEAT_TRANSFER_COEFF:
+          precicec_writeBlockScalarData(interfaces[i]->kDeltaWriteDataID, interfaces[i]->numElements, interfaces[i]->preciceFaceCenterIDs, KDelta);
+          printf("Writing HEAT_TRANSFER_COEFF coupling data with ID '%d'. \n", interfaces[i]->kDeltaWriteDataID);
+          break;
+        case DISPLACEMENTS:
+          getNodeDisplacements(interfaces[i]->nodeIDs, interfaces[i]->numNodes, interfaces[i]->dimCCX, sim->vold, sim->mt, interfaces[i]->nodeVectorData);
+          if (isQuasi2D3D(interfaces[i]->quasi2D3D)) {
             setDoubleArrayZero(interfaces[i]->node2DVectorData, interfaces[i]->num2DNodes, interfaces[i]->dim);
             mapData3Dto2DVector(interfaces[i]->nodeVectorData, interfaces[i]->mapping2D3D, interfaces[i]->numNodes, interfaces[i]->node2DVectorData);
-            precicec_writeBlockVectorData( interfaces[i]->displacementsDataID, interfaces[i]->num2DNodes, interfaces[i]->preciceNodeIDs, interfaces[i]->node2DVectorData );
+            precicec_writeBlockVectorData(interfaces[i]->displacementsDataID, interfaces[i]->num2DNodes, interfaces[i]->preciceNodeIDs, interfaces[i]->node2DVectorData);
+          } else {
+            precicec_writeBlockVectorData(interfaces[i]->displacementsDataID, interfaces[i]->numNodes, interfaces[i]->preciceNodeIDs, interfaces[i]->nodeVectorData);
           }
-          else
-          {
-            precicec_writeBlockVectorData( interfaces[i]->displacementsDataID, interfaces[i]->numNodes, interfaces[i]->preciceNodeIDs, interfaces[i]->nodeVectorData );
-          }
-					printf( "Writing DISPLACEMENTS coupling data with ID '%d'. \n",interfaces[i]->displacementsDataID );
-					break;
-				case DISPLACEMENTDELTAS:
-					getNodeDisplacementDeltas( interfaces[i]->nodeIDs, interfaces[i]->numNodes, interfaces[i]->dimCCX, sim->vold, sim->coupling_init_v, sim->mt, interfaces[i]->nodeVectorData );
-          if ( isQuasi2D3D(interfaces[i]->quasi2D3D) )
-          {
+          printf("Writing DISPLACEMENTS coupling data with ID '%d'. \n", interfaces[i]->displacementsDataID);
+          break;
+        case DISPLACEMENTDELTAS:
+          getNodeDisplacementDeltas(interfaces[i]->nodeIDs, interfaces[i]->numNodes, interfaces[i]->dimCCX, sim->vold, sim->coupling_init_v, sim->mt, interfaces[i]->nodeVectorData);
+          if (isQuasi2D3D(interfaces[i]->quasi2D3D)) {
             setDoubleArrayZero(interfaces[i]->node2DVectorData, interfaces[i]->num2DNodes, interfaces[i]->dim);
             mapData3Dto2DVector(interfaces[i]->nodeVectorData, interfaces[i]->mapping2D3D, interfaces[i]->numNodes, interfaces[i]->node2DVectorData);
-            precicec_writeBlockVectorData( interfaces[i]->displacementDeltasDataID, interfaces[i]->num2DNodes, interfaces[i]->preciceNodeIDs, interfaces[i]->node2DVectorData );
+            precicec_writeBlockVectorData(interfaces[i]->displacementDeltasDataID, interfaces[i]->num2DNodes, interfaces[i]->preciceNodeIDs, interfaces[i]->node2DVectorData);
+          } else {
+            precicec_writeBlockVectorData(interfaces[i]->displacementDeltasDataID, interfaces[i]->numNodes, interfaces[i]->preciceNodeIDs, interfaces[i]->nodeVectorData);
           }
-          else
-          {
-            precicec_writeBlockVectorData( interfaces[i]->displacementDeltasDataID, interfaces[i]->numNodes, interfaces[i]->preciceNodeIDs, interfaces[i]->nodeVectorData );
-          }
-					printf( "Writing DISPLACEMENTDELTAS coupling data with ID '%d'. \n",interfaces[i]->displacementDeltasDataID );
-					break;
-				case VELOCITIES:
-					getNodeVelocities( interfaces[i]->nodeIDs, interfaces[i]->numNodes, interfaces[i]->dim, sim->veold, sim->mt, interfaces[i]->nodeVectorData );
-					precicec_writeBlockVectorData( interfaces[i]->velocitiesDataID, interfaces[i]->numNodes, interfaces[i]->preciceNodeIDs, interfaces[i]->nodeVectorData );
-					printf( "Writing VELOCITIES coupling data with ID '%d'. \n",interfaces[i]->velocitiesDataID );
-					break;
-				case POSITIONS:
-					getNodeCoordinates( interfaces[i]->nodeIDs, interfaces[i]->numNodes, interfaces[i]->dim, sim->co, sim->vold, sim->mt, interfaces[i]->nodeVectorData );
-					precicec_writeBlockVectorData( interfaces[i]->positionsDataID, interfaces[i]->numNodes, interfaces[i]->preciceNodeIDs, interfaces[i]->nodeVectorData );
-					printf( "Writing POSITIONS coupling data with ID '%d'. \n",interfaces[i]->positionsDataID );
-					break;
-				case FORCES:
-          getNodeForces( interfaces[i]->nodeIDs, interfaces[i]->numNodes, interfaces[i]->dim, sim->fn, sim->mt, interfaces[i]->nodeVectorData );
-          precicec_writeBlockVectorData( interfaces[i]->forcesDataID, interfaces[i]->numNodes, interfaces[i]->preciceNodeIDs, interfaces[i]->nodeVectorData );
-					printf( "Writing FORCES coupling data with ID '%d'. \n",interfaces[i]->forcesDataID );
-					break;
-				}
-			}
+          printf("Writing DISPLACEMENTDELTAS coupling data with ID '%d'. \n", interfaces[i]->displacementDeltasDataID);
+          break;
+        case VELOCITIES:
+          getNodeVelocities(interfaces[i]->nodeIDs, interfaces[i]->numNodes, interfaces[i]->dim, sim->veold, sim->mt, interfaces[i]->nodeVectorData);
+          precicec_writeBlockVectorData(interfaces[i]->velocitiesDataID, interfaces[i]->numNodes, interfaces[i]->preciceNodeIDs, interfaces[i]->nodeVectorData);
+          printf("Writing VELOCITIES coupling data with ID '%d'. \n", interfaces[i]->velocitiesDataID);
+          break;
+        case POSITIONS:
+          getNodeCoordinates(interfaces[i]->nodeIDs, interfaces[i]->numNodes, interfaces[i]->dim, sim->co, sim->vold, sim->mt, interfaces[i]->nodeVectorData);
+          precicec_writeBlockVectorData(interfaces[i]->positionsDataID, interfaces[i]->numNodes, interfaces[i]->preciceNodeIDs, interfaces[i]->nodeVectorData);
+          printf("Writing POSITIONS coupling data with ID '%d'. \n", interfaces[i]->positionsDataID);
+          break;
+        case FORCES:
+          getNodeForces(interfaces[i]->nodeIDs, interfaces[i]->numNodes, interfaces[i]->dim, sim->fn, sim->mt, interfaces[i]->nodeVectorData);
+          precicec_writeBlockVectorData(interfaces[i]->forcesDataID, interfaces[i]->numNodes, interfaces[i]->preciceNodeIDs, interfaces[i]->nodeVectorData);
+          printf("Writing FORCES coupling data with ID '%d'. \n", interfaces[i]->forcesDataID);
+          break;
+        }
+      }
       // Cleanup data
-      free( T );
-      free( KDelta );
-		}
-		if( precicec_isActionRequired( "write-initial-data" ) )
-		{
-			precicec_markActionFulfilled( "write-initial-data" );
-		}
-	}
+      free(T);
+      free(KDelta);
+    }
+    if (precicec_isActionRequired("write-initial-data")) {
+      precicec_markActionFulfilled("write-initial-data");
+    }
+  }
 }
 
-void Precice_FreeData( SimulationData * sim )
+void Precice_FreeData(SimulationData *sim)
 {
-	int i;
+  int i;
 
-	if( sim->coupling_init_v != NULL ){
-		free( sim->coupling_init_v );
-	}
+  if (sim->coupling_init_v != NULL) {
+    free(sim->coupling_init_v);
+  }
 
-	for( i = 0 ; i < sim->numPreciceInterfaces ; i++ )
-	{
-		PreciceInterface_FreeData( sim->preciceInterfaces[i] );
-		free( sim->preciceInterfaces[i] );
-	}
-	
-	free( sim->preciceInterfaces );
-	precicec_finalize();
+  for (i = 0; i < sim->numPreciceInterfaces; i++) {
+    PreciceInterface_FreeData(sim->preciceInterfaces[i]);
+    free(sim->preciceInterfaces[i]);
+  }
+
+  free(sim->preciceInterfaces);
+  precicec_finalize();
 }
 
-void PreciceInterface_Create( PreciceInterface * interface, SimulationData * sim, InterfaceConfig const * config )
+void PreciceInterface_Create(PreciceInterface *interface, SimulationData *sim, InterfaceConfig const *config)
 {
-	interface->dim = precicec_getDimensions();
+  interface->dim = precicec_getDimensions();
 
-	// Initialize pointers as NULL
-	interface->elementIDs = NULL;
-	interface->faceIDs = NULL;
-	interface->faceCenterCoordinates = NULL;
-	interface->preciceFaceCenterIDs = NULL;
-	interface->nodeCoordinates = NULL;
-  interface->node2DCoordinates = NULL;
-  interface->nodeIDs = NULL;
-  interface->mapping2D3D = NULL;
-	interface->preciceNodeIDs = NULL;
-	interface->nodeScalarData = NULL;
-  interface->node2DScalarData = NULL;
-	interface->nodeVectorData = NULL;
-  interface->node2DVectorData = NULL;
-	interface->faceCenterData = NULL;
-	interface->xbounIndices = NULL;
-	interface->xloadIndices = NULL;
-	interface->xforcIndices = NULL;
+  // Initialize pointers as NULL
+  interface->elementIDs            = NULL;
+  interface->faceIDs               = NULL;
+  interface->faceCenterCoordinates = NULL;
+  interface->preciceFaceCenterIDs  = NULL;
+  interface->nodeCoordinates       = NULL;
+  interface->node2DCoordinates     = NULL;
+  interface->nodeIDs               = NULL;
+  interface->mapping2D3D           = NULL;
+  interface->preciceNodeIDs        = NULL;
+  interface->nodeScalarData        = NULL;
+  interface->node2DScalarData      = NULL;
+  interface->nodeVectorData        = NULL;
+  interface->node2DVectorData      = NULL;
+  interface->faceCenterData        = NULL;
+  interface->xbounIndices          = NULL;
+  interface->xloadIndices          = NULL;
+  interface->xforcIndices          = NULL;
 
   // Initialize data ids to -1
-	interface->temperatureDataID = -1;
-	interface->fluxDataID = -1;
-	interface->kDeltaWriteDataID = -1;
-	interface->kDeltaTemperatureWriteDataID = -1;
-	interface->kDeltaReadDataID = -1;
-	interface->kDeltaTemperatureReadDataID = -1;
-	interface->displacementsDataID = -1;
-	interface->displacementDeltasDataID = -1;
-	interface->positionsDataID = -1;
-	interface->velocitiesDataID = -1;
-	interface->forcesDataID = -1;
+  interface->temperatureDataID            = -1;
+  interface->fluxDataID                   = -1;
+  interface->kDeltaWriteDataID            = -1;
+  interface->kDeltaTemperatureWriteDataID = -1;
+  interface->kDeltaReadDataID             = -1;
+  interface->kDeltaTemperatureReadDataID  = -1;
+  interface->displacementsDataID          = -1;
+  interface->displacementDeltasDataID     = -1;
+  interface->positionsDataID              = -1;
+  interface->velocitiesDataID             = -1;
+  interface->forcesDataID                 = -1;
 
   // Check if quasi 2D-3D coupling needs to be implemented
-  if (interface->dim == 2)
-  {
+  if (interface->dim == 2) {
     interface->quasi2D3D = 1;
-    printf( "Using quasi 2D-3D coupling\n" );
+    printf("Using quasi 2D-3D coupling\n");
     interface->dimCCX = 3; // CalculiX always solves a 3D problem
-  }
-  else
-  {
+  } else {
     interface->quasi2D3D = 0;
-    interface->dimCCX = interface->dim;
+    interface->dimCCX    = interface->dim;
   }
 
-	//Mapping Type
-	// The patch identifies the set used as interface in Calculix
-	interface->name = strdup( config->patchName );
-	// Calculix needs to know if nearest-projection mapping is implemented. config->map = 1 is for nearest-projection, config->map = 0 is for everything else
-	interface->mapNPType = config->map;
+  //Mapping Type
+  // The patch identifies the set used as interface in Calculix
+  interface->name = strdup(config->patchName);
+  // Calculix needs to know if nearest-projection mapping is implemented. config->map = 1 is for nearest-projection, config->map = 0 is for everything else
+  interface->mapNPType = config->map;
 
-	// Nodes mesh
-	interface->nodesMeshID = -1;
-	interface->nodesMeshName = NULL;
-  if ( config->nodesMeshName ) {
-    interface->nodesMeshName = strdup( config->nodesMeshName );
-    PreciceInterface_ConfigureNodesMesh( interface, sim );
+  // Nodes mesh
+  interface->nodesMeshID   = -1;
+  interface->nodesMeshName = NULL;
+  if (config->nodesMeshName) {
+    interface->nodesMeshName = strdup(config->nodesMeshName);
+    PreciceInterface_ConfigureNodesMesh(interface, sim);
   }
 
-	// Face centers mesh
-	interface->faceCentersMeshID = -1;
-	interface->faceCentersMeshName = NULL;
-  if ( config->facesMeshName ) {
-	  interface->faceCentersMeshName = strdup( config->facesMeshName );
-		// Only configure a face center mesh if necesary; i.e. do not configure it for FSI simulations, also do not configure tetra faces if no face center mesh is used (as in FSI simulations)
-    PreciceInterface_ConfigureFaceCentersMesh( interface, sim );
-		// Triangles of the nodes mesh (needs to be called after the face centers mesh is configured!)
-    PreciceInterface_ConfigureTetraFaces( interface, sim );
-	}
+  // Face centers mesh
+  interface->faceCentersMeshID   = -1;
+  interface->faceCentersMeshName = NULL;
+  if (config->facesMeshName) {
+    interface->faceCentersMeshName = strdup(config->facesMeshName);
+    // Only configure a face center mesh if necesary; i.e. do not configure it for FSI simulations, also do not configure tetra faces if no face center mesh is used (as in FSI simulations)
+    PreciceInterface_ConfigureFaceCentersMesh(interface, sim);
+    // Triangles of the nodes mesh (needs to be called after the face centers mesh is configured!)
+    PreciceInterface_ConfigureTetraFaces(interface, sim);
+  }
 
-	PreciceInterface_ConfigureCouplingData( interface, sim, config );
+  PreciceInterface_ConfigureCouplingData(interface, sim, config);
 }
 
-void PreciceInterface_ConfigureFaceCentersMesh( PreciceInterface * interface, SimulationData * sim )
+void PreciceInterface_ConfigureFaceCentersMesh(PreciceInterface *interface, SimulationData *sim)
 {
-	//printf("Entering ConfigureFaceCentersMesh \n");
-	char * faceSetName = toFaceSetName( interface->name );
-	interface->faceSetID = getSetID( faceSetName, sim->set, sim->nset );
-	interface->numElements = getNumSetElements( interface->faceSetID, sim->istartset, sim->iendset );
+  //printf("Entering ConfigureFaceCentersMesh \n");
+  char *faceSetName      = toFaceSetName(interface->name);
+  interface->faceSetID   = getSetID(faceSetName, sim->set, sim->nset);
+  interface->numElements = getNumSetElements(interface->faceSetID, sim->istartset, sim->iendset);
 
-	interface->elementIDs = malloc( interface->numElements * sizeof( ITG ) );
-	interface->faceIDs = malloc( interface->numElements * sizeof( ITG ) );
-	getSurfaceElementsAndFaces( interface->faceSetID, sim->ialset, sim->istartset, sim->iendset, interface->elementIDs, interface->faceIDs );
+  interface->elementIDs = malloc(interface->numElements * sizeof(ITG));
+  interface->faceIDs    = malloc(interface->numElements * sizeof(ITG));
+  getSurfaceElementsAndFaces(interface->faceSetID, sim->ialset, sim->istartset, sim->iendset, interface->elementIDs, interface->faceIDs);
 
-	interface->faceCenterCoordinates = malloc( interface->numElements * 3 * sizeof( double ) );
-	interface->preciceFaceCenterIDs = malloc( interface->numElements * 3 * sizeof( int ) );
-	getTetraFaceCenters( interface->elementIDs, interface->faceIDs, interface->numElements, sim->kon, sim->ipkon, sim->co, interface->faceCenterCoordinates );
+  interface->faceCenterCoordinates = malloc(interface->numElements * 3 * sizeof(double));
+  interface->preciceFaceCenterIDs  = malloc(interface->numElements * 3 * sizeof(int));
+  getTetraFaceCenters(interface->elementIDs, interface->faceIDs, interface->numElements, sim->kon, sim->ipkon, sim->co, interface->faceCenterCoordinates);
 
+  interface->faceCentersMeshID    = precicec_getMeshID(interface->faceCentersMeshName);
+  interface->preciceFaceCenterIDs = malloc(interface->numElements * sizeof(int));
 
-	interface->faceCentersMeshID = precicec_getMeshID( interface->faceCentersMeshName );
-	interface->preciceFaceCenterIDs = malloc( interface->numElements * sizeof( int ) );
-
-	precicec_setMeshVertices( interface->faceCentersMeshID, interface->numElements, interface->faceCenterCoordinates, interface->preciceFaceCenterIDs);
-
+  precicec_setMeshVertices(interface->faceCentersMeshID, interface->numElements, interface->faceCenterCoordinates, interface->preciceFaceCenterIDs);
 }
 
-void PreciceInterface_ConfigureNodesMesh( PreciceInterface * interface, SimulationData * sim )
+void PreciceInterface_ConfigureNodesMesh(PreciceInterface *interface, SimulationData *sim)
 {
-	//printf("Entering configureNodesMesh \n");
-	char * nodeSetName = toNodeSetName( interface->name );
-	interface->nodeSetID = getSetID( nodeSetName, sim->set, sim->nset );
-	interface->numNodes = getNumSetElements( interface->nodeSetID, sim->istartset, sim->iendset );
-	interface->nodeIDs = &sim->ialset[sim->istartset[interface->nodeSetID] - 1]; //Lucia: make a copy
+  //printf("Entering configureNodesMesh \n");
+  char *nodeSetName    = toNodeSetName(interface->name);
+  interface->nodeSetID = getSetID(nodeSetName, sim->set, sim->nset);
+  interface->numNodes  = getNumSetElements(interface->nodeSetID, sim->istartset, sim->iendset);
+  interface->nodeIDs   = &sim->ialset[sim->istartset[interface->nodeSetID] - 1]; //Lucia: make a copy
 
-	interface->nodeCoordinates = malloc( interface->numNodes * interface->dimCCX * sizeof( double ) );
-	getNodeCoordinates( interface->nodeIDs, interface->numNodes, interface->dimCCX, sim->co, sim->vold, sim->mt, interface->nodeCoordinates );
+  interface->nodeCoordinates = malloc(interface->numNodes * interface->dimCCX * sizeof(double));
+  getNodeCoordinates(interface->nodeIDs, interface->numNodes, interface->dimCCX, sim->co, sim->vold, sim->mt, interface->nodeCoordinates);
 
   // Extract 2D coordinates from 3D coordinates for quasi 2D-3D coupling
-  if( isQuasi2D3D(interface->quasi2D3D) )
-  {
-    int count = 0;
-    int dim = interface->dim;
-    int dimCCX = interface->dimCCX;
-    interface->num2DNodes = interface->numNodes / 2;
-    interface->node2DCoordinates = malloc( interface->num2DNodes * dim * sizeof( double ) );
-    interface->mapping2D3D = malloc( interface->numNodes * sizeof( int ) );
-    for (int i = 0; i < interface->numNodes; i++)
-    {
+  if (isQuasi2D3D(interface->quasi2D3D)) {
+    int count                    = 0;
+    int dim                      = interface->dim;
+    int dimCCX                   = interface->dimCCX;
+    interface->num2DNodes        = interface->numNodes / 2;
+    interface->node2DCoordinates = malloc(interface->num2DNodes * dim * sizeof(double));
+    interface->mapping2D3D       = malloc(interface->numNodes * sizeof(int));
+    for (int i = 0; i < interface->numNodes; i++) {
       // Filter out nodes which are in the XY plane (Z = 0) for getting 2D mesh
-      if (isDoubleEqual(interface->nodeCoordinates[i*dimCCX + 2], 0.0))
-      {
-        interface->node2DCoordinates[count*dim] = interface->nodeCoordinates[i*dimCCX];
-        interface->node2DCoordinates[count*dim + 1] = interface->nodeCoordinates[i*dimCCX + 1];
+      if (isDoubleEqual(interface->nodeCoordinates[i * dimCCX + 2], 0.0)) {
+        interface->node2DCoordinates[count * dim]     = interface->nodeCoordinates[i * dimCCX];
+        interface->node2DCoordinates[count * dim + 1] = interface->nodeCoordinates[i * dimCCX + 1];
         count += 1;
       }
     }
-    assert (count == interface->num2DNodes && "Filtering of 2D nodes not done properly. Please make sure the out-of-plane axis is Z-axis");
+    assert(count == interface->num2DNodes && "Filtering of 2D nodes not done properly. Please make sure the out-of-plane axis is Z-axis");
 
     count = 0;
-    for (int i = 0; i < interface->numNodes; i++)
-    {
-      for (int ii = 0; ii < interface->numNodes; ii++)
-      {
+    for (int i = 0; i < interface->numNodes; i++) {
+      for (int ii = 0; ii < interface->numNodes; ii++) {
         // Compare each node with every other node to find nodes with matching X and Y coordinates
-        if (isDoubleEqual(interface->nodeCoordinates[ii*dimCCX], interface->nodeCoordinates[i*dimCCX]) &&
-            isDoubleEqual(interface->nodeCoordinates[ii*dimCCX + 1], interface->nodeCoordinates[i*dimCCX + 1]) &&
-            !isDoubleEqual(interface->nodeCoordinates[ii*dimCCX + 2], interface->nodeCoordinates[i*dimCCX + 2]))
-        {
-          if ( !isDoubleEqual(interface->nodeCoordinates[i*dimCCX + 2], 0.0) )
-          {
-            interface->mapping2D3D[i] = count;
+        if (isDoubleEqual(interface->nodeCoordinates[ii * dimCCX], interface->nodeCoordinates[i * dimCCX]) &&
+            isDoubleEqual(interface->nodeCoordinates[ii * dimCCX + 1], interface->nodeCoordinates[i * dimCCX + 1]) &&
+            !isDoubleEqual(interface->nodeCoordinates[ii * dimCCX + 2], interface->nodeCoordinates[i * dimCCX + 2])) {
+          if (!isDoubleEqual(interface->nodeCoordinates[i * dimCCX + 2], 0.0)) {
+            interface->mapping2D3D[i]  = count;
             interface->mapping2D3D[ii] = count;
             count += 1;
           }
@@ -590,296 +541,254 @@ void PreciceInterface_ConfigureNodesMesh( PreciceInterface * interface, Simulati
     }
   }
 
-	if( interface->nodesMeshName != NULL )
-	{
-		//printf("nodesMeshName is not null \n");
-		interface->nodesMeshID = precicec_getMeshID( interface->nodesMeshName );
-    if ( isQuasi2D3D(interface->quasi2D3D) )
-    {
-      interface->preciceNodeIDs = malloc( interface->num2DNodes * sizeof( int ) );
-      precicec_setMeshVertices( interface->nodesMeshID, interface->num2DNodes, interface->node2DCoordinates, interface->preciceNodeIDs );
+  if (interface->nodesMeshName != NULL) {
+    //printf("nodesMeshName is not null \n");
+    interface->nodesMeshID = precicec_getMeshID(interface->nodesMeshName);
+    if (isQuasi2D3D(interface->quasi2D3D)) {
+      interface->preciceNodeIDs = malloc(interface->num2DNodes * sizeof(int));
+      precicec_setMeshVertices(interface->nodesMeshID, interface->num2DNodes, interface->node2DCoordinates, interface->preciceNodeIDs);
+    } else {
+      interface->preciceNodeIDs = malloc(interface->numNodes * sizeof(int));
+      precicec_setMeshVertices(interface->nodesMeshID, interface->numNodes, interface->nodeCoordinates, interface->preciceNodeIDs);
     }
-    else
-    {
-      interface->preciceNodeIDs = malloc( interface->numNodes * sizeof( int ) );
-      precicec_setMeshVertices( interface->nodesMeshID, interface->numNodes, interface->nodeCoordinates, interface->preciceNodeIDs );
+  }
+
+  if (interface->mapNPType == 1) {
+    assert(!interface->quasi2D3D && "Quasi 2D - 3D configuration does not work for nearest-projection mapping");
+    PreciceInterface_NodeConnectivity(interface, sim);
+  }
+}
+
+void PreciceInterface_NodeConnectivity(PreciceInterface *interface, SimulationData *sim)
+{
+  int   numElements;
+  char *faceSetName                = toFaceSetName(interface->name);
+  interface->faceSetID             = getSetID(faceSetName, sim->set, sim->nset);
+  numElements                      = getNumSetElements(interface->faceSetID, sim->istartset, sim->iendset);
+  interface->elementIDs            = malloc(numElements * sizeof(ITG));
+  interface->faceIDs               = malloc(numElements * sizeof(ITG));
+  interface->faceCenterCoordinates = malloc(numElements * 3 * sizeof(double));
+  getSurfaceElementsAndFaces(interface->faceSetID, sim->ialset, sim->istartset, sim->iendset, interface->elementIDs, interface->faceIDs);
+  interface->numElements = numElements;
+  PreciceInterface_ConfigureTetraFaces(interface, sim);
+}
+
+void PreciceInterface_EnsureValidNodesMeshID(PreciceInterface *interface)
+{
+  if (interface->nodesMeshID < 0) {
+    printf("Nodes mesh not provided in YAML config file\n");
+    fflush(stdout);
+    exit(EXIT_FAILURE);
+  }
+}
+
+void PreciceInterface_ConfigureTetraFaces(PreciceInterface *interface, SimulationData *sim)
+{
+  int i;
+  printf("Setting node connectivity for nearest projection mapping: \n");
+  if (interface->nodesMeshName != NULL) {
+    int *triangles = malloc(interface->numElements * 3 * sizeof(ITG));
+    getTetraFaceNodes(interface->elementIDs, interface->faceIDs, interface->nodeIDs, interface->numElements, interface->numNodes, sim->kon, sim->ipkon, triangles);
+
+    for (i = 0; i < interface->numElements; i++) {
+      precicec_setMeshTriangleWithEdges(interface->nodesMeshID, triangles[3 * i], triangles[3 * i + 1], triangles[3 * i + 2]);
     }
-	}
-
-	if (interface->mapNPType == 1)
-	{
-    assert ( !interface->quasi2D3D && "Quasi 2D - 3D configuration does not work for nearest-projection mapping");
-		PreciceInterface_NodeConnectivity( interface, sim );
-	}
+    free(triangles);
+  }
 }
 
-void PreciceInterface_NodeConnectivity( PreciceInterface * interface, SimulationData * sim )
+void PreciceInterface_ConfigureCouplingData(PreciceInterface *interface, SimulationData *sim, InterfaceConfig const *config)
 {
-	int numElements;
-	char * faceSetName = toFaceSetName( interface->name );
-	interface->faceSetID = getSetID( faceSetName, sim->set, sim->nset );
-	numElements = getNumSetElements( interface->faceSetID, sim->istartset, sim->iendset );
-	interface->elementIDs = malloc( numElements * sizeof( ITG ) );
-	interface->faceIDs = malloc( numElements * sizeof( ITG ) );
-	interface->faceCenterCoordinates = malloc( numElements * 3 * sizeof( double ) );
-	getSurfaceElementsAndFaces( interface->faceSetID, sim->ialset, sim->istartset, sim->iendset, interface->elementIDs, interface->faceIDs );
-	interface->numElements = numElements;
-	PreciceInterface_ConfigureTetraFaces( interface, sim );
-}
+  interface->nodeScalarData = malloc(interface->numNodes * sizeof(double));
+  interface->nodeVectorData = malloc(interface->numNodes * 3 * sizeof(double));
 
-void PreciceInterface_EnsureValidNodesMeshID( PreciceInterface * interface )
-{
-	if( interface->nodesMeshID < 0 )
-	{
-		printf( "Nodes mesh not provided in YAML config file\n" );
-		fflush( stdout );
-		exit( EXIT_FAILURE );
-	}
-}
-
-void PreciceInterface_ConfigureTetraFaces( PreciceInterface * interface, SimulationData * sim )
-{
-	int i;
-	printf("Setting node connectivity for nearest projection mapping: \n");
-	if( interface->nodesMeshName != NULL )
-	{
-		int * triangles = malloc( interface->numElements * 3 * sizeof( ITG ) );
-		getTetraFaceNodes( interface->elementIDs, interface->faceIDs,  interface->nodeIDs, interface->numElements, interface->numNodes, sim->kon, sim->ipkon, triangles);
-
-		for( i = 0 ; i < interface->numElements ; i++ )
-		{
-			precicec_setMeshTriangleWithEdges( interface->nodesMeshID, triangles[3*i], triangles[3*i+1], triangles[3*i+2] );
-		}
-    free( triangles );
-	}
-}
-
-void PreciceInterface_ConfigureCouplingData( PreciceInterface * interface, SimulationData * sim, InterfaceConfig const * config )
-{
-	interface->nodeScalarData = malloc( interface->numNodes * sizeof( double ) );
-  interface->nodeVectorData = malloc( interface->numNodes * 3 * sizeof( double ) );
-
-  if ( isQuasi2D3D(interface->quasi2D3D) )
-  {
-    interface->node2DScalarData = malloc( interface->num2DNodes * sizeof( double ));
-    interface->node2DVectorData = malloc( interface->num2DNodes * 2 * sizeof( double ) );
+  if (isQuasi2D3D(interface->quasi2D3D)) {
+    interface->node2DScalarData = malloc(interface->num2DNodes * sizeof(double));
+    interface->node2DVectorData = malloc(interface->num2DNodes * 2 * sizeof(double));
 
     int dim = interface->dim;
-    for (int i = 0; i < interface->num2DNodes; i++)
-    {
-      interface->node2DScalarData[i] = 0.0;
-      interface->node2DVectorData[i*dim] = 0.0;
-      interface->node2DVectorData[i*dim + 1] = 0.0;
+    for (int i = 0; i < interface->num2DNodes; i++) {
+      interface->node2DScalarData[i]           = 0.0;
+      interface->node2DVectorData[i * dim]     = 0.0;
+      interface->node2DVectorData[i * dim + 1] = 0.0;
     }
   }
 
-	interface->faceCenterData = malloc( interface->numElements * sizeof( double ) );
+  interface->faceCenterData = malloc(interface->numElements * sizeof(double));
 
-	int i;
+  int i;
   interface->numReadData = config->numReadData;
-  if (config->numReadData > 0) interface->readData = malloc( config->numReadData * sizeof( int ) );
-	for( i = 0 ; i < config->numReadData ; i++ )
-	{
-		if ( isEqual( config->readDataNames[i], "Temperature" ) )
-		{
-			PreciceInterface_EnsureValidNodesMeshID( interface );
-			interface->readData[i] = TEMPERATURE;
-			interface->xbounIndices = malloc( interface->numNodes * sizeof( int ) );
-			interface->temperatureDataID = precicec_getDataID( "Temperature", interface->nodesMeshID );
-			getXbounIndices( interface->nodeIDs, interface->numNodes, sim->nboun, sim->ikboun, sim->ilboun, interface->xbounIndices, TEMPERATURE );
-			printf( "Read data '%s' found with ID # '%d'.\n", config->readDataNames[i], interface->temperatureDataID);
-		}
-		else if ( isEqual( config->readDataNames[i], "Heat-Flux" ) )
-		{
-			interface->readData[i] = HEAT_FLUX;
-			interface->xloadIndices = malloc( interface->numElements * sizeof( int ) );
-			getXloadIndices( "DFLUX", interface->elementIDs, interface->faceIDs, interface->numElements, sim->nload, sim->nelemload, sim->sideload, interface->xloadIndices );
-			interface->fluxDataID = precicec_getDataID( "Heat-Flux", interface->faceCentersMeshID );
-			printf( "Read data '%s' found with ID # '%d'.\n", config->readDataNames[i],interface->fluxDataID );
-		}
-		else if ( startsWith( config->readDataNames[i], "Sink-Temperature-" ) )
-		{
-			interface->readData[i] = SINK_TEMPERATURE;
-			interface->xloadIndices = malloc( interface->numElements * sizeof( int ) );
-			getXloadIndices( "FILM", interface->elementIDs, interface->faceIDs, interface->numElements, sim->nload, sim->nelemload, sim->sideload, interface->xloadIndices );
-			interface->kDeltaTemperatureReadDataID = precicec_getDataID( config->readDataNames[i], interface->faceCentersMeshID );
-			printf( "Read data '%s' found with ID # '%d'.\n", config->readDataNames[i], interface->kDeltaTemperatureReadDataID);
-		}
-		else if ( startsWith( config->readDataNames[i], "Heat-Transfer-Coefficient-" ) )
-		{
-			interface->readData[i] = HEAT_TRANSFER_COEFF;
-			interface->kDeltaReadDataID = precicec_getDataID( config->readDataNames[i], interface->faceCentersMeshID );
-			printf( "Read data '%s' found with ID # '%d'.\n", config->readDataNames[i],interface->kDeltaReadDataID );
-		}
-    else if ( startsWith( config->readDataNames[i], "Force" ) )
-		{
-			PreciceInterface_EnsureValidNodesMeshID( interface );
-			interface->readData[i] = FORCES;
-      interface->xforcIndices = malloc( interface->numNodes * 3 * sizeof( int ) );
-			interface->forcesDataID = precicec_getDataID( config->readDataNames[i], interface->nodesMeshID );
-			getXforcIndices( interface->nodeIDs, interface->numNodes, sim->nforc, sim->ikforc, sim->ilforc, interface->xforcIndices );
-			printf( "Read data '%s' found with ID # '%d'.\n", config->readDataNames[i],interface->forcesDataID );
-		}
-    else if ( startsWith( config->readDataNames[i], "Displacement" ) )
-		{
-			PreciceInterface_EnsureValidNodesMeshID( interface );
-			interface->readData[i] = DISPLACEMENTS;
-			interface->xbounIndices = malloc( interface->numNodes * 3 * sizeof( int ) );
-			interface->displacementsDataID = precicec_getDataID( config->readDataNames[i], interface->nodesMeshID );
-			getXbounIndices( interface->nodeIDs, interface->numNodes, sim->nboun, sim->ikboun, sim->ilboun, interface->xbounIndices, DISPLACEMENTS );
-			printf( "Read data '%s' found with ID # '%d'.\n", config->readDataNames[i], interface->displacementsDataID );
-		}
-		else
-		{
-			printf( "ERROR: Read data '%s' does not exist!\n", config->readDataNames[i] );
-			exit( EXIT_FAILURE );
-		}
-	}
+  if (config->numReadData > 0)
+    interface->readData = malloc(config->numReadData * sizeof(int));
+  for (i = 0; i < config->numReadData; i++) {
+    if (isEqual(config->readDataNames[i], "Temperature")) {
+      PreciceInterface_EnsureValidNodesMeshID(interface);
+      interface->readData[i]       = TEMPERATURE;
+      interface->xbounIndices      = malloc(interface->numNodes * sizeof(int));
+      interface->temperatureDataID = precicec_getDataID("Temperature", interface->nodesMeshID);
+      getXbounIndices(interface->nodeIDs, interface->numNodes, sim->nboun, sim->ikboun, sim->ilboun, interface->xbounIndices, TEMPERATURE);
+      printf("Read data '%s' found with ID # '%d'.\n", config->readDataNames[i], interface->temperatureDataID);
+    } else if (isEqual(config->readDataNames[i], "Heat-Flux")) {
+      interface->readData[i]  = HEAT_FLUX;
+      interface->xloadIndices = malloc(interface->numElements * sizeof(int));
+      getXloadIndices("DFLUX", interface->elementIDs, interface->faceIDs, interface->numElements, sim->nload, sim->nelemload, sim->sideload, interface->xloadIndices);
+      interface->fluxDataID = precicec_getDataID("Heat-Flux", interface->faceCentersMeshID);
+      printf("Read data '%s' found with ID # '%d'.\n", config->readDataNames[i], interface->fluxDataID);
+    } else if (startsWith(config->readDataNames[i], "Sink-Temperature-")) {
+      interface->readData[i]  = SINK_TEMPERATURE;
+      interface->xloadIndices = malloc(interface->numElements * sizeof(int));
+      getXloadIndices("FILM", interface->elementIDs, interface->faceIDs, interface->numElements, sim->nload, sim->nelemload, sim->sideload, interface->xloadIndices);
+      interface->kDeltaTemperatureReadDataID = precicec_getDataID(config->readDataNames[i], interface->faceCentersMeshID);
+      printf("Read data '%s' found with ID # '%d'.\n", config->readDataNames[i], interface->kDeltaTemperatureReadDataID);
+    } else if (startsWith(config->readDataNames[i], "Heat-Transfer-Coefficient-")) {
+      interface->readData[i]      = HEAT_TRANSFER_COEFF;
+      interface->kDeltaReadDataID = precicec_getDataID(config->readDataNames[i], interface->faceCentersMeshID);
+      printf("Read data '%s' found with ID # '%d'.\n", config->readDataNames[i], interface->kDeltaReadDataID);
+    } else if (startsWith(config->readDataNames[i], "Force")) {
+      PreciceInterface_EnsureValidNodesMeshID(interface);
+      interface->readData[i]  = FORCES;
+      interface->xforcIndices = malloc(interface->numNodes * 3 * sizeof(int));
+      interface->forcesDataID = precicec_getDataID(config->readDataNames[i], interface->nodesMeshID);
+      getXforcIndices(interface->nodeIDs, interface->numNodes, sim->nforc, sim->ikforc, sim->ilforc, interface->xforcIndices);
+      printf("Read data '%s' found with ID # '%d'.\n", config->readDataNames[i], interface->forcesDataID);
+    } else if (startsWith(config->readDataNames[i], "Displacement")) {
+      PreciceInterface_EnsureValidNodesMeshID(interface);
+      interface->readData[i]         = DISPLACEMENTS;
+      interface->xbounIndices        = malloc(interface->numNodes * 3 * sizeof(int));
+      interface->displacementsDataID = precicec_getDataID(config->readDataNames[i], interface->nodesMeshID);
+      getXbounIndices(interface->nodeIDs, interface->numNodes, sim->nboun, sim->ikboun, sim->ilboun, interface->xbounIndices, DISPLACEMENTS);
+      printf("Read data '%s' found with ID # '%d'.\n", config->readDataNames[i], interface->displacementsDataID);
+    } else {
+      printf("ERROR: Read data '%s' does not exist!\n", config->readDataNames[i]);
+      exit(EXIT_FAILURE);
+    }
+  }
 
   interface->numWriteData = config->numWriteData;
-  if (config->numWriteData > 0) interface->writeData = malloc( config->numWriteData * sizeof( int ) );
+  if (config->numWriteData > 0)
+    interface->writeData = malloc(config->numWriteData * sizeof(int));
 
-	for( i = 0 ; i < config->numWriteData ; i++ )
-	{
-		if ( isEqual( config->writeDataNames[i], "Temperature" ) )
-		{
-			PreciceInterface_EnsureValidNodesMeshID( interface );
-			interface->writeData[i] = TEMPERATURE;
-			interface->temperatureDataID = precicec_getDataID( "Temperature", interface->nodesMeshID );
-			printf( "Write data '%s' found with ID # '%d'.\n", config->writeDataNames[i],interface->temperatureDataID );
-		}
-		else if ( isEqual( config->writeDataNames[i], "Heat-Flux" ) )
-		{
-			interface->writeData[i] = HEAT_FLUX;
-			interface->fluxDataID = precicec_getDataID( "Heat-Flux", interface->faceCentersMeshID );
-			printf( "Write data '%s' found with ID # '%d'.\n", config->writeDataNames[i],interface->fluxDataID );
-		}
-		else if ( startsWith( config->writeDataNames[i], "Sink-Temperature-" ) )
-		{
-			interface->writeData[i] = SINK_TEMPERATURE;
-			interface->kDeltaTemperatureWriteDataID = precicec_getDataID( config->writeDataNames[i], interface->faceCentersMeshID );
-			printf( "Write data '%s' found with ID # '%d'.\n", config->writeDataNames[i],interface->kDeltaTemperatureWriteDataID );
-		}
-		else if ( startsWith( config->writeDataNames[i], "Heat-Transfer-Coefficient-" ) )
-		{
-			interface->writeData[i] = HEAT_TRANSFER_COEFF;
-			interface->kDeltaWriteDataID = precicec_getDataID( config->writeDataNames[i], interface->faceCentersMeshID );
-			printf( "Write data '%s' found with ID # '%d'.\n", config->writeDataNames[i],interface->kDeltaWriteDataID );
-		}
-    else if ( startsWith( config->writeDataNames[i], "DisplacementDelta" ) )
-    {
-      PreciceInterface_EnsureValidNodesMeshID( interface );
-      interface->writeData[i] = DISPLACEMENTDELTAS;
-      interface->displacementDeltasDataID = precicec_getDataID( config->writeDataNames[i], interface->nodesMeshID );
-      printf( "Write data '%s' found with ID # '%d'.\n", config->writeDataNames[i],interface->displacementDeltasDataID );
+  for (i = 0; i < config->numWriteData; i++) {
+    if (isEqual(config->writeDataNames[i], "Temperature")) {
+      PreciceInterface_EnsureValidNodesMeshID(interface);
+      interface->writeData[i]      = TEMPERATURE;
+      interface->temperatureDataID = precicec_getDataID("Temperature", interface->nodesMeshID);
+      printf("Write data '%s' found with ID # '%d'.\n", config->writeDataNames[i], interface->temperatureDataID);
+    } else if (isEqual(config->writeDataNames[i], "Heat-Flux")) {
+      interface->writeData[i] = HEAT_FLUX;
+      interface->fluxDataID   = precicec_getDataID("Heat-Flux", interface->faceCentersMeshID);
+      printf("Write data '%s' found with ID # '%d'.\n", config->writeDataNames[i], interface->fluxDataID);
+    } else if (startsWith(config->writeDataNames[i], "Sink-Temperature-")) {
+      interface->writeData[i]                 = SINK_TEMPERATURE;
+      interface->kDeltaTemperatureWriteDataID = precicec_getDataID(config->writeDataNames[i], interface->faceCentersMeshID);
+      printf("Write data '%s' found with ID # '%d'.\n", config->writeDataNames[i], interface->kDeltaTemperatureWriteDataID);
+    } else if (startsWith(config->writeDataNames[i], "Heat-Transfer-Coefficient-")) {
+      interface->writeData[i]      = HEAT_TRANSFER_COEFF;
+      interface->kDeltaWriteDataID = precicec_getDataID(config->writeDataNames[i], interface->faceCentersMeshID);
+      printf("Write data '%s' found with ID # '%d'.\n", config->writeDataNames[i], interface->kDeltaWriteDataID);
+    } else if (startsWith(config->writeDataNames[i], "DisplacementDelta")) {
+      PreciceInterface_EnsureValidNodesMeshID(interface);
+      interface->writeData[i]             = DISPLACEMENTDELTAS;
+      interface->displacementDeltasDataID = precicec_getDataID(config->writeDataNames[i], interface->nodesMeshID);
+      printf("Write data '%s' found with ID # '%d'.\n", config->writeDataNames[i], interface->displacementDeltasDataID);
+    } else if (startsWith(config->writeDataNames[i], "Displacement")) {
+      PreciceInterface_EnsureValidNodesMeshID(interface);
+      interface->writeData[i]        = DISPLACEMENTS;
+      interface->displacementsDataID = precicec_getDataID(config->writeDataNames[i], interface->nodesMeshID);
+      printf("Write data '%s' found with ID # '%d'.\n", config->writeDataNames[i], interface->displacementsDataID);
+    } else if (startsWith(config->writeDataNames[i], "Position")) {
+      PreciceInterface_EnsureValidNodesMeshID(interface);
+      interface->writeData[i]    = POSITIONS;
+      interface->positionsDataID = precicec_getDataID(config->writeDataNames[i], interface->nodesMeshID);
+      printf("Write data '%s' found with ID # '%d'.\n", config->writeDataNames[i], interface->positionsDataID);
+    } else if (startsWith(config->writeDataNames[i], "Velocit")) {
+      PreciceInterface_EnsureValidNodesMeshID(interface);
+      interface->writeData[i]     = VELOCITIES;
+      interface->velocitiesDataID = precicec_getDataID(config->writeDataNames[i], interface->nodesMeshID);
+      printf("Write data '%s' found with ID # '%d'.\n", config->writeDataNames[i], interface->velocitiesDataID);
+    } else if (startsWith(config->writeDataNames[i], "Force")) {
+      PreciceInterface_EnsureValidNodesMeshID(interface);
+      interface->writeData[i] = FORCES;
+      interface->forcesDataID = precicec_getDataID(config->writeDataNames[i], interface->nodesMeshID);
+      printf("Write data '%s' found with ID # '%d'.\n", config->writeDataNames[i], interface->forcesDataID);
+    } else {
+      printf("ERROR: Write data '%s' does not exist!\n", config->writeDataNames[i]);
+      exit(EXIT_FAILURE);
     }
-    else if ( startsWith( config->writeDataNames[i], "Displacement" ) )
-		{
-			PreciceInterface_EnsureValidNodesMeshID( interface );
-			interface->writeData[i] = DISPLACEMENTS;
-			interface->displacementsDataID = precicec_getDataID( config->writeDataNames[i], interface->nodesMeshID );
-			printf( "Write data '%s' found with ID # '%d'.\n", config->writeDataNames[i],interface->displacementsDataID );
-		}
-    else if ( startsWith( config->writeDataNames[i], "Position" ) )
-		{
-			PreciceInterface_EnsureValidNodesMeshID( interface );
-			interface->writeData[i] = POSITIONS;
-			interface->positionsDataID = precicec_getDataID( config->writeDataNames[i], interface->nodesMeshID );
-			printf( "Write data '%s' found with ID # '%d'.\n", config->writeDataNames[i],interface->positionsDataID );
-		}
-    else if ( startsWith( config->writeDataNames[i], "Velocit" ) )
-		{
-			PreciceInterface_EnsureValidNodesMeshID( interface );
-			interface->writeData[i] = VELOCITIES;
-			interface->velocitiesDataID = precicec_getDataID( config->writeDataNames[i], interface->nodesMeshID );
-			printf( "Write data '%s' found with ID # '%d'.\n", config->writeDataNames[i],interface->velocitiesDataID );
-		}
-    else if ( startsWith( config->writeDataNames[i], "Force" ) )
-		{
-			PreciceInterface_EnsureValidNodesMeshID( interface );
-			interface->writeData[i] = FORCES;
-			interface->forcesDataID = precicec_getDataID( config->writeDataNames[i], interface->nodesMeshID );
-			printf( "Write data '%s' found with ID # '%d'.\n", config->writeDataNames[i],interface->forcesDataID );
-		}
-		else
-		{
-			printf( "ERROR: Write data '%s' does not exist!\n", config->writeDataNames[i] );
-			exit( EXIT_FAILURE );
-		}
-	}
+  }
 }
 
-void PreciceInterface_FreeData( PreciceInterface * preciceInterface )
+void PreciceInterface_FreeData(PreciceInterface *preciceInterface)
 {
-	if( preciceInterface->readData != NULL ){
-		free( preciceInterface->readData );
-	}
-
-	if( preciceInterface->writeData != NULL ){
-		free( preciceInterface->writeData );
-	}
-
-	if( preciceInterface->elementIDs != NULL ){
-		free( preciceInterface->elementIDs );
-	}
-
-	if( preciceInterface->faceIDs != NULL ){
-		free( preciceInterface->faceIDs );
-	}
-
-	if( preciceInterface->faceCenterCoordinates != NULL ){
-		free( preciceInterface->faceCenterCoordinates );
-	}
-
-	if( preciceInterface->preciceFaceCenterIDs != NULL ){
-		free( preciceInterface->preciceFaceCenterIDs );
-	}
-
-	if( preciceInterface->nodeCoordinates != NULL ){
-		free( preciceInterface->nodeCoordinates );
-	}
-
-  if( preciceInterface->node2DCoordinates != NULL ){
-    free( preciceInterface->node2DCoordinates );
+  if (preciceInterface->readData != NULL) {
+    free(preciceInterface->readData);
   }
 
-	if( preciceInterface->preciceNodeIDs != NULL ){
-		free( preciceInterface->preciceNodeIDs );
-	}
+  if (preciceInterface->writeData != NULL) {
+    free(preciceInterface->writeData);
+  }
 
-	if( preciceInterface->nodeScalarData != NULL ){
-		free( preciceInterface->nodeScalarData );
-	}
+  if (preciceInterface->elementIDs != NULL) {
+    free(preciceInterface->elementIDs);
+  }
 
-  if( preciceInterface->node2DScalarData != NULL ){
-		free( preciceInterface->node2DScalarData );
-	}
+  if (preciceInterface->faceIDs != NULL) {
+    free(preciceInterface->faceIDs);
+  }
 
-	if( preciceInterface->nodeVectorData != NULL ){
-		free( preciceInterface->nodeVectorData );
-	}
+  if (preciceInterface->faceCenterCoordinates != NULL) {
+    free(preciceInterface->faceCenterCoordinates);
+  }
 
-  if( preciceInterface->node2DVectorData != NULL ){
-		free( preciceInterface->node2DVectorData );
-	}
+  if (preciceInterface->preciceFaceCenterIDs != NULL) {
+    free(preciceInterface->preciceFaceCenterIDs);
+  }
 
-	if( preciceInterface->faceCenterData != NULL ){
-		free( preciceInterface->faceCenterData );
-	}
+  if (preciceInterface->nodeCoordinates != NULL) {
+    free(preciceInterface->nodeCoordinates);
+  }
 
-	if( preciceInterface->xbounIndices != NULL ){
-		free( preciceInterface->xbounIndices );
-	}
+  if (preciceInterface->node2DCoordinates != NULL) {
+    free(preciceInterface->node2DCoordinates);
+  }
 
-	if( preciceInterface->xloadIndices != NULL ){
-		free( preciceInterface->xloadIndices );
-	}
+  if (preciceInterface->preciceNodeIDs != NULL) {
+    free(preciceInterface->preciceNodeIDs);
+  }
 
-	if ( preciceInterface->xforcIndices != NULL ){
-		free( preciceInterface->xforcIndices );
-	}
+  if (preciceInterface->nodeScalarData != NULL) {
+    free(preciceInterface->nodeScalarData);
+  }
 
-  if ( preciceInterface->mapping2D3D != NULL){
-    free( preciceInterface->mapping2D3D);
+  if (preciceInterface->node2DScalarData != NULL) {
+    free(preciceInterface->node2DScalarData);
+  }
+
+  if (preciceInterface->nodeVectorData != NULL) {
+    free(preciceInterface->nodeVectorData);
+  }
+
+  if (preciceInterface->node2DVectorData != NULL) {
+    free(preciceInterface->node2DVectorData);
+  }
+
+  if (preciceInterface->faceCenterData != NULL) {
+    free(preciceInterface->faceCenterData);
+  }
+
+  if (preciceInterface->xbounIndices != NULL) {
+    free(preciceInterface->xbounIndices);
+  }
+
+  if (preciceInterface->xloadIndices != NULL) {
+    free(preciceInterface->xloadIndices);
+  }
+
+  if (preciceInterface->xforcIndices != NULL) {
+    free(preciceInterface->xforcIndices);
+  }
+
+  if (preciceInterface->mapping2D3D != NULL) {
+    free(preciceInterface->mapping2D3D);
   }
 }

--- a/adapter/PreciceInterface.h
+++ b/adapter/PreciceInterface.h
@@ -11,8 +11,8 @@
 #define PRECICEINTERFACE_H
 
 #include <string.h>
-#include "ConfigReader.h"
 #include "CCXHelpers.h"
+#include "ConfigReader.h"
 
 /*
  * PreciceInterface: Structure with all the information of a coupled surface
@@ -20,67 +20,67 @@
  */
 typedef struct PreciceInterface {
 
-	char * name;
-	int dim; // Dimension received from preCICE configuration
-	int dimCCX; // Dimension as seen by CalculiX
+  char *name;
+  int   dim;    // Dimension received from preCICE configuration
+  int   dimCCX; // Dimension as seen by CalculiX
 
-	// Interface nodes
-	int numNodes;
-	int num2DNodes; // Nodes in a single plane in case of quasi 2D-3D coupling
-	int * nodeIDs;
-	int * mapping2D3D; // Node IDs to filter out 2D place in quasi 2D-3D coupling
-	double * nodeCoordinates;
-	double * node2DCoordinates; // 2D coordinates for quasi 2D-3D coupling
-	int nodeSetID;
-	int * preciceNodeIDs;
-	int nodesMeshID;
-	char * nodesMeshName;
+  // Interface nodes
+  int     numNodes;
+  int     num2DNodes; // Nodes in a single plane in case of quasi 2D-3D coupling
+  int *   nodeIDs;
+  int *   mapping2D3D; // Node IDs to filter out 2D place in quasi 2D-3D coupling
+  double *nodeCoordinates;
+  double *node2DCoordinates; // 2D coordinates for quasi 2D-3D coupling
+  int     nodeSetID;
+  int *   preciceNodeIDs;
+  int     nodesMeshID;
+  char *  nodesMeshName;
 
-	// Interface face elements
-	int numElements;
-	int * elementIDs;
-	int * faceIDs;
-	double * faceCenterCoordinates;
-	int faceSetID;
-	int faceCentersMeshID;
-	char * faceCentersMeshName;
-	int * preciceFaceCenterIDs;
+  // Interface face elements
+  int     numElements;
+  int *   elementIDs;
+  int *   faceIDs;
+  double *faceCenterCoordinates;
+  int     faceSetID;
+  int     faceCentersMeshID;
+  char *  faceCentersMeshName;
+  int *   preciceFaceCenterIDs;
 
-	// Arrays to store the coupling data
-	double * nodeScalarData;
-	double * node2DScalarData; // Scalar quantities in 2D in case quasi 2D-3D coupling is done
-	double * nodeVectorData; // Forces, displacements, velocities, positions and displacementDeltas are vector quantities
-	double * node2DVectorData; // Vector quantities in 2D in case quasi 2D-3D coupling is done
-	double * faceCenterData;
+  // Arrays to store the coupling data
+  double *nodeScalarData;
+  double *node2DScalarData; // Scalar quantities in 2D in case quasi 2D-3D coupling is done
+  double *nodeVectorData;   // Forces, displacements, velocities, positions and displacementDeltas are vector quantities
+  double *node2DVectorData; // Vector quantities in 2D in case quasi 2D-3D coupling is done
+  double *faceCenterData;
 
-	// preCICE Data IDs
-	int temperatureDataID;
-	int fluxDataID;
-	int kDeltaWriteDataID;
-	int kDeltaTemperatureWriteDataID;
-	int kDeltaReadDataID;
-	int kDeltaTemperatureReadDataID;
-	int displacementsDataID; //New data ID for displacements
-	int displacementDeltasDataID; //New data ID for displacementDeltas
-	int positionsDataID; //New data ID for positions
-	int velocitiesDataID; //New data ID for velocities
-	int forcesDataID; //New data ID for forces
+  // preCICE Data IDs
+  int temperatureDataID;
+  int fluxDataID;
+  int kDeltaWriteDataID;
+  int kDeltaTemperatureWriteDataID;
+  int kDeltaReadDataID;
+  int kDeltaTemperatureReadDataID;
+  int displacementsDataID;      //New data ID for displacements
+  int displacementDeltasDataID; //New data ID for displacementDeltas
+  int positionsDataID;          //New data ID for positions
+  int velocitiesDataID;         //New data ID for velocities
+  int forcesDataID;             //New data ID for forces
 
-	// Indices that indicate where to apply the boundary conditions / forces
-	int * xloadIndices;
-	int * xbounIndices;
-	int * xforcIndices;
+  // Indices that indicate where to apply the boundary conditions / forces
+  int *xloadIndices;
+  int *xbounIndices;
+  int *xforcIndices;
 
-	// Mapping type if nearest-projection mapping
-	int mapNPType;
+  // Mapping type if nearest-projection mapping
+  int mapNPType;
 
-	// Indicates if pseudo 2D-3D coupling is implemented
-	int quasi2D3D;
+  // Indicates if pseudo 2D-3D coupling is implemented
+  int quasi2D3D;
 
-	int numReadData;
-	int numWriteData;
-	enum CouplingDataType *readData;
-	enum CouplingDataType *writeData;
+  int                    numReadData;
+  int                    numWriteData;
+  enum CouplingDataType *readData;
+  enum CouplingDataType *writeData;
 
 } PreciceInterface;
 
@@ -92,57 +92,55 @@ typedef struct PreciceInterface {
  */
 typedef struct SimulationData {
 
-	// CalculiX data
-	ITG * ialset;
-	ITG * ielmat;
-	ITG * istartset;
-	ITG * iendset;
-	char ** lakon;
-	ITG * kon;
-	ITG * ipkon;
-	ITG nset;
-	char * set;
-	double * co;
-	ITG nboun;
-	ITG nforc; //total number of forces
-	ITG * ikboun;
-	ITG * ikforc; //the DoFs are all stored here in an array in numerical order
-	ITG * ilboun;
-	ITG * ilforc; //number of the force is stored here
-	ITG * nelemload;
-	int nload;
-	char * sideload;
-	double nk;
-	ITG mt;
-	double * theta;
-	double * dtheta;
-	double * tper;
-	ITG * nmethod;
-	double * xload;
-	double * xforc; //scalar value of the force in one direction
-	double * xboun;
-	ITG * ntmat_;
-	double * vold;
-	double * veold;
-	double * fn;//values of forces read from calculix
-	double * cocon;
-	ITG * ncocon;
-	ITG * mi;
+  // CalculiX data
+  ITG *   ialset;
+  ITG *   ielmat;
+  ITG *   istartset;
+  ITG *   iendset;
+  char ** lakon;
+  ITG *   kon;
+  ITG *   ipkon;
+  ITG     nset;
+  char *  set;
+  double *co;
+  ITG     nboun;
+  ITG     nforc; //total number of forces
+  ITG *   ikboun;
+  ITG *   ikforc; //the DoFs are all stored here in an array in numerical order
+  ITG *   ilboun;
+  ITG *   ilforc; //number of the force is stored here
+  ITG *   nelemload;
+  int     nload;
+  char *  sideload;
+  double  nk;
+  ITG     mt;
+  double *theta;
+  double *dtheta;
+  double *tper;
+  ITG *   nmethod;
+  double *xload;
+  double *xforc; //scalar value of the force in one direction
+  double *xboun;
+  ITG *   ntmat_;
+  double *vold;
+  double *veold;
+  double *fn; //values of forces read from calculix
+  double *cocon;
+  ITG *   ncocon;
+  ITG *   mi;
 
-	// Interfaces
-	int numPreciceInterfaces;
-	PreciceInterface ** preciceInterfaces;
+  // Interfaces
+  int                numPreciceInterfaces;
+  PreciceInterface **preciceInterfaces;
 
-	// Coupling data
-	double * coupling_init_v;
-	double coupling_init_theta;
-	double coupling_init_dtheta;
-	double precice_dt;
-	double solver_dt;
+  // Coupling data
+  double *coupling_init_v;
+  double  coupling_init_theta;
+  double  coupling_init_dtheta;
+  double  precice_dt;
+  double  solver_dt;
 
 } SimulationData;
-
-
 
 /**
  * @brief Configures and initializes preCICE and the interfaces
@@ -152,7 +150,7 @@ typedef struct SimulationData {
  * @param preciceInterfaces
  * @param numPreciceInterfaces
  */
-void Precice_Setup( char * configFilename, char * participantName, SimulationData * sim );
+void Precice_Setup(char *configFilename, char *participantName, SimulationData *sim);
 
 /**
  * @brief Initializes the coupling data (does an initial exchange) if necessary
@@ -160,19 +158,19 @@ void Precice_Setup( char * configFilename, char * participantName, SimulationDat
  * @param preciceInterfaces
  * @param numInterfaces
  */
-void Precice_InitializeData( SimulationData * sim );
+void Precice_InitializeData(SimulationData *sim);
 
 /**
  * @brief Adjusts the solver time step based on the coupling time step and the solver time step
  * @param sim
  */
-void Precice_AdjustSolverTimestep( SimulationData * sim );
+void Precice_AdjustSolverTimestep(SimulationData *sim);
 
 /**
  * @brief Advances the coupling
  * @param sim
  */
-void Precice_Advance( SimulationData * sim );
+void Precice_Advance(SimulationData *sim);
 
 /**
  * @brief Returns true if coupling is still ongoing
@@ -207,14 +205,14 @@ void Precice_FulfilledWriteCheckpoint();
  * @param sim: Structure with CalculiX data
  * @param v: CalculiX array with the temperature and displacement values
  */
-void Precice_ReadIterationCheckpoint( SimulationData * sim, double * v );
+void Precice_ReadIterationCheckpoint(SimulationData *sim, double *v);
 
 /**
  * @brief Writes iteration checkpoint
  * @param sim: Structure with CalculiX data
  * @param v: CalculiX array with the temperature and displacement values
  */
-void Precice_WriteIterationCheckpoint( SimulationData * sim, double * v );
+void Precice_WriteIterationCheckpoint(SimulationData *sim, double *v);
 
 /**
  * @brief Reads the coupling data for all interfaces
@@ -222,7 +220,7 @@ void Precice_WriteIterationCheckpoint( SimulationData * sim, double * v );
  * @param preciceInterfaces
  * @param numInterfaces
  */
-void Precice_ReadCouplingData( SimulationData * sim );
+void Precice_ReadCouplingData(SimulationData *sim);
 
 /**
  * @brief Writes the coupling data of all interfaces
@@ -230,7 +228,7 @@ void Precice_ReadCouplingData( SimulationData * sim );
  * @param preciceInterfaces
  * @param numInterfaces
  */
-void Precice_WriteCouplingData( SimulationData * sim );
+void Precice_WriteCouplingData(SimulationData *sim);
 
 /**
  * @brief Frees the memory
@@ -238,7 +236,7 @@ void Precice_WriteCouplingData( SimulationData * sim );
  * @param preciceInterfaces
  * @param numInterfaces
  */
-void Precice_FreeData( SimulationData * sim );
+void Precice_FreeData(SimulationData *sim);
 
 /**
  * @brief Creates an interface that is coupled with preCICE
@@ -246,34 +244,34 @@ void Precice_FreeData( SimulationData * sim );
  * @param sim
  * @param config
  */
-void PreciceInterface_Create( PreciceInterface * interface, SimulationData * sim, InterfaceConfig const * config );
+void PreciceInterface_Create(PreciceInterface *interface, SimulationData *sim, InterfaceConfig const *config);
 
 /**
  * @brief Configures the face centers mesh and calls setMeshVertices on preCICE
  * @param interface
  * @param sim
  */
-void PreciceInterface_ConfigureFaceCentersMesh( PreciceInterface * interface, SimulationData * sim );
+void PreciceInterface_ConfigureFaceCentersMesh(PreciceInterface *interface, SimulationData *sim);
 
 /**
  * @brief Configures the nodes mesh
  * @param interface
  * @param sim: Structure with CalculiX data
  */
-void PreciceInterface_ConfigureNodesMesh( PreciceInterface * interface, SimulationData * sim );
+void PreciceInterface_ConfigureNodesMesh(PreciceInterface *interface, SimulationData *sim);
 
 /**
  * @brief Terminate execution if the nodes mesh ID is not valid
  * @param interface
  */
-void PreciceInterface_EnsureValidNodesMeshID( PreciceInterface * interface );
+void PreciceInterface_EnsureValidNodesMeshID(PreciceInterface *interface);
 
 /**
  * @brief Configures the faces mesh (for tetrahedral elements only)
  * @param interface
  * @param sim
  */
-void PreciceInterface_ConfigureTetraFaces( PreciceInterface * interface, SimulationData * sim );
+void PreciceInterface_ConfigureTetraFaces(PreciceInterface *interface, SimulationData *sim);
 
 /**
  * @brief Configures the node connectivity for nearest-projection mapping
@@ -281,7 +279,7 @@ void PreciceInterface_ConfigureTetraFaces( PreciceInterface * interface, Simulat
  * @param sim
  * @param config
  */
-void PreciceInterface_NodeConnectivity( PreciceInterface * interface, SimulationData * sim );
+void PreciceInterface_NodeConnectivity(PreciceInterface *interface, SimulationData *sim);
 
 /**
  * @brief Configures the coupling data for CHT or FSI
@@ -289,12 +287,12 @@ void PreciceInterface_NodeConnectivity( PreciceInterface * interface, Simulation
  * @param sim
  * @param config
  */
-void PreciceInterface_ConfigureCouplingData( PreciceInterface * interface, SimulationData * sim, InterfaceConfig const * config );
+void PreciceInterface_ConfigureCouplingData(PreciceInterface *interface, SimulationData *sim, InterfaceConfig const *config);
 
 /**
  * @brief Frees the memory
  * @param preciceInterface
  */
-void PreciceInterface_FreeData( PreciceInterface * preciceInterface );
+void PreciceInterface_FreeData(PreciceInterface *preciceInterface);
 
 #endif // PRECICEINTERFACE_H

--- a/ccx_2.19.c
+++ b/ccx_2.19.c
@@ -7,7 +7,7 @@
 /*                                                                       */
 
 /*     This program is distributed in the hope that it will be useful,   */
-/*     but WITHOUT ANY WARRANTY; without even the implied warranty of    */ 
+/*     but WITHOUT ANY WARRANTY; without even the implied warranty of    */
 /*     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the      */
 /*     GNU General Public License for more details.                      */
 
@@ -23,86 +23,86 @@ _set_output_format(_TWO_DIGIT_EXPONENT);
 #include <spoolesMPI.h>
 #endif
 
-#include <stdlib.h>
 #include <math.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #include "CalculiX.h"
 
 #ifdef CALCULIX_MPI
-ITG myid = 0,nproc = 0;
+ITG myid = 0, nproc = 0;
 #endif
 
-struct timespec totalCalculixTimeStart,totalCalculixTimeEnd; 
+struct timespec totalCalculixTimeStart, totalCalculixTimeEnd;
 
-int main(int argc,char *argv[])
+int main(int argc, char *argv[])
 {
-  
+
   FILE *f1;
-    
-  char *sideload=NULL,*set=NULL,*matname=NULL,*orname=NULL,*amname=NULL,
-    *filab=NULL,*lakon=NULL,*labmpc=NULL,*prlab=NULL,*prset=NULL,
-    jobnamec[792]="",jobnamef[132]="",output[5],*typeboun=NULL,
-    *inpc=NULL,*tieset=NULL,*cbody=NULL,fneig[132],*sideloadtemp=NULL,
-    kind1[2],kind2[2],*heading=NULL,*objectset=NULL;
-  
-  ITG *kon=NULL,*nodeboun=NULL,*ndirboun=NULL,*ipompc=NULL,
-    *nodempc=NULL,*nodeforc=NULL,*ndirforc=NULL,
-    *nelemload=NULL,im,*inodesd=NULL,nload1,*idefforc=NULL,
-    *nactdof=NULL,*icol=NULL,*ics=NULL,itempuser[3],
-    *jq=NULL,*mast1=NULL,*irow=NULL,*rig=NULL,*idefbody=NULL,
-    *ikmpc=NULL,*ilmpc=NULL,*ikboun=NULL,*ilboun=NULL,
-    *nreorder=NULL,*ipointer=NULL,*idefload=NULL,
-    *istartset=NULL,*iendset=NULL,*ialset=NULL,*ielmat=NULL,
-    *ielorien=NULL,*nrhcon=NULL,*nodebounold=NULL,*ndirbounold=NULL,
-    *nelcon=NULL,*nalcon=NULL,*iamforc=NULL,*iamload=NULL,
-    *iamt1=NULL,*namta=NULL,*ipkon=NULL,*iamboun=NULL,
-    *nplicon=NULL,*nplkcon=NULL,*inotr=NULL,*iponor=NULL,*knor=NULL,
-    *ikforc=NULL,*ilforc=NULL,*iponoel=NULL,*inoel=NULL,*nshcon=NULL,
-    *ncocon=NULL,*ibody=NULL,*ielprop=NULL,*islavsurf=NULL,
-    *ipoinpc=NULL,mt,nxstate,nload0,iload,*iuel=NULL,*ne2boun=NULL,
-    *irandomtype=NULL,irobustdesign[3],*iparentel=NULL,ifreebody,
-    *ipobody=NULL,inewton=0,*iprfn=NULL,*konrfn=NULL;
-     
-  ITG nk,ne,nboun,nmpc,nforc,nload,nprint,nset,nalset,nentries=18,
-    nmethod,neq[3],i,mpcfree,mei[4]={0,0,0,0},j,nzl,nam,nbounold,
-    nforcold,nloadold,nbody,nbody_,nbodyold,network,nheading_,
-    k,nzs[3],nmpc_,nload_,nforc_,istep,istat,nboun_,nintpoint,
-    iperturb[2],nmat,ntmat_,norien,ithermal[2]={0,0},nmpcold,
-    iprestr,kode,isolver,nslavs,nkon_,ne0,nkon0,mortar,
-    jout[2],nlabel,nkon,idrct,jmax[2],iexpl,nevtot,ifacecount,
-    iplas,npmat_,mi[3],ntrans,mpcend,namtot_,iumat,iheading,
-    icascade,maxlenmpc,mpcinfo[4],ne1d,ne2d,infree[4],
-    callfrommain,nflow,jin=0,irstrt[2],nener,jrstrt,nenerold,
-    nline,*ipoinp=NULL,*inp=NULL,ntie,ntie_,mcs,nprop_,
-    nprop,itpamp,iviewfile,nkold,nevdamp_,npt_,cyclicsymmetry,
-    nmethodl,iaxial,inext,icontact,nobject,nobject_,iit,
-    nzsprevstep[3],memmpcref_,mpcfreeref,maxlenmpcref,*nodempcref=NULL,
-    *ikmpcref=NULL,isens,namtot,nstam,ndamp,nef,inp_size,
-    *ipoinp_sav=NULL,*inp_sav=NULL,irefineloop=0,icoordinate=0,
-    *nodedesi=NULL,ndesi=0,nobjectstart=0,nfc_,ndc_,nfc,ndc,*ikdc=NULL;
 
-  ITG *meminset=NULL,*rmeminset=NULL;
+  char *sideload = NULL, *set = NULL, *matname = NULL, *orname = NULL, *amname = NULL,
+       *filab = NULL, *lakon = NULL, *labmpc = NULL, *prlab = NULL, *prset = NULL,
+       jobnamec[792] = "", jobnamef[132] = "", output[5], *typeboun = NULL,
+       *inpc = NULL, *tieset = NULL, *cbody = NULL, fneig[132], *sideloadtemp = NULL,
+       kind1[2], kind2[2], *heading = NULL, *objectset = NULL;
 
-  ITG nzs_,nk_,ne_,nset_=0,nalset_,nmat_,norien_,nam_,
-    ntrans_,ncs_,nstate_,ncmat_,memmpc_,nprint_,nuel_=0;
-    
-  double *co=NULL,*xboun=NULL,*coefmpc=NULL,*xforc=NULL,*clearini=NULL,
-    *xload=NULL,*xbounold=NULL,*xforcold=NULL,*randomval=NULL,
-    *vold=NULL,*sti=NULL,*xloadold=NULL,*xnor=NULL,
-    *reorder=NULL,*dcs=NULL,*thickn=NULL,*thicke=NULL,*offset=NULL,
-    *elcon=NULL,*rhcon=NULL,*alcon=NULL,*alzero=NULL,*t0=NULL,*t1=NULL,
-    *prestr=NULL,*orab=NULL,*amta=NULL,*veold=NULL,*accold=NULL,
-    *t1old=NULL,*eme=NULL,*plicon=NULL,*pslavsurf=NULL,*plkcon=NULL,
-    *xstate=NULL,*trab=NULL,*ener=NULL,*shcon=NULL,*cocon=NULL,
-    *cs=NULL,*tietol=NULL,*fmpc=NULL,*prop=NULL,*t0g=NULL,*t1g=NULL,
-    *xbody=NULL,*xbodyold=NULL,*coefmpcref=NULL,*dacon=NULL,*vel=NULL,
-    *velo=NULL,*veloo=NULL,energy[5],*ratiorfn=NULL,*dgdxglob=NULL,
-    *g0=NULL,*xdesi=NULL,*coeffc=NULL,*edc=NULL;
-    
+  ITG *kon = NULL, *nodeboun = NULL, *ndirboun = NULL, *ipompc = NULL,
+      *nodempc = NULL, *nodeforc = NULL, *ndirforc = NULL,
+      *nelemload = NULL, im, *inodesd = NULL, nload1, *idefforc = NULL,
+      *nactdof = NULL, *icol = NULL, *ics = NULL, itempuser[3],
+      *jq = NULL, *mast1 = NULL, *irow = NULL, *rig = NULL, *idefbody = NULL,
+      *ikmpc = NULL, *ilmpc = NULL, *ikboun = NULL, *ilboun = NULL,
+      *nreorder = NULL, *ipointer = NULL, *idefload = NULL,
+      *istartset = NULL, *iendset = NULL, *ialset = NULL, *ielmat = NULL,
+      *ielorien = NULL, *nrhcon = NULL, *nodebounold = NULL, *ndirbounold = NULL,
+      *nelcon = NULL, *nalcon = NULL, *iamforc = NULL, *iamload = NULL,
+      *iamt1 = NULL, *namta = NULL, *ipkon = NULL, *iamboun = NULL,
+      *nplicon = NULL, *nplkcon = NULL, *inotr = NULL, *iponor = NULL, *knor = NULL,
+      *ikforc = NULL, *ilforc = NULL, *iponoel = NULL, *inoel = NULL, *nshcon = NULL,
+      *ncocon = NULL, *ibody = NULL, *ielprop = NULL, *islavsurf = NULL,
+      *ipoinpc = NULL, mt, nxstate, nload0, iload, *iuel = NULL, *ne2boun = NULL,
+      *irandomtype = NULL, irobustdesign[3], *iparentel = NULL, ifreebody,
+      *ipobody = NULL, inewton = 0, *iprfn = NULL, *konrfn = NULL;
+
+  ITG nk, ne, nboun, nmpc, nforc, nload, nprint, nset, nalset, nentries = 18,
+                                                               nmethod, neq[3], i, mpcfree, mei[4] = {0, 0, 0, 0}, j, nzl, nam, nbounold,
+                                                               nforcold, nloadold, nbody, nbody_, nbodyold, network, nheading_,
+                                                               k, nzs[3], nmpc_, nload_, nforc_, istep, istat, nboun_, nintpoint,
+                                                               iperturb[2], nmat, ntmat_, norien, ithermal[2] = {0, 0}, nmpcold,
+                                                               iprestr, kode, isolver, nslavs, nkon_, ne0, nkon0, mortar,
+                                                               jout[2], nlabel, nkon, idrct, jmax[2], iexpl, nevtot, ifacecount,
+                                                               iplas, npmat_, mi[3], ntrans, mpcend, namtot_, iumat, iheading,
+                                                               icascade, maxlenmpc, mpcinfo[4], ne1d, ne2d, infree[4],
+                                                               callfrommain, nflow, jin = 0, irstrt[2], nener, jrstrt, nenerold,
+                                                               nline, *ipoinp = NULL, *inp = NULL, ntie, ntie_, mcs, nprop_,
+                                                               nprop, itpamp, iviewfile, nkold, nevdamp_, npt_, cyclicsymmetry,
+                                                               nmethodl, iaxial, inext, icontact, nobject, nobject_, iit,
+                                                               nzsprevstep[3], memmpcref_, mpcfreeref, maxlenmpcref, *nodempcref = NULL,
+                                                               *ikmpcref   = NULL, isens, namtot, nstam, ndamp, nef, inp_size,
+                                                               *ipoinp_sav = NULL, *inp_sav = NULL, irefineloop = 0, icoordinate = 0,
+                                                               *nodedesi = NULL, ndesi = 0, nobjectstart = 0, nfc_, ndc_, nfc, ndc, *ikdc = NULL;
+
+  ITG *meminset = NULL, *rmeminset = NULL;
+
+  ITG nzs_, nk_, ne_, nset_ = 0, nalset_, nmat_, norien_, nam_,
+                      ntrans_, ncs_, nstate_, ncmat_, memmpc_, nprint_, nuel_ = 0;
+
+  double *co = NULL, *xboun = NULL, *coefmpc = NULL, *xforc = NULL, *clearini = NULL,
+         *xload = NULL, *xbounold = NULL, *xforcold = NULL, *randomval = NULL,
+         *vold = NULL, *sti = NULL, *xloadold = NULL, *xnor = NULL,
+         *reorder = NULL, *dcs = NULL, *thickn = NULL, *thicke = NULL, *offset = NULL,
+         *elcon = NULL, *rhcon = NULL, *alcon = NULL, *alzero = NULL, *t0 = NULL, *t1 = NULL,
+         *prestr = NULL, *orab = NULL, *amta = NULL, *veold = NULL, *accold = NULL,
+         *t1old = NULL, *eme = NULL, *plicon = NULL, *pslavsurf = NULL, *plkcon = NULL,
+         *xstate = NULL, *trab = NULL, *ener = NULL, *shcon = NULL, *cocon = NULL,
+         *cs = NULL, *tietol = NULL, *fmpc = NULL, *prop = NULL, *t0g = NULL, *t1g = NULL,
+         *xbody = NULL, *xbodyold = NULL, *coefmpcref = NULL, *dacon = NULL, *vel = NULL,
+         *velo = NULL, *veloo = NULL, energy[5], *ratiorfn = NULL, *dgdxglob = NULL,
+         *g0 = NULL, *xdesi = NULL, *coeffc = NULL, *edc = NULL;
+
   double ctrl[57];
 
-  double fei[3],*xmodal=NULL,timepar[5],alpha[2],ttime,qaold[2],physcon[14];
+  double fei[3], *xmodal = NULL, timepar[5], alpha[2], ttime, qaold[2], physcon[14];
 
   double totalCalculixTime;
 
@@ -110,62 +110,72 @@ int main(int argc,char *argv[])
  * Additional variables for the coupling with preCICE
  * preCICE is used only if a participant name is provided as a command line argument!
  */
-char preciceParticipantName[256] = "", configFilename[256] = "config.yml";
-int preciceUsed = 0;
+  char preciceParticipantName[256] = "", configFilename[256] = "config.yml";
+  int  preciceUsed = 0;
 
 #ifdef CALCULIX_MPI
-  MPI_Init(&argc, &argv) ;
-  MPI_Comm_rank(MPI_COMM_WORLD, &myid) ;
-  MPI_Comm_size(MPI_COMM_WORLD, &nproc) ;
+  MPI_Init(&argc, &argv);
+  MPI_Comm_rank(MPI_COMM_WORLD, &myid);
+  MPI_Comm_size(MPI_COMM_WORLD, &nproc);
 #endif
 
   clock_gettime(CLOCK_MONOTONIC, &totalCalculixTimeStart);
 
-  if(argc==1){printf("Usage: CalculiX.exe -i jobname\n");FORTRAN(stop,());}
-  else{
-    for(i=1;i<argc;i++){
-      if(strcmp1(argv[i],"-i")==0){
-	strcpy(jobnamec,argv[i+1]);strcpy1(jobnamef,argv[i+1],132);jin++;break;}
-      if(strcmp1(argv[i],"-v")==0){
-	printf("\nThis is Version 2.19\n\n");
-	FORTRAN(stop,());
+  if (argc == 1) {
+    printf("Usage: CalculiX.exe -i jobname\n");
+    FORTRAN(stop, ());
+  } else {
+    for (i = 1; i < argc; i++) {
+      if (strcmp1(argv[i], "-i") == 0) {
+        strcpy(jobnamec, argv[i + 1]);
+        strcpy1(jobnamef, argv[i + 1], 132);
+        jin++;
+        break;
       }
-
+      if (strcmp1(argv[i], "-v") == 0) {
+        printf("\nThis is Version 2.19\n\n");
+        FORTRAN(stop, ());
+      }
     }
-    if(jin==0){strcpy(jobnamec,argv[1]);strcpy1(jobnamef,argv[1],132);}
+    if (jin == 0) {
+      strcpy(jobnamec, argv[1]);
+      strcpy1(jobnamef, argv[1], 132);
+    }
 
     /* next lines deactivated on March 18, 2020 */
-    
+
     /*    for(i=1;i<argc;i++){
       if(strcmp1(argv[i],"-o")==0){
 	strcpy(output,argv[i+1]);break;}
 	}*/
 
-  for(i=1;i<argc;i++){
-    if(strcmp1(argv[i],"-o")==0) {
-    strcpy(output,argv[i+1]);break;}
+    for (i = 1; i < argc; i++) {
+      if (strcmp1(argv[i], "-o") == 0) {
+        strcpy(output, argv[i + 1]);
+        break;
+      }
 
-    // Get preCICE participantName
-    if(strcmp1(argv[i],"-precice-participant")==0) {
-        strcpy(preciceParticipantName,argv[i+1]);
+      // Get preCICE participantName
+      if (strcmp1(argv[i], "-precice-participant") == 0) {
+        strcpy(preciceParticipantName, argv[i + 1]);
         preciceUsed = 1;
+      }
+      // Overwrite YAML config file name in case a specific file name is given on the command line
+      if (strcmp1(argv[i], "-precice-config") == 0) {
+        strcpy(configFilename, argv[i + 1]);
+      }
     }
-    // Overwrite YAML config file name in case a specific file name is given on the command line
-    if(strcmp1(argv[i],"-precice-config")==0) {
-        strcpy(configFilename,argv[i+1]);
-    }
-  }
   }
 
   putenv("CCX_JOBNAME_GETJOBNAME=jobnamec");
 
 #ifdef BAM
-  ITG lop=0,lrestart=0,kstep=1,kinc=1;
-  double time[2],dtime;
-  FORTRAN(uexternaldb,(&lop,&lrestart,time,&dtime,&kstep,&kinc));
+  ITG    lop = 0, lrestart = 0, kstep = 1, kinc = 1;
+  double time[2], dtime;
+  FORTRAN(uexternaldb, (&lop, &lrestart, time, &dtime, &kstep, &kinc));
 #endif
 
-  FORTRAN(openfile,(jobnamef));
+  FORTRAN(openfile, (jobnamef));
 
   printf("\n************************************************************\n\n");
   printf("CalculiX Version 2.19, Copyright(C) 1998-2021 Guido Dhondt\n");
@@ -176,57 +186,59 @@ int preciceUsed = 0;
   printf("You are using an executable made on Fri Dec 17 13:15:26 CET 2021\n");
   fflush(stdout);
 
-  NNEW(ipoinp,ITG,2*nentries);
+  NNEW(ipoinp, ITG, 2 * nentries);
 
   /* conservative estimate of the fields to be allocated */
 
-  readinput(jobnamec,&inpc,&nline,&nset_,ipoinp,&inp,&ipoinpc,ithermal,&nuel_,
-	    &inp_size); 
+  readinput(jobnamec, &inpc, &nline, &nset_, ipoinp, &inp, &ipoinpc, ithermal, &nuel_,
+            &inp_size);
 
   /* saving the original input deck reading pointers */
 
-  NNEW(ipoinp_sav,ITG,2*nentries);
-  memcpy(ipoinp_sav,ipoinp,sizeof(ITG)*2*nentries);
-  NNEW(inp_sav,ITG,inp_size);
-  memcpy(inp_sav,inp,sizeof(ITG)*inp_size);
+  NNEW(ipoinp_sav, ITG, 2 * nentries);
+  memcpy(ipoinp_sav, ipoinp, sizeof(ITG) * 2 * nentries);
+  NNEW(inp_sav, ITG, inp_size);
+  memcpy(inp_sav, inp, sizeof(ITG) * inp_size);
 
   /* initialization of the variables */
-  
-  ini_cal(jobnamec,output,fneig,kind1,kind2,itempuser,irobustdesign,&nprint,
-	  neq,&mpcfree,&nbounold,&nforcold,&nloadold,&nbody_,
-	  &nbodyold,&network,&nheading_,&nmpc_,&nload_,&nforc_,&nboun_,
-	  &nintpoint,iperturb,&ntmat_,ithermal,&isolver,&nslavs,&nkon_,&mortar,
-	  jout,&nkon,&nevtot,&ifacecount,&iplas,&npmat_,mi,&mpcend,&namtot_,
-	  &iumat,&icascade,&ne1d,&ne2d,infree,&nflow,irstrt,&nener,&jrstrt,
-	  &ntie_,&mcs,&nprop_,&nprop,&itpamp,&nevdamp_,&npt_,&iaxial,&inext,
-	  &icontact,&nobject,&nobject_,&iit,&mpcfreeref,&isens,&namtot,&nstam,
-	  &ndamp,&nef,&nk_,&ne_,&nalset_,&nmat_,&norien_,&nam_,
-	  &ntrans_,&ncs_,&nstate_,&ncmat_,&memmpc_,&nprint_,energy,ctrl,alpha,
-	  qaold,physcon,&istep,&istat,&iprestr,&kode,&nload,&nbody,&nforc,
-	  &nboun,&nk,&nmpc,&nam,&nzs_,&nlabel,&ttime,&iheading,&nfc,&nfc_,&ndc,
-	  &ndc_);
-  
-  NNEW(set,char,81*nset_);
-  NNEW(meminset,ITG,nset_);
-  NNEW(rmeminset,ITG,nset_);
-  NNEW(iuel,ITG,4*nuel_);
 
-  FORTRAN(allocation,(&nload_,&nforc_,&nboun_,&nk_,&ne_,&nmpc_,&nset_,&nalset_,
-		      &nmat_,&ntmat_,&npmat_,&norien_,&nam_,&nprint_,mi,
-		      &ntrans_,set,meminset,rmeminset,&ncs_,&namtot_,&ncmat_,
-		      &memmpc_,&ne1d,&ne2d,&nflow,jobnamec,irstrt,ithermal,
-		      &nener,&nstate_,&istep,inpc,ipoinp,inp,&ntie_,&nbody_,
-		      &nprop_,ipoinpc,&nevdamp_,&npt_,&nslavs,&nkon_,&mcs,
-		      &mortar,&ifacecount,&nintpoint,infree,&nheading_,
-		      &nobject_,iuel,&iprestr,&nstam,&ndamp,&nef,&nbounold,
-		      &nforcold,&nloadold,&nbodyold,&mpcend,irobustdesign,
-		      &nfc_,&ndc_));
+  ini_cal(jobnamec, output, fneig, kind1, kind2, itempuser, irobustdesign, &nprint,
+          neq, &mpcfree, &nbounold, &nforcold, &nloadold, &nbody_,
+          &nbodyold, &network, &nheading_, &nmpc_, &nload_, &nforc_, &nboun_,
+          &nintpoint, iperturb, &ntmat_, ithermal, &isolver, &nslavs, &nkon_, &mortar,
+          jout, &nkon, &nevtot, &ifacecount, &iplas, &npmat_, mi, &mpcend, &namtot_,
+          &iumat, &icascade, &ne1d, &ne2d, infree, &nflow, irstrt, &nener, &jrstrt,
+          &ntie_, &mcs, &nprop_, &nprop, &itpamp, &nevdamp_, &npt_, &iaxial, &inext,
+          &icontact, &nobject, &nobject_, &iit, &mpcfreeref, &isens, &namtot, &nstam,
+          &ndamp, &nef, &nk_, &ne_, &nalset_, &nmat_, &norien_, &nam_,
+          &ntrans_, &ncs_, &nstate_, &ncmat_, &memmpc_, &nprint_, energy, ctrl, alpha,
+          qaold, physcon, &istep, &istat, &iprestr, &kode, &nload, &nbody, &nforc,
+          &nboun, &nk, &nmpc, &nam, &nzs_, &nlabel, &ttime, &iheading, &nfc, &nfc_, &ndc,
+          &ndc_);
+
+  NNEW(set, char, 81 * nset_);
+  NNEW(meminset, ITG, nset_);
+  NNEW(rmeminset, ITG, nset_);
+  NNEW(iuel, ITG, 4 * nuel_);
+
+  FORTRAN(allocation, (&nload_, &nforc_, &nboun_, &nk_, &ne_, &nmpc_, &nset_, &nalset_,
+                       &nmat_, &ntmat_, &npmat_, &norien_, &nam_, &nprint_, mi,
+                       &ntrans_, set, meminset, rmeminset, &ncs_, &namtot_, &ncmat_,
+                       &memmpc_, &ne1d, &ne2d, &nflow, jobnamec, irstrt, ithermal,
+                       &nener, &nstate_, &istep, inpc, ipoinp, inp, &ntie_, &nbody_,
+                       &nprop_, ipoinpc, &nevdamp_, &npt_, &nslavs, &nkon_, &mcs,
+                       &mortar, &ifacecount, &nintpoint, infree, &nheading_,
+                       &nobject_, iuel, &iprestr, &nstam, &ndamp, &nef, &nbounold,
+                       &nforcold, &nloadold, &nbodyold, &mpcend, irobustdesign,
+                       &nfc_, &ndc_));
 
   //  SFREE(set);
-  SFREE(meminset);SFREE(rmeminset);mt=mi[1]+1;
-  NNEW(heading,char,66*nheading_);
+  SFREE(meminset);
+  SFREE(rmeminset);
+  mt = mi[1] + 1;
+  NNEW(heading, char, 66 * nheading_);
 
-  while(istat>=0){
+  while (istat >= 0) {
 
     fflush(stdout);
 
@@ -234,476 +246,502 @@ int preciceUsed = 0;
        the subroutines, the max. field sizes are (for most fields) copied
        into the real sizes */
 
-    nzs[1]=nzs_;
+    nzs[1] = nzs_;
 
-    if((istep==0)||(irstrt[0]<0)){
-      ne=ne_;
-      nset=nset_;
-      nalset=nalset_;
-      nmat=nmat_;
-      norien=norien_;
-      ntrans=ntrans_;
-      ntie=ntie_;
+    if ((istep == 0) || (irstrt[0] < 0)) {
+      ne     = ne_;
+      nset   = nset_;
+      nalset = nalset_;
+      nmat   = nmat_;
+      norien = norien_;
+      ntrans = ntrans_;
+      ntie   = ntie_;
 
       /* allocating space before the first step */
 
       /* coordinates and topology */
 
-      NNEW(co,double,3*nk_);
-      NNEW(kon,ITG,nkon_);
-      NNEW(ipkon,ITG,ne_);
-      NNEW(lakon,char,8*ne_);
+      NNEW(co, double, 3 * nk_);
+      NNEW(kon, ITG, nkon_);
+      NNEW(ipkon, ITG, ne_);
+      NNEW(lakon, char, 8 * ne_);
 
       /* property cards */
 
-      if(nprop_>0){
-	NNEW(ielprop,ITG,ne_);
-	for(i=0;i<ne_;i++) ielprop[i]=-1;
-	NNEW(prop,double,nprop_);
+      if (nprop_ > 0) {
+        NNEW(ielprop, ITG, ne_);
+        for (i = 0; i < ne_; i++)
+          ielprop[i] = -1;
+        NNEW(prop, double, nprop_);
       }
 
       /* fields for 1-D and 2-D elements */
 
-      if((ne1d!=0)||(ne2d!=0)){
-	NNEW(iponor,ITG,2*nkon_);
-	for(i=0;i<2*nkon_;i++) iponor[i]=-1;
-	NNEW(xnor,double,36*ne1d+24*ne2d);
-	NNEW(knor,ITG,24*(ne1d+ne2d)*(mi[2]+1));
-	NNEW(thickn,double,2*nk_);
-	NNEW(thicke,double,mi[2]*nkon_);
-	NNEW(offset,double,2*ne_);
-	NNEW(iponoel,ITG,nk_);
-	NNEW(inoel,ITG,9*ne1d+24*ne2d);
-	NNEW(rig,ITG,nk_);
-	NNEW(ne2boun,ITG,2*nk_);
-	if(infree[2]==0)infree[2]=1;
+      if ((ne1d != 0) || (ne2d != 0)) {
+        NNEW(iponor, ITG, 2 * nkon_);
+        for (i = 0; i < 2 * nkon_; i++)
+          iponor[i] = -1;
+        NNEW(xnor, double, 36 * ne1d + 24 * ne2d);
+        NNEW(knor, ITG, 24 * (ne1d + ne2d) * (mi[2] + 1));
+        NNEW(thickn, double, 2 * nk_);
+        NNEW(thicke, double, mi[2] * nkon_);
+        NNEW(offset, double, 2 * ne_);
+        NNEW(iponoel, ITG, nk_);
+        NNEW(inoel, ITG, 9 * ne1d + 24 * ne2d);
+        NNEW(rig, ITG, nk_);
+        NNEW(ne2boun, ITG, 2 * nk_);
+        if (infree[2] == 0)
+          infree[2] = 1;
       }
 
       /* SPC's */
 
-      NNEW(nodeboun,ITG,nboun_);
-      NNEW(ndirboun,ITG,nboun_);
-      NNEW(typeboun,char,nboun_+1);
-      if((istep==0)||((irstrt[0]<0)&&(nam_>0)))NNEW(iamboun,ITG,nboun_);
-      NNEW(xboun,double,nboun_);
-      NNEW(ikboun,ITG,nboun_);
-      NNEW(ilboun,ITG,nboun_);
+      NNEW(nodeboun, ITG, nboun_);
+      NNEW(ndirboun, ITG, nboun_);
+      NNEW(typeboun, char, nboun_ + 1);
+      if ((istep == 0) || ((irstrt[0] < 0) && (nam_ > 0)))
+        NNEW(iamboun, ITG, nboun_);
+      NNEW(xboun, double, nboun_);
+      NNEW(ikboun, ITG, nboun_);
+      NNEW(ilboun, ITG, nboun_);
 
       /* MPC's */
 
-      NNEW(ipompc,ITG,nmpc_);
-      NNEW(nodempc,ITG,3*memmpc_);
-      for(i=0;i<3*memmpc_;i+=3){nodempc[i+2]=i/3+2;}
-      nodempc[3*memmpc_-1]=0;
-      NNEW(coefmpc,double,memmpc_);
-      NNEW(labmpc,char,20*nmpc_+1);
-      NNEW(ikmpc,ITG,nmpc_);
-      NNEW(ilmpc,ITG,nmpc_);
-      NNEW(fmpc,double,nmpc_);
+      NNEW(ipompc, ITG, nmpc_);
+      NNEW(nodempc, ITG, 3 * memmpc_);
+      for (i = 0; i < 3 * memmpc_; i += 3) {
+        nodempc[i + 2] = i / 3 + 2;
+      }
+      nodempc[3 * memmpc_ - 1] = 0;
+      NNEW(coefmpc, double, memmpc_);
+      NNEW(labmpc, char, 20 * nmpc_ + 1);
+      NNEW(ikmpc, ITG, nmpc_);
+      NNEW(ilmpc, ITG, nmpc_);
+      NNEW(fmpc, double, nmpc_);
 
       /* coupling, distributed */
 
-      if(nfc_>0){
-	NNEW(coeffc,double,7*nfc_);
-	NNEW(ikdc,ITG,ndc_);
-	NNEW(edc,double,12*ndc_);
+      if (nfc_ > 0) {
+        NNEW(coeffc, double, 7 * nfc_);
+        NNEW(ikdc, ITG, ndc_);
+        NNEW(edc, double, 12 * ndc_);
       }
-      
+
       /* nodal loads */
 
-      NNEW(nodeforc,ITG,2*nforc_);
-      NNEW(ndirforc,ITG,nforc_);
-      if((istep==0)||((irstrt[0]<0)&&(nam_>0)))NNEW(iamforc,ITG,nforc_);
-      NNEW(idefforc,ITG,nforc_);
-      NNEW(xforc,double,nforc_);
-      NNEW(ikforc,ITG,nforc_);
-      NNEW(ilforc,ITG,nforc_);
+      NNEW(nodeforc, ITG, 2 * nforc_);
+      NNEW(ndirforc, ITG, nforc_);
+      if ((istep == 0) || ((irstrt[0] < 0) && (nam_ > 0)))
+        NNEW(iamforc, ITG, nforc_);
+      NNEW(idefforc, ITG, nforc_);
+      NNEW(xforc, double, nforc_);
+      NNEW(ikforc, ITG, nforc_);
+      NNEW(ilforc, ITG, nforc_);
 
       /* distributed facial loads */
 
-      NNEW(nelemload,ITG,2*nload_);
-      if((istep==0)||((irstrt[0]<0)&&(nam_>0)))NNEW(iamload,ITG,2*nload_);
-      NNEW(idefload,ITG,nload_);
-      NNEW(sideload,char,20*nload_);
-      NNEW(xload,double,2*nload_);
+      NNEW(nelemload, ITG, 2 * nload_);
+      if ((istep == 0) || ((irstrt[0] < 0) && (nam_ > 0)))
+        NNEW(iamload, ITG, 2 * nload_);
+      NNEW(idefload, ITG, nload_);
+      NNEW(sideload, char, 20 * nload_);
+      NNEW(xload, double, 2 * nload_);
 
       /* distributed volumetric loads */
 
-      NNEW(cbody,char,81*nbody_);
-      NNEW(idefbody,ITG,nbody_);
-      NNEW(ibody,ITG,3*nbody_);
-      NNEW(xbody,double,7*nbody_);
-      NNEW(xbodyold,double,7*nbody_);
+      NNEW(cbody, char, 81 * nbody_);
+      NNEW(idefbody, ITG, nbody_);
+      NNEW(ibody, ITG, 3 * nbody_);
+      NNEW(xbody, double, 7 * nbody_);
+      NNEW(xbodyold, double, 7 * nbody_);
 
       /* printing output */
 
-      NNEW(prlab,char,6*nprint_);
-      NNEW(prset,char,81*nprint_);
+      NNEW(prlab, char, 6 * nprint_);
+      NNEW(prset, char, 81 * nprint_);
 
       /* set definitions */
 
-      RENEW(set,char,81*nset);
-      NNEW(istartset,ITG,nset);DMEMSET(istartset,0,nset,1);
-      NNEW(iendset,ITG,nset);
-      NNEW(ialset,ITG,nalset);
+      RENEW(set, char, 81 * nset);
+      NNEW(istartset, ITG, nset);
+      DMEMSET(istartset, 0, nset, 1);
+      NNEW(iendset, ITG, nset);
+      NNEW(ialset, ITG, nalset);
 
       /* (hyper)elastic constants */
 
-      NNEW(elcon,double,(ncmat_+1)*ntmat_*nmat);
-      NNEW(nelcon,ITG,2*nmat);
+      NNEW(elcon, double, (ncmat_ + 1) * ntmat_ * nmat);
+      NNEW(nelcon, ITG, 2 * nmat);
 
       /* density */
 
-      NNEW(rhcon,double,2*ntmat_*nmat);
-      NNEW(nrhcon,ITG,nmat);
+      NNEW(rhcon, double, 2 * ntmat_ * nmat);
+      NNEW(nrhcon, ITG, nmat);
 
       /* damping */
 
-      if(ndamp>0){NNEW(dacon,double,nmat);}
+      if (ndamp > 0) {
+        NNEW(dacon, double, nmat);
+      }
 
       /* specific heat */
 
-      NNEW(shcon,double,4*ntmat_*nmat);
-      NNEW(nshcon,ITG,nmat);
+      NNEW(shcon, double, 4 * ntmat_ * nmat);
+      NNEW(nshcon, ITG, nmat);
 
       /* thermal expansion coefficients */
 
-      NNEW(alcon,double,7*ntmat_*nmat);
-      NNEW(nalcon,ITG,2*nmat);
-      NNEW(alzero,double,nmat);
+      NNEW(alcon, double, 7 * ntmat_ * nmat);
+      NNEW(nalcon, ITG, 2 * nmat);
+      NNEW(alzero, double, nmat);
 
       /* conductivity */
 
-      NNEW(cocon,double,7*ntmat_*nmat);
-      NNEW(ncocon,ITG,2*nmat);
+      NNEW(cocon, double, 7 * ntmat_ * nmat);
+      NNEW(ncocon, ITG, 2 * nmat);
 
       /* isotropic and kinematic hardening coefficients*/
 
-      if(npmat_>0){
-	NNEW(plicon,double,(2*npmat_+1)*ntmat_*nmat);
-	NNEW(nplicon,ITG,(ntmat_+1)*nmat);
-	NNEW(plkcon,double,(2*npmat_+1)*ntmat_*nmat);
-	NNEW(nplkcon,ITG,(ntmat_+1)*nmat);
+      if (npmat_ > 0) {
+        NNEW(plicon, double, (2 * npmat_ + 1) * ntmat_ * nmat);
+        NNEW(nplicon, ITG, (ntmat_ + 1) * nmat);
+        NNEW(plkcon, double, (2 * npmat_ + 1) * ntmat_ * nmat);
+        NNEW(nplkcon, ITG, (ntmat_ + 1) * nmat);
       }
 
       /* linear dynamic properties */
-    
-      NNEW(xmodal,double,11+nevdamp_);
-      xmodal[10]=nevdamp_+0.5;
+
+      NNEW(xmodal, double, 11 + nevdamp_);
+      xmodal[10] = nevdamp_ + 0.5;
 
       /* internal state variables (nslavs is needed for restart
 	 calculations) */
 
-      if(mortar!=1){
-	NNEW(xstate,double,nstate_*mi[0]*(ne+nslavs));
-	nxstate=nstate_*mi[0]*(ne+nslavs);
-      }else if(mortar==1){
-	NNEW(xstate,double,nstate_*mi[0]*(ne+nintpoint));
-	nxstate=nstate_*mi[0]*(ne+nintpoint);
+      if (mortar != 1) {
+        NNEW(xstate, double, nstate_ *mi[0] * (ne + nslavs));
+        nxstate = nstate_ * mi[0] * (ne + nslavs);
+      } else if (mortar == 1) {
+        NNEW(xstate, double, nstate_ *mi[0] * (ne + nintpoint));
+        nxstate = nstate_ * mi[0] * (ne + nintpoint);
       }
 
       /* material orientation */
 
-      if((istep==0)||((irstrt[0]<0)&&(norien>0))){
-	NNEW(orname,char,80*norien);
-	NNEW(orab,double,7*norien);
-	NNEW(ielorien,ITG,mi[2]*ne_);
+      if ((istep == 0) || ((irstrt[0] < 0) && (norien > 0))) {
+        NNEW(orname, char, 80 * norien);
+        NNEW(orab, double, 7 * norien);
+        NNEW(ielorien, ITG, mi[2] * ne_);
       }
 
       /* transformations */
 
-      if((istep==0)||((irstrt[0]<0)&&(ntrans>0))){
-	NNEW(trab,double,7*ntrans);
-	NNEW(inotr,ITG,2*nk_);
+      if ((istep == 0) || ((irstrt[0] < 0) && (ntrans > 0))) {
+        NNEW(trab, double, 7 * ntrans);
+        NNEW(inotr, ITG, 2 * nk_);
       }
 
       /* amplitude definitions */
 
-      if((istep==0)||((irstrt[0]<0)&&(nam_>0))){
-	NNEW(amname,char,80*nam_);
-	NNEW(amta,double,2*namtot_);
-	NNEW(namta,ITG,3*nam_);
+      if ((istep == 0) || ((irstrt[0] < 0) && (nam_ > 0))) {
+        NNEW(amname, char, 80 * nam_);
+        NNEW(amta, double, 2 * namtot_);
+        NNEW(namta, ITG, 3 * nam_);
       }
 
-      if((istep==0)||((irstrt[0]<0)&&(ithermal[0]>0))){
-	NNEW(t0,double,nk_);
-	NNEW(t1,double,nk_);
-	if((ne1d!=0)||(ne2d!=0)||(nuel_!=0)){
-	  NNEW(t0g,double,2*nk_);
-	  NNEW(t1g,double,2*nk_);
-	}
+      if ((istep == 0) || ((irstrt[0] < 0) && (ithermal[0] > 0))) {
+        NNEW(t0, double, nk_);
+        NNEW(t1, double, nk_);
+        if ((ne1d != 0) || (ne2d != 0) || (nuel_ != 0)) {
+          NNEW(t0g, double, 2 * nk_);
+          NNEW(t1g, double, 2 * nk_);
+        }
       }
 
       /* the number in next line is NOT 1.2357111317 -> points
 	 to user input; instead it is a generic nonzero
 	 initialization */
 
-      if(istep==0){
-	DMEMSET(t0,0,nk_,1.2357111319);
-	DMEMSET(t1,0,nk_,1.2357111319);
+      if (istep == 0) {
+        DMEMSET(t0, 0, nk_, 1.2357111319);
+        DMEMSET(t1, 0, nk_, 1.2357111319);
       }
-    
-      if((istep==0)||((irstrt[0]<0)&&(ithermal[0]>0)&&(nam_>0)))NNEW(iamt1,ITG,nk_);
 
-      if((istep==0)||((irstrt[0]<0)&&(iprestr>0)))NNEW(prestr,double,6*mi[0]*ne_);
+      if ((istep == 0) || ((irstrt[0] < 0) && (ithermal[0] > 0) && (nam_ > 0)))
+        NNEW(iamt1, ITG, nk_);
 
-      NNEW(vold,double,mt*nk_);
-      NNEW(veold,double,mt*nk_);
+      if ((istep == 0) || ((irstrt[0] < 0) && (iprestr > 0)))
+        NNEW(prestr, double, 6 * mi[0] * ne_);
+
+      NNEW(vold, double, mt *nk_);
+      NNEW(veold, double, mt *nk_);
 
       /* CFD-results */
 
-      NNEW(vel,double,8*nef);
-      NNEW(velo,double,8*nef);
-      NNEW(veloo,double,8*nef);
+      NNEW(vel, double, 8 * nef);
+      NNEW(velo, double, 8 * nef);
+      NNEW(veloo, double, 8 * nef);
 
-      NNEW(ielmat,ITG,mi[2]*ne_);
+      NNEW(ielmat, ITG, mi[2] * ne_);
 
-      NNEW(matname,char,80*nmat);
+      NNEW(matname, char, 80 * nmat);
 
-      NNEW(filab,char,87*nlabel);
+      NNEW(filab, char, 87 * nlabel);
 
       /* tied constraints */
 
-      if(ntie_>0){
-	NNEW(tieset,char,243*ntie_);
-	NNEW(tietol,double,4*ntie_);
-	NNEW(cs,double,17*ntie_);
+      if (ntie_ > 0) {
+        NNEW(tieset, char, 243 * ntie_);
+        NNEW(tietol, double, 4 * ntie_);
+        NNEW(cs, double, 17 * ntie_);
       }
 
       /* objectives for sensitivity analysis */
 
-      if(nobject_>0){
-	NNEW(nodedesi,ITG,nk_);
-	NNEW(dgdxglob,double,nobject_*2*nk_);
-	NNEW(g0,double,nobject_);
-	NNEW(xdesi,double,3*nk_);
-	NNEW(objectset,char,405*nobject_);
-	for(i=0;i<405*nobject_;i++){objectset[i]=' ';}
+      if (nobject_ > 0) {
+        NNEW(nodedesi, ITG, nk_);
+        NNEW(dgdxglob, double, nobject_ * 2 * nk_);
+        NNEW(g0, double, nobject_);
+        NNEW(xdesi, double, 3 * nk_);
+        NNEW(objectset, char, 405 * nobject_);
+        for (i = 0; i < 405 * nobject_; i++) {
+          objectset[i] = ' ';
+        }
       }
 
       /* temporary fields for cyclic symmetry calculations */
 
-      if((ncs_>0)||(npt_>0)){
-	if(2*npt_>24*ncs_){
-	  NNEW(ics,ITG,2*npt_);
-	}else{
-	  NNEW(ics,ITG,24*ncs_);
-	}
-	if(npt_>30*ncs_){
-	  NNEW(dcs,double,npt_);
-	}else{
-	  NNEW(dcs,double,30*ncs_);
-	}
+      if ((ncs_ > 0) || (npt_ > 0)) {
+        if (2 * npt_ > 24 * ncs_) {
+          NNEW(ics, ITG, 2 * npt_);
+        } else {
+          NNEW(ics, ITG, 24 * ncs_);
+        }
+        if (npt_ > 30 * ncs_) {
+          NNEW(dcs, double, npt_);
+        } else {
+          NNEW(dcs, double, 30 * ncs_);
+        }
       }
 
       /* slave faces */
 
-      NNEW(islavsurf,ITG,2*ifacecount+2);
-    
+      NNEW(islavsurf, ITG, 2 * ifacecount + 2);
+
       /* robustdesign analysis */
-    
-      if(irobustdesign[0]>0){
-	NNEW(irandomtype,ITG,nk_);
-	NNEW(randomval,double,2*nk_);
+
+      if (irobustdesign[0] > 0) {
+        NNEW(irandomtype, ITG, nk_);
+        NNEW(randomval, double, 2 * nk_);
       }
 
-    }
-    else {
+    } else {
 
       /* allocating and reallocating space for subsequent steps */
-      
-      if((nmethod!=4)&&(nmethod!=5)&&(nmethod!=8)&&(nmethod!=9)&& 
-	 ((abs(nmethod)!=1)||(iperturb[0]<2))){
-        NNEW(veold,double,mt*nk_);
+
+      if ((nmethod != 4) && (nmethod != 5) && (nmethod != 8) && (nmethod != 9) &&
+          ((abs(nmethod) != 1) || (iperturb[0] < 2))) {
+        NNEW(veold, double, mt *nk_);
+      } else {
+        RENEW(veold, double, mt *nk_);
+        DMEMSET(veold, mt * nk, mt * nk_, 0.);
       }
-      else{
-	RENEW(veold,double,mt*nk_);
-	DMEMSET(veold,mt*nk,mt*nk_,0.);
-      }
-      RENEW(vold,double,mt*nk_);
-      DMEMSET(vold,mt*nk,mt*nk_,0.);
+      RENEW(vold, double, mt *nk_);
+      DMEMSET(vold, mt * nk, mt * nk_, 0.);
 
-      RENEW(nodeboun,ITG,nboun_);
-      RENEW(ndirboun,ITG,nboun_);
-      RENEW(typeboun,char,nboun_+1);
-      RENEW(xboun,double,nboun_);
-      RENEW(ikboun,ITG,nboun_);
-      RENEW(ilboun,ITG,nboun_);
+      RENEW(nodeboun, ITG, nboun_);
+      RENEW(ndirboun, ITG, nboun_);
+      RENEW(typeboun, char, nboun_ + 1);
+      RENEW(xboun, double, nboun_);
+      RENEW(ikboun, ITG, nboun_);
+      RENEW(ilboun, ITG, nboun_);
 
-      RENEW(nodeforc,ITG,2*nforc_);
-      RENEW(ndirforc,ITG,nforc_);
-      NNEW(idefforc,ITG,nforc_);
-      RENEW(xforc,double,nforc_);
-      RENEW(ikforc,ITG,nforc_);
-      RENEW(ilforc,ITG,nforc_);
+      RENEW(nodeforc, ITG, 2 * nforc_);
+      RENEW(ndirforc, ITG, nforc_);
+      NNEW(idefforc, ITG, nforc_);
+      RENEW(xforc, double, nforc_);
+      RENEW(ikforc, ITG, nforc_);
+      RENEW(ilforc, ITG, nforc_);
 
-      RENEW(nelemload,ITG,2*nload_);
-      NNEW(idefload,ITG,nload_);
-      RENEW(sideload,char,20*nload_);
-      RENEW(xload,double,2*nload_);
+      RENEW(nelemload, ITG, 2 * nload_);
+      NNEW(idefload, ITG, nload_);
+      RENEW(sideload, char, 20 * nload_);
+      RENEW(xload, double, 2 * nload_);
 
-      RENEW(cbody,char,81*nbody_);
-      NNEW(idefbody,ITG,nbody_);
-      RENEW(ibody,ITG,3*nbody_);
-      RENEW(xbody,double,7*nbody_);
-      RENEW(xbodyold,double,7*nbody_);
-      for(i=7*nbodyold;i<7*nbody_;i++) xbodyold[i]=0;
+      RENEW(cbody, char, 81 * nbody_);
+      NNEW(idefbody, ITG, nbody_);
+      RENEW(ibody, ITG, 3 * nbody_);
+      RENEW(xbody, double, 7 * nbody_);
+      RENEW(xbodyold, double, 7 * nbody_);
+      for (i = 7 * nbodyold; i < 7 * nbody_; i++)
+        xbodyold[i] = 0;
 
-      if(nam>0){
-	RENEW(iamforc,ITG,nforc_);
-	RENEW(iamload,ITG,2*nload_);
-	RENEW(iamboun,ITG,nboun_);
-	RENEW(amname,char,80*nam_);
-	RENEW(amta,double,2*namtot_);
-	RENEW(namta,ITG,3*nam_);
-      }
-
-      RENEW(ipompc,ITG,nmpc_);
-
-      RENEW(labmpc,char,20*nmpc_+1);
-      RENEW(ikmpc,ITG,nmpc_);
-      RENEW(ilmpc,ITG,nmpc_);
-      RENEW(fmpc,double,nmpc_);
-
-      if(ntrans>0){
-	RENEW(inotr,ITG,2*nk_);DMEMSET(inotr,2*nk,2*nk_,0);
+      if (nam > 0) {
+        RENEW(iamforc, ITG, nforc_);
+        RENEW(iamload, ITG, 2 * nload_);
+        RENEW(iamboun, ITG, nboun_);
+        RENEW(amname, char, 80 * nam_);
+        RENEW(amta, double, 2 * namtot_);
+        RENEW(namta, ITG, 3 * nam_);
       }
 
-      RENEW(co,double,3*nk_);DMEMSET(co,3*nk,3*nk_,0.);
+      RENEW(ipompc, ITG, nmpc_);
 
-      if(ithermal[0] != 0){
-	RENEW(t0,double,nk_);DMEMSET(t0,nk,nk_,0.);
-	RENEW(t1,double,nk_);DMEMSET(t1,nk,nk_,0.);
-	if((ne1d!=0)||(ne2d!=0)||(nuel_!=0)){
-	  RENEW(t0g,double,2*nk_);DMEMSET(t0g,2*nk,2*nk_,0.);
-	  RENEW(t1g,double,2*nk_);DMEMSET(t1g,2*nk,2*nk_,0.);
-	}
-	if(nam>0){RENEW(iamt1,ITG,nk_);}
+      RENEW(labmpc, char, 20 * nmpc_ + 1);
+      RENEW(ikmpc, ITG, nmpc_);
+      RENEW(ilmpc, ITG, nmpc_);
+      RENEW(fmpc, double, nmpc_);
+
+      if (ntrans > 0) {
+        RENEW(inotr, ITG, 2 * nk_);
+        DMEMSET(inotr, 2 * nk, 2 * nk_, 0);
       }
 
+      RENEW(co, double, 3 * nk_);
+      DMEMSET(co, 3 * nk, 3 * nk_, 0.);
+
+      if (ithermal[0] != 0) {
+        RENEW(t0, double, nk_);
+        DMEMSET(t0, nk, nk_, 0.);
+        RENEW(t1, double, nk_);
+        DMEMSET(t1, nk, nk_, 0.);
+        if ((ne1d != 0) || (ne2d != 0) || (nuel_ != 0)) {
+          RENEW(t0g, double, 2 * nk_);
+          DMEMSET(t0g, 2 * nk, 2 * nk_, 0.);
+          RENEW(t1g, double, 2 * nk_);
+          DMEMSET(t1g, 2 * nk, 2 * nk_, 0.);
+        }
+        if (nam > 0) {
+          RENEW(iamt1, ITG, nk_);
+        }
+      }
     }
 
     /* allocation of fields in the restart file */
 
-    if(irstrt[0]<0){
-      NNEW(nodebounold,ITG,nboun_);
-      NNEW(ndirbounold,ITG,nboun_);
-      NNEW(xbounold,double,nboun_);
-      NNEW(xforcold,double,nforc_);
-      NNEW(xloadold,double,2*nload_);
-      if(ithermal[0]!=0) NNEW(t1old,double,nk_); 
-      NNEW(sti,double,6*mi[0]*ne);
-      NNEW(eme,double,6*mi[0]*ne);
-      if(nener==1)NNEW(ener,double,mi[0]*ne*2);
-      if(mcs>ntie_) RENEW(cs,double,17*mcs);
-      if(mortar==1){
-	NNEW(pslavsurf,double,3*nintpoint);
-	NNEW(clearini,double,3*9*ifacecount);
+    if (irstrt[0] < 0) {
+      NNEW(nodebounold, ITG, nboun_);
+      NNEW(ndirbounold, ITG, nboun_);
+      NNEW(xbounold, double, nboun_);
+      NNEW(xforcold, double, nforc_);
+      NNEW(xloadold, double, 2 * nload_);
+      if (ithermal[0] != 0)
+        NNEW(t1old, double, nk_);
+      NNEW(sti, double, 6 * mi[0] * ne);
+      NNEW(eme, double, 6 * mi[0] * ne);
+      if (nener == 1)
+        NNEW(ener, double, mi[0] * ne * 2);
+      if (mcs > ntie_)
+        RENEW(cs, double, 17 * mcs);
+      if (mortar == 1) {
+        NNEW(pslavsurf, double, 3 * nintpoint);
+        NNEW(clearini, double, 3 * 9 * ifacecount);
       }
-			
     }
 
-    nenerold=nener;
-    nkold=nk;
+    nenerold = nener;
+    nkold    = nk;
 
     /* opening the eigenvalue file and checking for cyclic symmetry */
 
-    strcpy(fneig,jobnamec);
-    strcat(fneig,".eig");
-    cyclicsymmetry=0;
-    if((f1=fopen(fneig,"rb"))!=NULL){
-      if(fread(&cyclicsymmetry,sizeof(ITG),1,f1)!=1){
-	printf("*ERROR reading the information whether cyclic symmetry is involved in the eigenvalue file");
-	exit(0);
+    strcpy(fneig, jobnamec);
+    strcat(fneig, ".eig");
+    cyclicsymmetry = 0;
+    if ((f1 = fopen(fneig, "rb")) != NULL) {
+      if (fread(&cyclicsymmetry, sizeof(ITG), 1, f1) != 1) {
+        printf("*ERROR reading the information whether cyclic symmetry is involved in the eigenvalue file");
+        exit(0);
       }
       fclose(f1);
     }
 
-    nmpcold=nmpc;
+    nmpcold = nmpc;
 
     /* reading the input file */
 
     //    if(istep==0)mortar=-2;
-    FORTRAN(calinput,(co,&nk,kon,ipkon,lakon,&nkon,&ne,nodeboun,ndirboun,xboun,
-		      &nboun,ipompc,nodempc,coefmpc,&nmpc,&nmpc_,nodeforc,
-		      ndirforc,xforc,&nforc,&nforc_,nelemload,sideload,xload,
-		      &nload,&nload_,&nprint,prlab,prset,&mpcfree,&nboun_,mei,
-		      set,istartset,iendset,ialset,&nset,&nalset,elcon,nelcon,
-		      rhcon,nrhcon,alcon,nalcon,alzero,t0,t1,matname,ielmat,
-		      orname,orab,ielorien,amname,amta,namta,&nam,&nmethod,
-		      iamforc,iamload,iamt1,ithermal,iperturb,&istat,&istep,
-		      &nmat,&ntmat_,&norien,prestr,&iprestr,&isolver,fei,veold,
-		      timepar,xmodal,filab,jout,&nlabel,&idrct,jmax,&iexpl,
-		      alpha,iamboun,plicon,nplicon,plkcon,nplkcon,&iplas,
-		      &npmat_,mi,&nk_,trab,inotr,&ntrans,ikboun,ilboun,ikmpc,
-		      ilmpc,ics,dcs,&ncs_,&namtot_,cs,&nstate_,&ncmat_,&iumat,
-		      &mcs,labmpc,iponor,xnor,knor,thickn,thicke,ikforc,ilforc,
-		      offset,iponoel,inoel,rig,infree,nshcon,shcon,cocon,
-		      ncocon,physcon,&nflow,ctrl,&maxlenmpc,&ne1d,&ne2d,&nener,
-		      vold,nodebounold,ndirbounold,xbounold,xforcold,xloadold,
-		      t1old,eme,sti,ener,xstate,jobnamec,irstrt,&ttime,qaold,
-		      output,typeboun,inpc,ipoinp,inp,tieset,tietol,&ntie,fmpc,
-		      cbody,ibody,xbody,&nbody,&nbody_,xbodyold,&nam_,ielprop,
-		      &nprop,&nprop_,prop,&itpamp,&iviewfile,ipoinpc,&nslavs,
-		      t0g,t1g,&network,&cyclicsymmetry,idefforc,idefload,
-		      idefbody,&mortar,&ifacecount,islavsurf,pslavsurf,
-		      clearini,heading,&iaxial,&nobject,objectset,&nprint_,
-		      iuel,&nuel_,nodempcref,coefmpcref,ikmpcref,&memmpcref_,
-		      &mpcfreeref,&maxlenmpcref,&memmpc_,&isens,&namtot,&nstam,
-		      dacon,vel,&nef,velo,veloo,ne2boun,itempuser,
-		      irobustdesign,irandomtype,randomval,&nfc,&nfc_,coeffc,
-		      ikdc,&ndc,&ndc_,edc));
-    
-    SFREE(idefforc);SFREE(idefload);SFREE(idefbody);
+    FORTRAN(calinput, (co, &nk, kon, ipkon, lakon, &nkon, &ne, nodeboun, ndirboun, xboun,
+                       &nboun, ipompc, nodempc, coefmpc, &nmpc, &nmpc_, nodeforc,
+                       ndirforc, xforc, &nforc, &nforc_, nelemload, sideload, xload,
+                       &nload, &nload_, &nprint, prlab, prset, &mpcfree, &nboun_, mei,
+                       set, istartset, iendset, ialset, &nset, &nalset, elcon, nelcon,
+                       rhcon, nrhcon, alcon, nalcon, alzero, t0, t1, matname, ielmat,
+                       orname, orab, ielorien, amname, amta, namta, &nam, &nmethod,
+                       iamforc, iamload, iamt1, ithermal, iperturb, &istat, &istep,
+                       &nmat, &ntmat_, &norien, prestr, &iprestr, &isolver, fei, veold,
+                       timepar, xmodal, filab, jout, &nlabel, &idrct, jmax, &iexpl,
+                       alpha, iamboun, plicon, nplicon, plkcon, nplkcon, &iplas,
+                       &npmat_, mi, &nk_, trab, inotr, &ntrans, ikboun, ilboun, ikmpc,
+                       ilmpc, ics, dcs, &ncs_, &namtot_, cs, &nstate_, &ncmat_, &iumat,
+                       &mcs, labmpc, iponor, xnor, knor, thickn, thicke, ikforc, ilforc,
+                       offset, iponoel, inoel, rig, infree, nshcon, shcon, cocon,
+                       ncocon, physcon, &nflow, ctrl, &maxlenmpc, &ne1d, &ne2d, &nener,
+                       vold, nodebounold, ndirbounold, xbounold, xforcold, xloadold,
+                       t1old, eme, sti, ener, xstate, jobnamec, irstrt, &ttime, qaold,
+                       output, typeboun, inpc, ipoinp, inp, tieset, tietol, &ntie, fmpc,
+                       cbody, ibody, xbody, &nbody, &nbody_, xbodyold, &nam_, ielprop,
+                       &nprop, &nprop_, prop, &itpamp, &iviewfile, ipoinpc, &nslavs,
+                       t0g, t1g, &network, &cyclicsymmetry, idefforc, idefload,
+                       idefbody, &mortar, &ifacecount, islavsurf, pslavsurf,
+                       clearini, heading, &iaxial, &nobject, objectset, &nprint_,
+                       iuel, &nuel_, nodempcref, coefmpcref, ikmpcref, &memmpcref_,
+                       &mpcfreeref, &maxlenmpcref, &memmpc_, &isens, &namtot, &nstam,
+                       dacon, vel, &nef, velo, veloo, ne2boun, itempuser,
+                       irobustdesign, irandomtype, randomval, &nfc, &nfc_, coeffc,
+                       ikdc, &ndc, &ndc_, edc));
 
-    if(istat<0) break;
-  
-    /* assigning the body forces to the elements */ 
+    SFREE(idefforc);
+    SFREE(idefload);
+    SFREE(idefbody);
 
-    if(nbody>0){
-      ifreebody=ne+1;
-      NNEW(ipobody,ITG,2*ifreebody*nbody);
-      for(k=1;k<=nbody;k++){
-	FORTRAN(bodyforce,(cbody,ibody,ipobody,&nbody,set,istartset,
-			   iendset,ialset,&inewton,&nset,&ifreebody,&k));
-	RENEW(ipobody,ITG,2*(ne+ifreebody));
+    if (istat < 0)
+      break;
+
+    /* assigning the body forces to the elements */
+
+    if (nbody > 0) {
+      ifreebody = ne + 1;
+      NNEW(ipobody, ITG, 2 * ifreebody * nbody);
+      for (k = 1; k <= nbody; k++) {
+        FORTRAN(bodyforce, (cbody, ibody, ipobody, &nbody, set, istartset,
+                            iendset, ialset, &inewton, &nset, &ifreebody, &k));
+        RENEW(ipobody, ITG, 2 * (ne + ifreebody));
       }
-      RENEW(ipobody,ITG,2*(ifreebody-1));
+      RENEW(ipobody, ITG, 2 * (ifreebody - 1));
     }
-    
-    if(irefineloop==1){
+
+    if (irefineloop == 1) {
 
       /* in the last step refinement was requested and the mesh
          was appropriately refined; this mesh has to be read */
-      
-      readnewmesh(jobnamec,&nboun,nodeboun,iamboun,xboun,&nload,sideload,
-		  iamload,&nforc,nodeforc,iamforc,xforc,ithermal,&nk,&t1,&iamt1,
-		  &ne,&lakon,&ipkon,&kon,istartset,iendset,ialset,set,&nset,
-		  filab,&co,&ipompc,&nodempc,&coefmpc,&nmpc,&nmpc_,&labmpc,
-		  &mpcfree,&memmpc_,&ikmpc,&ilmpc,&nk_,&ne_,&nkon_,&istep,
-		  &nprop_,&ielprop,&ne1d,&ne2d,&iponor,&thickn,&thicke,mi,
-		  &offset,&iponoel,&rig,&ne2boun,&ielorien,&inotr,&t0,&t0g,&t1g,
-		  &prestr,&vold,&veold,&ielmat,irobustdesign,&irandomtype,
-		  &randomval,&nalset,&nalset_,&nkon,xnor,&iaxial,
-		  &network,&nlabel,iuel,iperturb,&iprestr,&ntie,tieset,
-		  &iparentel,ikboun,&ifreebody,&ipobody,&nbody,&iprfn,
-		  &konrfn,&ratiorfn,nodempcref,coefmpcref,&memmpcref_,
-		  &mpcfreeref,&maxlenmpcref,&maxlenmpc,&norien,tietol);
+
+      readnewmesh(jobnamec, &nboun, nodeboun, iamboun, xboun, &nload, sideload,
+                  iamload, &nforc, nodeforc, iamforc, xforc, ithermal, &nk, &t1, &iamt1,
+                  &ne, &lakon, &ipkon, &kon, istartset, iendset, ialset, set, &nset,
+                  filab, &co, &ipompc, &nodempc, &coefmpc, &nmpc, &nmpc_, &labmpc,
+                  &mpcfree, &memmpc_, &ikmpc, &ilmpc, &nk_, &ne_, &nkon_, &istep,
+                  &nprop_, &ielprop, &ne1d, &ne2d, &iponor, &thickn, &thicke, mi,
+                  &offset, &iponoel, &rig, &ne2boun, &ielorien, &inotr, &t0, &t0g, &t1g,
+                  &prestr, &vold, &veold, &ielmat, irobustdesign, &irandomtype,
+                  &randomval, &nalset, &nalset_, &nkon, xnor, &iaxial,
+                  &network, &nlabel, iuel, iperturb, &iprestr, &ntie, tieset,
+                  &iparentel, ikboun, &ifreebody, &ipobody, &nbody, &iprfn,
+                  &konrfn, &ratiorfn, nodempcref, coefmpcref, &memmpcref_,
+                  &mpcfreeref, &maxlenmpcref, &maxlenmpc, &norien, tietol);
     }
 
 #ifdef CALCULIX_EXTERNAL_BEHAVIOURS_SUPPORT
-    for(i=0;i!=nmat;++i){
-      calculix_registerExternalBehaviour(matname+80*i);
+    for (i = 0; i != nmat; ++i) {
+      calculix_registerExternalBehaviour(matname + 80 * i);
     }
 #endif /* CALCULIX_EXTERNAL_BEHAVIOURS_SUPPORT */
-  
+
     //    if((istep==1)&&(mortar==-1)){mortar=0;}else{icontact=1;}
 
-    nload0=nload;
+    nload0 = nload;
 
-    if(iheading==0){
-      writeheading(jobnamec,heading,&nheading_);
-      iheading=1;
+    if (iheading == 0) {
+      writeheading(jobnamec, heading, &nheading_);
+      iheading = 1;
     }
 
     /*    if(nheading_>=0){
@@ -712,424 +750,452 @@ int preciceUsed = 0;
       nheading_=-1;
       }*/
 
-    if((abs(nmethod)!=1)||(iperturb[0]<2))icascade=0;
+    if ((abs(nmethod) != 1) || (iperturb[0] < 2))
+      icascade = 0;
 
     //    FORTRAN(writeboun,(nodeboun,ndirboun,xboun,typeboun,&nboun));
 
-    if(istep==1){
+    if (istep == 1) {
 
       SFREE(iuel);
 
       /* tied contact constraints: generate appropriate MPC's */
 
-      tiedcontact(&ntie, tieset, &nset, set,istartset, iendset, ialset,
-		  lakon, ipkon, kon,tietol,&nmpc, &mpcfree, &memmpc_,
-		  &ipompc, &labmpc, &ikmpc, &ilmpc,&fmpc, &nodempc, &coefmpc,
-		  ithermal, co, vold,&nef,&nmpc_,mi,&nk,&istep,ikboun,&nboun,
-		  kind1,kind2);
+      tiedcontact(&ntie, tieset, &nset, set, istartset, iendset, ialset,
+                  lakon, ipkon, kon, tietol, &nmpc, &mpcfree, &memmpc_,
+                  &ipompc, &labmpc, &ikmpc, &ilmpc, &fmpc, &nodempc, &coefmpc,
+                  ithermal, co, vold, &nef, &nmpc_, mi, &nk, &istep, ikboun, &nboun,
+                  kind1, kind2);
 
       /* reallocating space in the first step */
 
       /* allocating and initializing fields pointing to the previous step */
 
-      RENEW(vold,double,mt*nk);
-      NNEW(sti,double,6*mi[0]*ne);
+      RENEW(vold, double, mt *nk);
+      NNEW(sti, double, 6 * mi[0] * ne);
 
       /* strains */
 
-      NNEW(eme,double,6*mi[0]*ne);
+      NNEW(eme, double, 6 * mi[0] * ne);
 
       /* residual stresses/strains */
 
-      if(iprestr==1){
-	RENEW(prestr,double,6*mi[0]*ne);
-	for(i=0;i<ne;i++){
-	  for(j=0;j<mi[0];j++){
-	    for(k=0;k<6;k++){
-	      sti[6*mi[0]*i+6*j+k]=prestr[6*mi[0]*i+6*j+k];
-	    }
-	  }
-	}
-      }
-      else if(iprestr==2){
-	RENEW(prestr,double,6*mi[0]*ne);
-	for(i=0;i<ne;i++){
-	  for(j=0;j<mi[0];j++){
-	    for(k=0;k<6;k++){
-	      eme[6*mi[0]*i+6*j+k]=prestr[6*mi[0]*i+6*j+k];
-	    }
-	  }
-	}
-      }
-      else {
-	SFREE(prestr);
+      if (iprestr == 1) {
+        RENEW(prestr, double, 6 * mi[0] * ne);
+        for (i = 0; i < ne; i++) {
+          for (j = 0; j < mi[0]; j++) {
+            for (k = 0; k < 6; k++) {
+              sti[6 * mi[0] * i + 6 * j + k] = prestr[6 * mi[0] * i + 6 * j + k];
+            }
+          }
+        }
+      } else if (iprestr == 2) {
+        RENEW(prestr, double, 6 * mi[0] * ne);
+        for (i = 0; i < ne; i++) {
+          for (j = 0; j < mi[0]; j++) {
+            for (k = 0; k < 6; k++) {
+              eme[6 * mi[0] * i + 6 * j + k] = prestr[6 * mi[0] * i + 6 * j + k];
+            }
+          }
+        }
+      } else {
+        SFREE(prestr);
       }
 
-      NNEW(nodebounold,ITG,nboun);
-      NNEW(ndirbounold,ITG,nboun);
-      NNEW(xbounold,double,nboun);
-      NNEW(xforcold,double,nforc);
-      NNEW(xloadold,double,2*nload);
+      NNEW(nodebounold, ITG, nboun);
+      NNEW(ndirbounold, ITG, nboun);
+      NNEW(xbounold, double, nboun);
+      NNEW(xforcold, double, nforc);
+      NNEW(xloadold, double, 2 * nload);
 
       /* initial temperatures: store in the "old" boundary conditions */
 
-      if(ithermal[0]>1){
-	for(i=0;i<nboun;i++){
-	  if(strcmp1(&typeboun[i],"F")==0) continue;
-	  if(ndirboun[i]==0){
-	    xbounold[i]=vold[mt*(nodeboun[i]-1)];
-	  }
-	}
+      if (ithermal[0] > 1) {
+        for (i = 0; i < nboun; i++) {
+          if (strcmp1(&typeboun[i], "F") == 0)
+            continue;
+          if (ndirboun[i] == 0) {
+            xbounold[i] = vold[mt * (nodeboun[i] - 1)];
+          }
+        }
       }
 
       /* initial temperatures: store in the "old" temperature field */
 
-      if(ithermal[0]!=0){
-	NNEW(t1old,double,nk);
-	for(i=0;i<nk;i++) t1old[i]=t0[i];
+      if (ithermal[0] != 0) {
+        NNEW(t1old, double, nk);
+        for (i = 0; i < nk; i++)
+          t1old[i] = t0[i];
       }
 
       /* element definition */
 
-      RENEW(kon,ITG,nkon);
-      RENEW(ipkon,ITG,ne);
-      RENEW(lakon,char,8*ne);
+      RENEW(kon, ITG, nkon);
+      RENEW(ipkon, ITG, ne);
+      RENEW(lakon, char, 8 * ne);
 
       /* property cards */
 
-      if(nprop_>0){
-	RENEW(ielprop,ITG,ne);
-	RENEW(prop,double,nprop);
-      }else{
-	SFREE(ielprop);SFREE(prop);
+      if (nprop_ > 0) {
+        RENEW(ielprop, ITG, ne);
+        RENEW(prop, double, nprop);
+      } else {
+        SFREE(ielprop);
+        SFREE(prop);
       }
 
       /* coupling, distributed */
 
-      if(nfc>0){
-	RENEW(coeffc,double,7*nfc);
-	RENEW(ikdc,ITG,ndc);
-	RENEW(edc,double,12*ndc);
-      }else{
-	SFREE(coeffc);SFREE(ikdc);SFREE(edc);
+      if (nfc > 0) {
+        RENEW(coeffc, double, 7 * nfc);
+        RENEW(ikdc, ITG, ndc);
+        RENEW(edc, double, 12 * ndc);
+      } else {
+        SFREE(coeffc);
+        SFREE(ikdc);
+        SFREE(edc);
       }
 
       /* fields for 1-D and 2-D elements */
 
-      if((ne1d!=0)||(ne2d!=0)){
-	RENEW(iponor,ITG,2*nkon);
-	RENEW(xnor,double,infree[0]);
-	RENEW(knor,ITG,infree[1]);
-	SFREE(thickn);
-	RENEW(thicke,double,mi[2]*nkon);
-	RENEW(offset,double,2*ne);
-	RENEW(inoel,ITG,3*(infree[2]-1));
-	RENEW(iponoel,ITG,infree[3]);
-	RENEW(rig,ITG,infree[3]);
-	RENEW(ne2boun,ITG,2*infree[3]);
+      if ((ne1d != 0) || (ne2d != 0)) {
+        RENEW(iponor, ITG, 2 * nkon);
+        RENEW(xnor, double, infree[0]);
+        RENEW(knor, ITG, infree[1]);
+        SFREE(thickn);
+        RENEW(thicke, double, mi[2] * nkon);
+        RENEW(offset, double, 2 * ne);
+        RENEW(inoel, ITG, 3 * (infree[2] - 1));
+        RENEW(iponoel, ITG, infree[3]);
+        RENEW(rig, ITG, infree[3]);
+        RENEW(ne2boun, ITG, 2 * infree[3]);
       }
 
-      /* set definitions */ 
+      /* set definitions */
 
-      RENEW(set,char,81*nset);
-      RENEW(istartset,ITG,nset);
-      RENEW(iendset,ITG,nset);
-      RENEW(ialset,ITG,nalset);
+      RENEW(set, char, 81 * nset);
+      RENEW(istartset, ITG, nset);
+      RENEW(iendset, ITG, nset);
+      RENEW(ialset, ITG, nalset);
 
       /* material properties */
 
-      RENEW(elcon,double,(ncmat_+1)*ntmat_*nmat);
-      RENEW(nelcon,ITG,2*nmat);
+      RENEW(elcon, double, (ncmat_ + 1) * ntmat_ * nmat);
+      RENEW(nelcon, ITG, 2 * nmat);
 
-      RENEW(rhcon,double,2*ntmat_*nmat);
-      RENEW(nrhcon,ITG,nmat);
+      RENEW(rhcon, double, 2 * ntmat_ * nmat);
+      RENEW(nrhcon, ITG, nmat);
 
-      if(ndamp>0){RENEW(dacon,double,nmat);}
+      if (ndamp > 0) {
+        RENEW(dacon, double, nmat);
+      }
 
-      RENEW(shcon,double,4*ntmat_*nmat);
-      RENEW(nshcon,ITG,nmat);
+      RENEW(shcon, double, 4 * ntmat_ * nmat);
+      RENEW(nshcon, ITG, nmat);
 
-      RENEW(cocon,double,7*ntmat_*nmat);
-      RENEW(ncocon,ITG,2*nmat);
+      RENEW(cocon, double, 7 * ntmat_ * nmat);
+      RENEW(ncocon, ITG, 2 * nmat);
 
-      RENEW(alcon,double,7*ntmat_*nmat);
-      RENEW(nalcon,ITG,2*nmat);
-      RENEW(alzero,double,nmat);
+      RENEW(alcon, double, 7 * ntmat_ * nmat);
+      RENEW(nalcon, ITG, 2 * nmat);
+      RENEW(alzero, double, nmat);
 
-      RENEW(matname,char,80*nmat);
-      RENEW(ielmat,ITG,mi[2]*ne);
+      RENEW(matname, char, 80 * nmat);
+      RENEW(ielmat, ITG, mi[2] * ne);
 
       /* allocating space for the state variables */
 
-      if(mortar!=1){
-	RENEW(xstate,double,nstate_*mi[0]*(ne+nslavs));
-	for(i=nxstate;i<nstate_*mi[0]*(ne+nslavs);i++){xstate[i]=0.;}
-      }else if(mortar==1){
-	RENEW(xstate,double,nstate_*mi[0]*(ne+nintpoint));
-	for(i=nxstate;i<nstate_*mi[0]*(ne+nintpoint);i++){xstate[i]=0.;}
+      if (mortar != 1) {
+        RENEW(xstate, double, nstate_ *mi[0] * (ne + nslavs));
+        for (i = nxstate; i < nstate_ * mi[0] * (ne + nslavs); i++) {
+          xstate[i] = 0.;
+        }
+      } else if (mortar == 1) {
+        RENEW(xstate, double, nstate_ *mi[0] * (ne + nintpoint));
+        for (i = nxstate; i < nstate_ * mi[0] * (ne + nintpoint); i++) {
+          xstate[i] = 0.;
+        }
       }
 
       /* next statements for plastic materials and nonlinear springs */
 
-      if(npmat_>0){
-	RENEW(plicon,double,(2*npmat_+1)*ntmat_*nmat);
-	RENEW(nplicon,ITG,(ntmat_+1)*nmat);
-	RENEW(plkcon,double,(2*npmat_+1)*ntmat_*nmat);
-	RENEW(nplkcon,ITG,(ntmat_+1)*nmat);
+      if (npmat_ > 0) {
+        RENEW(plicon, double, (2 * npmat_ + 1) * ntmat_ * nmat);
+        RENEW(nplicon, ITG, (ntmat_ + 1) * nmat);
+        RENEW(plkcon, double, (2 * npmat_ + 1) * ntmat_ * nmat);
+        RENEW(nplkcon, ITG, (ntmat_ + 1) * nmat);
       }
 
       /* material orientation */
 
-      if(norien>0){
-	RENEW(orname,char,80*norien);
-	RENEW(ielorien,ITG,mi[2]*ne);
-	RENEW(orab,double,7*norien);
-      }
-      else {
-	SFREE(orname);
-	SFREE(ielorien);
-	SFREE(orab);
+      if (norien > 0) {
+        RENEW(orname, char, 80 * norien);
+        RENEW(ielorien, ITG, mi[2] * ne);
+        RENEW(orab, double, 7 * norien);
+      } else {
+        SFREE(orname);
+        SFREE(ielorien);
+        SFREE(orab);
       }
 
       /* amplitude definitions */
 
-      if(nam>0){
-	RENEW(amname,char,80*nam);
-	RENEW(namta,ITG,3*nam);
-	RENEW(amta,double,2*namta[3*nam-2]);
-      }
-      else {
-	SFREE(amname);
-	SFREE(amta);
-	SFREE(namta);
-	SFREE(iamforc);
-	SFREE(iamload);
-	SFREE(iamboun);
-      }
-
-      if(ntrans>0){
-	RENEW(trab,double,7*ntrans);
-      }
-      else{SFREE(trab);SFREE(inotr);}
-
-      if(ithermal[0]==0){
-	SFREE(t0);SFREE(t1);
-	if((ne1d!=0)||(ne2d!=0)||(nuel_!=0)){
-	  SFREE(t0g);SFREE(t1g);
-	}
-      }
-      
-      if((ithermal[0]==0)||(nam<=0)){SFREE(iamt1);}
-
-      if(ncs_>0){
-	RENEW(ics,ITG,ncs_);
-      }else if(npt_>0){
-	SFREE(ics);
-      }
-      if((ncs_>0)||(npt_>0)){
-	SFREE(dcs);
+      if (nam > 0) {
+        RENEW(amname, char, 80 * nam);
+        RENEW(namta, ITG, 3 * nam);
+        RENEW(amta, double, 2 * namta[3 * nam - 2]);
+      } else {
+        SFREE(amname);
+        SFREE(amta);
+        SFREE(namta);
+        SFREE(iamforc);
+        SFREE(iamload);
+        SFREE(iamboun);
       }
 
-      if(mcs>0){
-	RENEW(cs,double,17*mcs);
-      }else{
-	SFREE(cs);
+      if (ntrans > 0) {
+        RENEW(trab, double, 7 * ntrans);
+      } else {
+        SFREE(trab);
+        SFREE(inotr);
+      }
+
+      if (ithermal[0] == 0) {
+        SFREE(t0);
+        SFREE(t1);
+        if ((ne1d != 0) || (ne2d != 0) || (nuel_ != 0)) {
+          SFREE(t0g);
+          SFREE(t1g);
+        }
+      }
+
+      if ((ithermal[0] == 0) || (nam <= 0)) {
+        SFREE(iamt1);
+      }
+
+      if (ncs_ > 0) {
+        RENEW(ics, ITG, ncs_);
+      } else if (npt_ > 0) {
+        SFREE(ics);
+      }
+      if ((ncs_ > 0) || (npt_ > 0)) {
+        SFREE(dcs);
+      }
+
+      if (mcs > 0) {
+        RENEW(cs, double, 17 * mcs);
+      } else {
+        SFREE(cs);
       }
 
       /* check for design variables */
-      
-      for(i=0;i<ntie;i++){
-        if(strcmp1(&tieset[i*243+80],"D")==0){
-          if(strcmp1(&tieset[i*243],"COORDINATE")==0){
-	    icoordinate=1;
-	  }
-	}
+
+      for (i = 0; i < ntie; i++) {
+        if (strcmp1(&tieset[i * 243 + 80], "D") == 0) {
+          if (strcmp1(&tieset[i * 243], "COORDINATE") == 0) {
+            icoordinate = 1;
+          }
+        }
       }
 
-    }else{
+    } else {
 
       /* reallocating space in all but the first step (>1) */
 
-      RENEW(vold,double,mt*nk);
+      RENEW(vold, double, mt *nk);
 
       /* if the SPC boundary conditions were changed in the present step,
 	 they have to be rematched with those in the last step. Removed SPC 
 	 boundary conditions do not appear any more (this is different from
 	 forces and loads, where removed forces or loads are reset to zero;
 	 a removed SPC constraint does not have a numerical value any more) */
-       
-      NNEW(reorder,double,nboun);
-      NNEW(nreorder,ITG,nboun);
-      if(nbounold<nboun){
-	RENEW(xbounold,double,nboun);
-	RENEW(nodebounold,ITG,nboun);
-	RENEW(ndirbounold,ITG,nboun);
+
+      NNEW(reorder, double, nboun);
+      NNEW(nreorder, ITG, nboun);
+      if (nbounold < nboun) {
+        RENEW(xbounold, double, nboun);
+        RENEW(nodebounold, ITG, nboun);
+        RENEW(ndirbounold, ITG, nboun);
       }
-      FORTRAN(spcmatch,(xboun,nodeboun,ndirboun,&nboun,xbounold,nodebounold,
-			ndirbounold,&nbounold,ikboun,ilboun,vold,reorder,nreorder,
-			mi,typeboun));
-      RENEW(xbounold,double,nboun);
-      RENEW(nodebounold,ITG,nboun);
-      RENEW(ndirbounold,ITG,nboun);
-      SFREE(reorder); SFREE(nreorder);
+      FORTRAN(spcmatch, (xboun, nodeboun, ndirboun, &nboun, xbounold, nodebounold,
+                         ndirbounold, &nbounold, ikboun, ilboun, vold, reorder, nreorder,
+                         mi, typeboun));
+      RENEW(xbounold, double, nboun);
+      RENEW(nodebounold, ITG, nboun);
+      RENEW(ndirbounold, ITG, nboun);
+      SFREE(reorder);
+      SFREE(nreorder);
 
       /* for additional forces or loads in the present step, the
 	 corresponding slots in the force and load fields of the
 	 previous steps are initialized */
 
-      RENEW(xforcold,double,nforc);
-      for(i=nforcold;i<nforc;i++) xforcold[i]=0;
+      RENEW(xforcold, double, nforc);
+      for (i = nforcold; i < nforc; i++)
+        xforcold[i] = 0;
 
-      RENEW(xloadold,double,2*nload);
-      for(i=2*nloadold;i<2*nload;i++) xloadold[i]=0;
+      RENEW(xloadold, double, 2 * nload);
+      for (i = 2 * nloadold; i < 2 * nload; i++)
+        xloadold[i] = 0;
 
-      if(ithermal[0]!=0){
-	RENEW(t1old,double,nk);
+      if (ithermal[0] != 0) {
+        RENEW(t1old, double, nk);
       }
 
-      if(nam>0){
-	RENEW(amname,char,80*nam);
-	RENEW(namta,ITG,3*nam);
-	RENEW(amta,double,2*namta[3*nam-2]);
+      if (nam > 0) {
+        RENEW(amname, char, 80 * nam);
+        RENEW(namta, ITG, 3 * nam);
+        RENEW(amta, double, 2 * namta[3 * nam - 2]);
       }
-    
     }
 
     /* reallocating fields for all steps (>=1) */
 
-    RENEW(co,double,3*nk);
+    RENEW(co, double, 3 * nk);
 
-    RENEW(nodeboun,ITG,nboun);
-    RENEW(ndirboun,ITG,nboun);
-    RENEW(typeboun,char,nboun+1);
-    RENEW(xboun,double,nboun);
-    RENEW(ikboun,ITG,nboun);
-    RENEW(ilboun,ITG,nboun);
-    
-    RENEW(nodeforc,ITG,2*nforc);
-    RENEW(ndirforc,ITG,nforc);
-    RENEW(xforc,double,nforc);
-    RENEW(ikforc,ITG,nforc);
-    RENEW(ilforc,ITG,nforc);
+    RENEW(nodeboun, ITG, nboun);
+    RENEW(ndirboun, ITG, nboun);
+    RENEW(typeboun, char, nboun + 1);
+    RENEW(xboun, double, nboun);
+    RENEW(ikboun, ITG, nboun);
+    RENEW(ilboun, ITG, nboun);
+
+    RENEW(nodeforc, ITG, 2 * nforc);
+    RENEW(ndirforc, ITG, nforc);
+    RENEW(xforc, double, nforc);
+    RENEW(ikforc, ITG, nforc);
+    RENEW(ilforc, ITG, nforc);
 
     /* temperature loading */
-  
-    if(ithermal[0] != 0){
-      RENEW(t0,double,nk);
-      RENEW(t1,double,nk);
-      if((ne1d!=0)||(ne2d!=0)||(nuel_!=0)){
-	RENEW(t0g,double,2*nk);
-	RENEW(t1g,double,2*nk);
+
+    if (ithermal[0] != 0) {
+      RENEW(t0, double, nk);
+      RENEW(t1, double, nk);
+      if ((ne1d != 0) || (ne2d != 0) || (nuel_ != 0)) {
+        RENEW(t0g, double, 2 * nk);
+        RENEW(t1g, double, 2 * nk);
       }
-      if(nam>0){RENEW(iamt1,ITG,nk);}
+      if (nam > 0) {
+        RENEW(iamt1, ITG, nk);
+      }
     }
 
-    RENEW(nelemload,ITG,2*nload);
-    RENEW(sideload,char,20*nload);
-    RENEW(xload,double,2*nload);
+    RENEW(nelemload, ITG, 2 * nload);
+    RENEW(sideload, char, 20 * nload);
+    RENEW(xload, double, 2 * nload);
 
-    RENEW(cbody,char,81*nbody);
-    RENEW(ibody,ITG,3*nbody);
-    RENEW(xbody,double,7*nbody);
-    RENEW(xbodyold,double,7*nbody);
+    RENEW(cbody, char, 81 * nbody);
+    RENEW(ibody, ITG, 3 * nbody);
+    RENEW(xbody, double, 7 * nbody);
+    RENEW(xbodyold, double, 7 * nbody);
 
-    RENEW(ipompc,ITG,nmpc);
-    RENEW(labmpc,char,20*nmpc+1);
-    RENEW(ikmpc,ITG,nmpc);
-    RENEW(ilmpc,ITG,nmpc);
-    RENEW(fmpc,double,nmpc);
+    RENEW(ipompc, ITG, nmpc);
+    RENEW(labmpc, char, 20 * nmpc + 1);
+    RENEW(ikmpc, ITG, nmpc);
+    RENEW(ilmpc, ITG, nmpc);
+    RENEW(fmpc, double, nmpc);
 
     /* energy */
 
-    if((nener==1)&&(nenerold==0)){
-      NNEW(ener,double,mi[0]*ne*2);
-      if((istep>1)&&(iperturb[0]>1)){
-	printf(" *ERROR in CalculiX: in nonlinear calculations\n");
-	printf("        energy output must be selected in the first step\n\n");
-	FORTRAN(stop,());
+    if ((nener == 1) && (nenerold == 0)) {
+      NNEW(ener, double, mi[0] * ne * 2);
+      if ((istep > 1) && (iperturb[0] > 1)) {
+        printf(" *ERROR in CalculiX: in nonlinear calculations\n");
+        printf("        energy output must be selected in the first step\n\n");
+        FORTRAN(stop, ());
       }
     }
 
     /* initial velocities and accelerations */
 
-    if((nmethod==4)||(nmethod==5)||(nmethod==8)||(nmethod==9)||
-       ((abs(nmethod)==1)&&(iperturb[0]>=2))){
-      RENEW(veold,double,mt*nk);
-    }
-    else{
+    if ((nmethod == 4) || (nmethod == 5) || (nmethod == 8) || (nmethod == 9) ||
+        ((abs(nmethod) == 1) && (iperturb[0] >= 2))) {
+      RENEW(veold, double, mt *nk);
+    } else {
       SFREE(veold);
     }
 
-    if((nmethod==4)&&(iperturb[0]>1)){
-      NNEW(accold,double,mt*nk);
+    if ((nmethod == 4) && (iperturb[0] > 1)) {
+      NNEW(accold, double, mt *nk);
     }
 
-    if(nam>0){
-      RENEW(iamforc,ITG,nforc);
-      RENEW(iamload,ITG,2*nload);
-      RENEW(iamboun,ITG,nboun);
+    if (nam > 0) {
+      RENEW(iamforc, ITG, nforc);
+      RENEW(iamload, ITG, 2 * nload);
+      RENEW(iamboun, ITG, nboun);
     }
 
     /* generate force convection elements */
 
-    if(network>0){
-      ne0=ne;nkon0=nkon;nload1=nload;
-      RENEW(ipkon,ITG,ne+nload);
-      RENEW(ielmat,ITG,mi[2]*(ne+nload));
-      for(i=mi[2]*ne;i<mi[2]*(ne+nload);i++)ielmat[i]=0;
-      if(norien>0){
-	RENEW(ielorien,ITG,mi[2]*(ne+nload));
-	for(i=mi[2]*ne;i<mi[2]*(ne+nload);i++)ielorien[i]=0;
+    if (network > 0) {
+      ne0    = ne;
+      nkon0  = nkon;
+      nload1 = nload;
+      RENEW(ipkon, ITG, ne + nload);
+      RENEW(ielmat, ITG, mi[2] * (ne + nload));
+      for (i = mi[2] * ne; i < mi[2] * (ne + nload); i++)
+        ielmat[i] = 0;
+      if (norien > 0) {
+        RENEW(ielorien, ITG, mi[2] * (ne + nload));
+        for (i = mi[2] * ne; i < mi[2] * (ne + nload); i++)
+          ielorien[i] = 0;
       }
-      RENEW(lakon,char,8*(ne+nload));
-      RENEW(kon,ITG,nkon+9*nload);
-      NNEW(inodesd,ITG,nk);
-      RENEW(nelemload,ITG,4*nload);
-      RENEW(sideload,char,40*nload);
-      
-      FORTRAN(genadvecelem,(inodesd,ipkon,&ne,lakon,kon,&nload,
-			    sideload,nelemload,&nkon,&network));
-      
+      RENEW(lakon, char, 8 * (ne + nload));
+      RENEW(kon, ITG, nkon + 9 * nload);
+      NNEW(inodesd, ITG, nk);
+      RENEW(nelemload, ITG, 4 * nload);
+      RENEW(sideload, char, 40 * nload);
+
+      FORTRAN(genadvecelem, (inodesd, ipkon, &ne, lakon, kon, &nload,
+                             sideload, nelemload, &nkon, &network));
+
       SFREE(inodesd);
-      RENEW(ipkon,ITG,ne);
-      RENEW(lakon,char,8*ne);
-      RENEW(kon,ITG,nkon);
-      RENEW(sti,double,6*mi[0]*ne);
-      RENEW(eme,double,6*mi[0]*ne);
-      if(iprestr>0) RENEW(prestr,double,6*mi[0]*ne);
-      if(nprop>0) RENEW(ielprop,ITG,ne);
-      if((ne1d!=0)||(ne2d!=0)) RENEW(offset,double,2*ne);
-      RENEW(nelemload,ITG,2*nload);
-      RENEW(sideload,char,20*nload);
-      RENEW(xload,double,2*nload);
-      RENEW(xloadold,double,2*nload);
-      if(nam>0){
-	RENEW(iamload,ITG,2*nload);
-	for(i=2*nload1;i<2*nload;i++)iamload[i]=0;
+      RENEW(ipkon, ITG, ne);
+      RENEW(lakon, char, 8 * ne);
+      RENEW(kon, ITG, nkon);
+      RENEW(sti, double, 6 * mi[0] * ne);
+      RENEW(eme, double, 6 * mi[0] * ne);
+      if (iprestr > 0)
+        RENEW(prestr, double, 6 * mi[0] * ne);
+      if (nprop > 0)
+        RENEW(ielprop, ITG, ne);
+      if ((ne1d != 0) || (ne2d != 0))
+        RENEW(offset, double, 2 * ne);
+      RENEW(nelemload, ITG, 2 * nload);
+      RENEW(sideload, char, 20 * nload);
+      RENEW(xload, double, 2 * nload);
+      RENEW(xloadold, double, 2 * nload);
+      if (nam > 0) {
+        RENEW(iamload, ITG, 2 * nload);
+        for (i = 2 * nload1; i < 2 * nload; i++)
+          iamload[i] = 0;
       }
-      if(nener==1)RENEW(ener,double,mi[0]*ne*2);
-      if(norien>0)RENEW(ielorien,ITG,mi[2]*ne);
-      RENEW(ielmat,ITG,mi[2]*ne);
-      for(i=mi[2]*ne0;i<mi[2]*ne;i++)ielmat[i]=1;
+      if (nener == 1)
+        RENEW(ener, double, mi[0] * ne * 2);
+      if (norien > 0)
+        RENEW(ielorien, ITG, mi[2] * ne);
+      RENEW(ielmat, ITG, mi[2] * ne);
+      for (i = mi[2] * ne0; i < mi[2] * ne; i++)
+        ielmat[i] = 1;
     }
 
-    if(ntrans>0){
-      RENEW(inotr,ITG,2*nk);
+    if (ntrans > 0) {
+      RENEW(inotr, ITG, 2 * nk);
     }
-  
+
     /*   calling the user routine ufaceload (can be empty) */
 
-    if(ithermal[1]>=2){
-      NNEW(sideloadtemp,char,20*nload);
-      for(i=0;i<nload;i++){
-	strcpy1(&sideloadtemp[20*i],&sideload[20*i],20);
-	if((strcmp1(&sideload[20*i]," ")==0)&&
-	   (strcmp1(&sideload[20*i+1]," ")!=0)){
-	  strcpy1(&sideloadtemp[20*i],"F",1);
-	}
+    if (ithermal[1] >= 2) {
+      NNEW(sideloadtemp, char, 20 * nload);
+      for (i = 0; i < nload; i++) {
+        strcpy1(&sideloadtemp[20 * i], &sideload[20 * i], 20);
+        if ((strcmp1(&sideload[20 * i], " ") == 0) &&
+            (strcmp1(&sideload[20 * i + 1], " ") != 0)) {
+          strcpy1(&sideloadtemp[20 * i], "F", 1);
+        }
       }
-      FORTRAN(ufaceload,(co,ipkon,kon,lakon,&nboun,nodeboun,
-			 nelemload,sideloadtemp,&nload,&ne,&nk));
+      FORTRAN(ufaceload, (co, ipkon, kon, lakon, &nboun, nodeboun,
+                          nelemload, sideloadtemp, &nload, &ne, &nk));
       SFREE(sideloadtemp);
     }
 
@@ -1139,71 +1205,91 @@ int preciceUsed = 0;
        2) in any subsequent step in which the MPC's were changed by
           the user in the input deck */
 
-    if(mpcfreeref==-1){
-      if(istep>1){SFREE(nodempcref);SFREE(coefmpcref);SFREE(ikmpcref);}
-      memmpcref_=memmpc_;mpcfreeref=mpcfree;maxlenmpcref=maxlenmpc;
-      NNEW(nodempcref,ITG,3*memmpc_);
-      memcpy(nodempcref,nodempc,sizeof(ITG)*3*memmpc_);
-      NNEW(coefmpcref,double,memmpc_);
-      memcpy(coefmpcref,coefmpc,sizeof(double)*memmpc_);
-      NNEW(ikmpcref,ITG,nmpc);memcpy(ikmpcref,ikmpc,sizeof(ITG)*nmpc);
+    if (mpcfreeref == -1) {
+      if (istep > 1) {
+        SFREE(nodempcref);
+        SFREE(coefmpcref);
+        SFREE(ikmpcref);
+      }
+      memmpcref_   = memmpc_;
+      mpcfreeref   = mpcfree;
+      maxlenmpcref = maxlenmpc;
+      NNEW(nodempcref, ITG, 3 * memmpc_);
+      memcpy(nodempcref, nodempc, sizeof(ITG) * 3 * memmpc_);
+      NNEW(coefmpcref, double, memmpc_);
+      memcpy(coefmpcref, coefmpc, sizeof(double) * memmpc_);
+      NNEW(ikmpcref, ITG, nmpc);
+      memcpy(ikmpcref, ikmpc, sizeof(ITG) * nmpc);
     }
- 
+
     /* decascading MPC's only necessary if MPC's changed */
 
-    if(((istep==1)||(ntrans>0)||(mpcend<0)||(nk!=nkold)||(nmpc!=nmpcold))&&(icascade==0)){
+    if (((istep == 1) || (ntrans > 0) || (mpcend < 0) || (nk != nkold) || (nmpc != nmpcold)) && (icascade == 0)) {
 
       /* decascading the MPC's */
 
       printf(" Decascading the MPC's\n\n");
 
-      callfrommain=1;
-      cascade(ipompc,&coefmpc,&nodempc,&nmpc,
-	      &mpcfree,nodeboun,ndirboun,&nboun,ikmpc,
-	      ilmpc,ikboun,ilboun,&mpcend,
-	      labmpc,&nk,&memmpc_,&icascade,&maxlenmpc,
-	      &callfrommain,iperturb,ithermal);
+      callfrommain = 1;
+      cascade(ipompc, &coefmpc, &nodempc, &nmpc,
+              &mpcfree, nodeboun, ndirboun, &nboun, ikmpc,
+              ilmpc, ikboun, ilboun, &mpcend,
+              labmpc, &nk, &memmpc_, &icascade, &maxlenmpc,
+              &callfrommain, iperturb, ithermal);
     }
 
     /* determining the matrix structure: changes if SPC's have changed */
-  
-    if((icascade==0)&&(nmethod<8)) printf(" Determining the structure of the matrix:\n");
-  
-    NNEW(nactdof,ITG,mt*nk);  
-    NNEW(mast1,ITG,nzs[1]);
-    NNEW(irow,ITG,1);
-  
-    if((mcs==0)||(cs[1]<0)){
-      
-      NNEW(icol,ITG,mt*nk);
-      NNEW(jq,ITG,mt*nk+1);
-      NNEW(ipointer,ITG,mt*nk);
-      
-      if((icascade==0)&&((nmethod<8)||(nmethod>10))){
-	if((nmethod==11)||(nmethod==13)){nmethodl=2;}else{nmethodl=nmethod;}
-	mastruct(&nk,kon,ipkon,lakon,&ne,nodeboun,ndirboun,&nboun,ipompc,
-		 nodempc,&nmpc,nactdof,icol,jq,&mast1,&irow,&isolver,neq,
-		 ikmpc,ilmpc,ipointer,nzs,&nmethodl,ithermal,
-		 ikboun,ilboun,iperturb,mi,&mortar,typeboun,labmpc,
-		 &iit,&icascade,&network,&iexpl);
+
+    if ((icascade == 0) && (nmethod < 8))
+      printf(" Determining the structure of the matrix:\n");
+
+    NNEW(nactdof, ITG, mt * nk);
+    NNEW(mast1, ITG, nzs[1]);
+    NNEW(irow, ITG, 1);
+
+    if ((mcs == 0) || (cs[1] < 0)) {
+
+      NNEW(icol, ITG, mt * nk);
+      NNEW(jq, ITG, mt * nk + 1);
+      NNEW(ipointer, ITG, mt * nk);
+
+      if ((icascade == 0) && ((nmethod < 8) || (nmethod > 10))) {
+        if ((nmethod == 11) || (nmethod == 13)) {
+          nmethodl = 2;
+        } else {
+          nmethodl = nmethod;
+        }
+        mastruct(&nk, kon, ipkon, lakon, &ne, nodeboun, ndirboun, &nboun, ipompc,
+                 nodempc, &nmpc, nactdof, icol, jq, &mast1, &irow, &isolver, neq,
+                 ikmpc, ilmpc, ipointer, nzs, &nmethodl, ithermal,
+                 ikboun, ilboun, iperturb, mi, &mortar, typeboun, labmpc,
+                 &iit, &icascade, &network, &iexpl);
+      } else {
+        neq[0] = 1;
+        neq[1] = 1;
+        neq[2] = 1;
       }
-      else{neq[0]=1;neq[1]=1;neq[2]=1;}
+    } else {
+
+      NNEW(icol, ITG, 8 * nk);
+      NNEW(jq, ITG, 8 * nk + 1);
+      NNEW(ipointer, ITG, 8 * nk);
+
+      if (nmethod == 13) {
+        nmethodl = 2;
+      } else {
+        nmethodl = nmethod;
+      }
+      mastructcs(&nk, kon, ipkon, lakon, &ne, nodeboun, ndirboun, &nboun,
+                 ipompc, nodempc, &nmpc, nactdof, icol, jq, &mast1, &irow, &isolver,
+                 neq, ikmpc, ilmpc, ipointer, nzs, &nmethodl,
+                 ics, cs, labmpc, &mcs, mi, &mortar);
     }
-    else{
-      
-      NNEW(icol,ITG,8*nk);
-      NNEW(jq,ITG,8*nk+1);
-      NNEW(ipointer,ITG,8*nk);
-      
-      if(nmethod==13){nmethodl=2;}else{nmethodl=nmethod;}
-      mastructcs(&nk,kon,ipkon,lakon,&ne,nodeboun,ndirboun,&nboun,
-		 ipompc,nodempc,&nmpc,nactdof,icol,jq,&mast1,&irow,&isolver,
-		 neq,ikmpc,ilmpc,ipointer,nzs,&nmethodl,
-		 ics,cs,labmpc,&mcs,mi,&mortar);
-    }
-  
-    SFREE(ipointer);SFREE(mast1);
-    if((icascade==0)&&(nmethod<8))RENEW(irow,ITG,nzs[2]);
+
+    SFREE(ipointer);
+    SFREE(mast1);
+    if ((icascade == 0) && (nmethod < 8))
+      RENEW(irow, ITG, nzs[2]);
 
     /* nmethod=1: static analysis   */
     /* nmethod=2: frequency analysis  */
@@ -1221,805 +1307,853 @@ int preciceUsed = 0;
     /* nmethod=14: Robustness w.r.t. to geometric tolerances */
     /* nmethod=15: Crack propagation */
     /* nmethod=16: Feasible direction based on sensitivity information */
-    if(preciceUsed) {
-        int isStaticOrDynamic = (nmethod == 1) || (nmethod == 4);
-        int isDynamic = nmethod == 4;
-        int isThermalAnalysis = ithermal[0] >= 2;
-        
-        if(isStaticOrDynamic && isThermalAnalysis) {
-            
-            printf("Starting CHT analysis via preCICE...\n");
-            
-            mpcinfo[0]=memmpc_;mpcinfo[1]=mpcfree;mpcinfo[2]=icascade;
-            mpcinfo[3]=maxlenmpc;
-            
-            nonlingeo_precice(&co,&nk,&kon,&ipkon,&lakon,&ne,nodeboun,ndirboun,xboun,&nboun, 
-	     &ipompc,&nodempc,&coefmpc,&labmpc,&nmpc,nodeforc,ndirforc,xforc,
-             &nforc,&nelemload,&sideload,xload,&nload, 
-	     nactdof,&icol,jq,&irow,neq,&nzl,&nmethod,&ikmpc, 
-	     &ilmpc,ikboun,ilboun,elcon,nelcon,rhcon,nrhcon,
-	     alcon,nalcon,alzero,&ielmat,&ielorien,&norien,orab,&ntmat_,
-             t0,t1,t1old,ithermal,prestr,&iprestr, 
-	     &vold,iperturb,sti,nzs,&kode,filab,&idrct,jmax,
-	     jout,timepar,eme,xbounold,xforcold,xloadold,
-	     veold,accold,amname,amta,namta,
-	     &nam,iamforc,&iamload,iamt1,alpha,
-             &iexpl,iamboun,plicon,nplicon,plkcon,nplkcon,
-	     &xstate,&npmat_,&istep,&ttime,matname,qaold,mi,
-	     &isolver,&ncmat_,&nstate_,&iumat,cs,&mcs,&nkon,&ener,
-	     mpcinfo,output,
-             shcon,nshcon,cocon,ncocon,physcon,&nflow,ctrl,
-             set,&nset,istartset,iendset,ialset,&nprint,prlab,
-             prset,&nener,ikforc,ilforc,trab,inotr,&ntrans,&fmpc,
-             cbody,ibody,xbody,&nbody,xbodyold,ielprop,prop,
-	     &ntie,tieset,&itpamp,&iviewfile,jobnamec,tietol,&nslavs,thicke,
-	     ics,&nintpoint,&mortar,
-	     &ifacecount,typeboun,&islavsurf,&pslavsurf,&clearini,&nmat,
-	     xmodal,&iaxial,&inext,&nprop,&network,orname,vel,&nef,
-	     velo,veloo,energy,itempuser,
-       /* New args from 2.19 */
-       &ipobody, &inewton, &t0g, &t1g, &ifreebody,
-       /* PreCICE args */
-       preciceParticipantName,configFilename);
-            
-            memmpc_=mpcinfo[0];mpcfree=mpcinfo[1];icascade=mpcinfo[2];
-            maxlenmpc=mpcinfo[3];
-            
-        } else if(isDynamic && !isThermalAnalysis) {
-            
-            printf("Starting FSI analysis via preCICE");
-            
-            if(iperturb[1]==0) {
-                printf(" using the geometrically linear CalculiX solver...\n");
-                
-                mpcinfo[0]=memmpc_;mpcinfo[1]=mpcfree;mpcinfo[2]=icascade;
-                mpcinfo[3]=maxlenmpc;
-                
-                nonlingeo_precice(&co,&nk,&kon,&ipkon,&lakon,&ne,nodeboun,ndirboun,xboun,&nboun, 
-	     &ipompc,&nodempc,&coefmpc,&labmpc,&nmpc,nodeforc,ndirforc,xforc,
-             &nforc,&nelemload,&sideload,xload,&nload, 
-	     nactdof,&icol,jq,&irow,neq,&nzl,&nmethod,&ikmpc, 
-	     &ilmpc,ikboun,ilboun,elcon,nelcon,rhcon,nrhcon,
-	     alcon,nalcon,alzero,&ielmat,&ielorien,&norien,orab,&ntmat_,
-             t0,t1,t1old,ithermal,prestr,&iprestr, 
-	     &vold,iperturb,sti,nzs,&kode,filab,&idrct,jmax,
-	     jout,timepar,eme,xbounold,xforcold,xloadold,
-	     veold,accold,amname,amta,namta,
-	     &nam,iamforc,&iamload,iamt1,alpha,
-             &iexpl,iamboun,plicon,nplicon,plkcon,nplkcon,
-	     &xstate,&npmat_,&istep,&ttime,matname,qaold,mi,
-	     &isolver,&ncmat_,&nstate_,&iumat,cs,&mcs,&nkon,&ener,
-	     mpcinfo,output,
-             shcon,nshcon,cocon,ncocon,physcon,&nflow,ctrl,
-             set,&nset,istartset,iendset,ialset,&nprint,prlab,
-             prset,&nener,ikforc,ilforc,trab,inotr,&ntrans,&fmpc,
-             cbody,ibody,xbody,&nbody,xbodyold,ielprop,prop,
-	     &ntie,tieset,&itpamp,&iviewfile,jobnamec,tietol,&nslavs,thicke,
-	     ics,&nintpoint,&mortar,
-	     &ifacecount,typeboun,&islavsurf,&pslavsurf,&clearini,&nmat,
-	     xmodal,&iaxial,&inext,&nprop,&network,orname,vel,&nef,
-	     velo,veloo,energy,itempuser,
-       /* New args from 2.19 */
-       &ipobody, &inewton, &t0g, &t1g, &ifreebody,
-       /* PreCICE args */
-       preciceParticipantName,configFilename);
-                
-                memmpc_=mpcinfo[0];mpcfree=mpcinfo[1];icascade=mpcinfo[2];
-                maxlenmpc=mpcinfo[3];
-            }
-            else if(iperturb[1]==1){
-                printf(" using the geometrically non-linear CalculiX solver...\n");
-                
-                mpcinfo[0]=memmpc_;mpcinfo[1]=mpcfree;mpcinfo[2]=icascade;
-                mpcinfo[3]=maxlenmpc;
-                
-                nonlingeo_precice(&co,&nk,&kon,&ipkon,&lakon,&ne,nodeboun,ndirboun,xboun,&nboun, 
-	     &ipompc,&nodempc,&coefmpc,&labmpc,&nmpc,nodeforc,ndirforc,xforc,
-             &nforc,&nelemload,&sideload,xload,&nload, 
-	     nactdof,&icol,jq,&irow,neq,&nzl,&nmethod,&ikmpc, 
-	     &ilmpc,ikboun,ilboun,elcon,nelcon,rhcon,nrhcon,
-	     alcon,nalcon,alzero,&ielmat,&ielorien,&norien,orab,&ntmat_,
-             t0,t1,t1old,ithermal,prestr,&iprestr, 
-	     &vold,iperturb,sti,nzs,&kode,filab,&idrct,jmax,
-	     jout,timepar,eme,xbounold,xforcold,xloadold,
-	     veold,accold,amname,amta,namta,
-	     &nam,iamforc,&iamload,iamt1,alpha,
-             &iexpl,iamboun,plicon,nplicon,plkcon,nplkcon,
-	     &xstate,&npmat_,&istep,&ttime,matname,qaold,mi,
-	     &isolver,&ncmat_,&nstate_,&iumat,cs,&mcs,&nkon,&ener,
-	     mpcinfo,output,
-             shcon,nshcon,cocon,ncocon,physcon,&nflow,ctrl,
-             set,&nset,istartset,iendset,ialset,&nprint,prlab,
-             prset,&nener,ikforc,ilforc,trab,inotr,&ntrans,&fmpc,
-             cbody,ibody,xbody,&nbody,xbodyold,ielprop,prop,
-	     &ntie,tieset,&itpamp,&iviewfile,jobnamec,tietol,&nslavs,thicke,
-	     ics,&nintpoint,&mortar,
-	     &ifacecount,typeboun,&islavsurf,&pslavsurf,&clearini,&nmat,
-	     xmodal,&iaxial,&inext,&nprop,&network,orname,vel,&nef,
-	     velo,veloo,energy,itempuser,
-       /* New args from 2.19 */
-       &ipobody, &inewton, &t0g, &t1g, &ifreebody,
-       /* PreCICE args */
-       preciceParticipantName,configFilename);
-                
-                memmpc_=mpcinfo[0];mpcfree=mpcinfo[1];icascade=mpcinfo[2];
-                maxlenmpc=mpcinfo[3];
-            }
-            else {
-                printf("ERROR: This simulation type is not available with preCICE");
-                exit(0);
-            }
+    if (preciceUsed) {
+      int isStaticOrDynamic = (nmethod == 1) || (nmethod == 4);
+      int isDynamic         = nmethod == 4;
+      int isThermalAnalysis = ithermal[0] >= 2;
+
+      if (isStaticOrDynamic && isThermalAnalysis) {
+
+        printf("Starting CHT analysis via preCICE...\n");
+
+        mpcinfo[0] = memmpc_;
+        mpcinfo[1] = mpcfree;
+        mpcinfo[2] = icascade;
+        mpcinfo[3] = maxlenmpc;
+
+        nonlingeo_precice(&co, &nk, &kon, &ipkon, &lakon, &ne, nodeboun, ndirboun, xboun, &nboun,
+                          &ipompc, &nodempc, &coefmpc, &labmpc, &nmpc, nodeforc, ndirforc, xforc,
+                          &nforc, &nelemload, &sideload, xload, &nload,
+                          nactdof, &icol, jq, &irow, neq, &nzl, &nmethod, &ikmpc,
+                          &ilmpc, ikboun, ilboun, elcon, nelcon, rhcon, nrhcon,
+                          alcon, nalcon, alzero, &ielmat, &ielorien, &norien, orab, &ntmat_,
+                          t0, t1, t1old, ithermal, prestr, &iprestr,
+                          &vold, iperturb, sti, nzs, &kode, filab, &idrct, jmax,
+                          jout, timepar, eme, xbounold, xforcold, xloadold,
+                          veold, accold, amname, amta, namta,
+                          &nam, iamforc, &iamload, iamt1, alpha,
+                          &iexpl, iamboun, plicon, nplicon, plkcon, nplkcon,
+                          &xstate, &npmat_, &istep, &ttime, matname, qaold, mi,
+                          &isolver, &ncmat_, &nstate_, &iumat, cs, &mcs, &nkon, &ener,
+                          mpcinfo, output,
+                          shcon, nshcon, cocon, ncocon, physcon, &nflow, ctrl,
+                          set, &nset, istartset, iendset, ialset, &nprint, prlab,
+                          prset, &nener, ikforc, ilforc, trab, inotr, &ntrans, &fmpc,
+                          cbody, ibody, xbody, &nbody, xbodyold, ielprop, prop,
+                          &ntie, tieset, &itpamp, &iviewfile, jobnamec, tietol, &nslavs, thicke,
+                          ics, &nintpoint, &mortar,
+                          &ifacecount, typeboun, &islavsurf, &pslavsurf, &clearini, &nmat,
+                          xmodal, &iaxial, &inext, &nprop, &network, orname, vel, &nef,
+                          velo, veloo, energy, itempuser,
+                          /* New args from 2.19 */
+                          &ipobody, &inewton, &t0g, &t1g, &ifreebody,
+                          /* PreCICE args */
+                          preciceParticipantName, configFilename);
+
+        memmpc_   = mpcinfo[0];
+        mpcfree   = mpcinfo[1];
+        icascade  = mpcinfo[2];
+        maxlenmpc = mpcinfo[3];
+
+      } else if (isDynamic && !isThermalAnalysis) {
+
+        printf("Starting FSI analysis via preCICE");
+
+        if (iperturb[1] == 0) {
+          printf(" using the geometrically linear CalculiX solver...\n");
+
+          mpcinfo[0] = memmpc_;
+          mpcinfo[1] = mpcfree;
+          mpcinfo[2] = icascade;
+          mpcinfo[3] = maxlenmpc;
+
+          nonlingeo_precice(&co, &nk, &kon, &ipkon, &lakon, &ne, nodeboun, ndirboun, xboun, &nboun,
+                            &ipompc, &nodempc, &coefmpc, &labmpc, &nmpc, nodeforc, ndirforc, xforc,
+                            &nforc, &nelemload, &sideload, xload, &nload,
+                            nactdof, &icol, jq, &irow, neq, &nzl, &nmethod, &ikmpc,
+                            &ilmpc, ikboun, ilboun, elcon, nelcon, rhcon, nrhcon,
+                            alcon, nalcon, alzero, &ielmat, &ielorien, &norien, orab, &ntmat_,
+                            t0, t1, t1old, ithermal, prestr, &iprestr,
+                            &vold, iperturb, sti, nzs, &kode, filab, &idrct, jmax,
+                            jout, timepar, eme, xbounold, xforcold, xloadold,
+                            veold, accold, amname, amta, namta,
+                            &nam, iamforc, &iamload, iamt1, alpha,
+                            &iexpl, iamboun, plicon, nplicon, plkcon, nplkcon,
+                            &xstate, &npmat_, &istep, &ttime, matname, qaold, mi,
+                            &isolver, &ncmat_, &nstate_, &iumat, cs, &mcs, &nkon, &ener,
+                            mpcinfo, output,
+                            shcon, nshcon, cocon, ncocon, physcon, &nflow, ctrl,
+                            set, &nset, istartset, iendset, ialset, &nprint, prlab,
+                            prset, &nener, ikforc, ilforc, trab, inotr, &ntrans, &fmpc,
+                            cbody, ibody, xbody, &nbody, xbodyold, ielprop, prop,
+                            &ntie, tieset, &itpamp, &iviewfile, jobnamec, tietol, &nslavs, thicke,
+                            ics, &nintpoint, &mortar,
+                            &ifacecount, typeboun, &islavsurf, &pslavsurf, &clearini, &nmat,
+                            xmodal, &iaxial, &inext, &nprop, &network, orname, vel, &nef,
+                            velo, veloo, energy, itempuser,
+                            /* New args from 2.19 */
+                            &ipobody, &inewton, &t0g, &t1g, &ifreebody,
+                            /* PreCICE args */
+                            preciceParticipantName, configFilename);
+
+          memmpc_   = mpcinfo[0];
+          mpcfree   = mpcinfo[1];
+          icascade  = mpcinfo[2];
+          maxlenmpc = mpcinfo[3];
+        } else if (iperturb[1] == 1) {
+          printf(" using the geometrically non-linear CalculiX solver...\n");
+
+          mpcinfo[0] = memmpc_;
+          mpcinfo[1] = mpcfree;
+          mpcinfo[2] = icascade;
+          mpcinfo[3] = maxlenmpc;
+
+          nonlingeo_precice(&co, &nk, &kon, &ipkon, &lakon, &ne, nodeboun, ndirboun, xboun, &nboun,
+                            &ipompc, &nodempc, &coefmpc, &labmpc, &nmpc, nodeforc, ndirforc, xforc,
+                            &nforc, &nelemload, &sideload, xload, &nload,
+                            nactdof, &icol, jq, &irow, neq, &nzl, &nmethod, &ikmpc,
+                            &ilmpc, ikboun, ilboun, elcon, nelcon, rhcon, nrhcon,
+                            alcon, nalcon, alzero, &ielmat, &ielorien, &norien, orab, &ntmat_,
+                            t0, t1, t1old, ithermal, prestr, &iprestr,
+                            &vold, iperturb, sti, nzs, &kode, filab, &idrct, jmax,
+                            jout, timepar, eme, xbounold, xforcold, xloadold,
+                            veold, accold, amname, amta, namta,
+                            &nam, iamforc, &iamload, iamt1, alpha,
+                            &iexpl, iamboun, plicon, nplicon, plkcon, nplkcon,
+                            &xstate, &npmat_, &istep, &ttime, matname, qaold, mi,
+                            &isolver, &ncmat_, &nstate_, &iumat, cs, &mcs, &nkon, &ener,
+                            mpcinfo, output,
+                            shcon, nshcon, cocon, ncocon, physcon, &nflow, ctrl,
+                            set, &nset, istartset, iendset, ialset, &nprint, prlab,
+                            prset, &nener, ikforc, ilforc, trab, inotr, &ntrans, &fmpc,
+                            cbody, ibody, xbody, &nbody, xbodyold, ielprop, prop,
+                            &ntie, tieset, &itpamp, &iviewfile, jobnamec, tietol, &nslavs, thicke,
+                            ics, &nintpoint, &mortar,
+                            &ifacecount, typeboun, &islavsurf, &pslavsurf, &clearini, &nmat,
+                            xmodal, &iaxial, &inext, &nprop, &network, orname, vel, &nef,
+                            velo, veloo, energy, itempuser,
+                            /* New args from 2.19 */
+                            &ipobody, &inewton, &t0g, &t1g, &ifreebody,
+                            /* PreCICE args */
+                            preciceParticipantName, configFilename);
+
+          memmpc_   = mpcinfo[0];
+          mpcfree   = mpcinfo[1];
+          icascade  = mpcinfo[2];
+          maxlenmpc = mpcinfo[3];
+        } else {
+          printf("ERROR: This simulation type is not available with preCICE");
+          exit(0);
         }
-        
-        else {
-            printf("ERROR: Only thermal coupling or FSI is available with preCICE");
-            exit(0);
+      }
+
+      else {
+        printf("ERROR: Only thermal coupling or FSI is available with preCICE");
+        exit(0);
+      }
+    } else if ((nmethod <= 1) || (nmethod == 11) || ((iperturb[0] > 1) && (nmethod < 8))) {
+      if (iperturb[0] < 2) {
+
+        mpcinfo[0] = memmpc_;
+        mpcinfo[1] = mpcfree;
+        mpcinfo[2] = icascade;
+        mpcinfo[3] = maxlenmpc;
+
+        if (icascade != 0) {
+          printf(" *ERROR in CalculiX: the matrix structure may");
+          printf("        change due to nonlinear equations;");
+          printf("        a purely linear calculation is not");
+          printf("        feasible; use NLGEOM on the *STEP card.");
+          FORTRAN(stop, ());
         }
-    }
-  else if((nmethod<=1)||(nmethod==11)||((iperturb[0]>1)&&(nmethod<8)))
-      {
-	if(iperturb[0]<2){
-	
-	  mpcinfo[0]=memmpc_;mpcinfo[1]=mpcfree;mpcinfo[2]=icascade;
-	  mpcinfo[3]=maxlenmpc;
 
-	  if(icascade!=0){
-	    printf(" *ERROR in CalculiX: the matrix structure may");
-	    printf("        change due to nonlinear equations;");
-	    printf("        a purely linear calculation is not");
-	    printf("        feasible; use NLGEOM on the *STEP card.");
-	    FORTRAN(stop,());
-	  }
+        linstatic(co, &nk, &kon, &ipkon, &lakon, &ne, nodeboun, ndirboun, xboun,
+                  &nboun,
+                  ipompc, nodempc, coefmpc, labmpc, &nmpc, nodeforc, ndirforc, xforc,
+                  &nforc, nelemload, sideload, xload, &nload,
+                  nactdof, &icol, jq, &irow, neq, &nzl, &nmethod, ikmpc,
+                  ilmpc, ikboun, ilboun, elcon, nelcon, rhcon, nrhcon,
+                  alcon, nalcon, alzero, &ielmat, &ielorien, &norien, orab, &ntmat_,
+                  t0, t1, t1old, ithermal, prestr, &iprestr, vold, iperturb, sti, nzs,
+                  &kode, filab, eme, &iexpl, plicon,
+                  nplicon, plkcon, nplkcon, &xstate, &npmat_, matname,
+                  &isolver, mi, &ncmat_, &nstate_, cs, &mcs, &nkon, &ener,
+                  xbounold, xforcold, xloadold, amname, amta, namta,
+                  &nam, iamforc, iamload, iamt1, iamboun, &ttime,
+                  output, set, &nset, istartset, iendset, ialset, &nprint, prlab,
+                  prset, &nener, trab, inotr, &ntrans, fmpc, ipobody, ibody, xbody,
+                  &nbody,
+                  xbodyold, timepar, thicke, jobnamec, tieset, &ntie, &istep, &nmat,
+                  ielprop, prop, typeboun, &mortar, mpcinfo, tietol, ics,
+                  orname, itempuser, t0g, t1g);
 
-	  linstatic(co,&nk,&kon,&ipkon,&lakon,&ne,nodeboun,ndirboun,xboun,
-		    &nboun,
-		    ipompc,nodempc,coefmpc,labmpc,&nmpc,nodeforc,ndirforc,xforc,
-		    &nforc,nelemload,sideload,xload,&nload,
-		    nactdof,&icol,jq,&irow,neq,&nzl,&nmethod,ikmpc,
-		    ilmpc,ikboun,ilboun,elcon,nelcon,rhcon,nrhcon,
-		    alcon,nalcon,alzero,&ielmat,&ielorien,&norien,orab,&ntmat_,
-		    t0,t1,t1old,ithermal,prestr,&iprestr,vold,iperturb,sti,nzs,
-		    &kode,filab,eme,&iexpl,plicon,
-		    nplicon,plkcon,nplkcon,&xstate,&npmat_,matname,
-		    &isolver,mi,&ncmat_,&nstate_,cs,&mcs,&nkon,&ener,
-		    xbounold,xforcold,xloadold,amname,amta,namta,
-		    &nam,iamforc,iamload,iamt1,iamboun,&ttime,
-		    output,set,&nset,istartset,iendset,ialset,&nprint,prlab,
-		    prset,&nener,trab,inotr,&ntrans,fmpc,ipobody,ibody,xbody,
-		    &nbody,
-		    xbodyold,timepar,thicke,jobnamec,tieset,&ntie,&istep,&nmat,
-		    ielprop,prop,typeboun,&mortar,mpcinfo,tietol,ics,
-		    orname,itempuser,t0g,t1g);
+        for (i = 0; i < 3; i++) {
+          nzsprevstep[i] = nzs[i];
+        }
 
-	  for(i=0;i<3;i++){nzsprevstep[i]=nzs[i];}
-
-	  memmpc_=mpcinfo[0];mpcfree=mpcinfo[1];icascade=mpcinfo[2];
-	  maxlenmpc=mpcinfo[3];
-
-	}
-
-	else{
-
-	  mpcinfo[0]=memmpc_;mpcinfo[1]=mpcfree;mpcinfo[2]=icascade;
-	  mpcinfo[3]=maxlenmpc;
-
-	  nonlingeo(&co,&nk,&kon,&ipkon,&lakon,&ne,nodeboun,ndirboun,xboun,
-		    &nboun,&ipompc,&nodempc,&coefmpc,&labmpc,&nmpc,nodeforc,
-		    ndirforc,xforc,&nforc,&nelemload,&sideload,xload,&nload,
-		    nactdof,&icol,jq,&irow,neq,&nzl,&nmethod,&ikmpc,&ilmpc,
-		    ikboun,ilboun,elcon,nelcon,rhcon,nrhcon,alcon,nalcon,
-		    alzero,&ielmat,&ielorien,&norien,orab,&ntmat_,t0,t1,t1old,
-		    ithermal,prestr,&iprestr,&vold,iperturb,sti,nzs,&kode,
-		    filab,&idrct,jmax,jout,timepar,eme,xbounold,xforcold,
-		    xloadold,veold,accold,amname,amta,namta,&nam,iamforc,
-		    &iamload,iamt1,alpha,&iexpl,iamboun,plicon,nplicon,plkcon,
-		    nplkcon,&xstate,&npmat_,&istep,&ttime,matname,qaold,mi,
-		    &isolver,&ncmat_,&nstate_,&iumat,cs,&mcs,&nkon,&ener,
-		    mpcinfo,output,shcon,nshcon,cocon,ncocon,physcon,&nflow,
-		    ctrl,set,&nset,istartset,iendset,ialset,&nprint,prlab,
-		    prset,&nener,ikforc,ilforc,trab,inotr,&ntrans,&fmpc,cbody,
-		    ibody,xbody,&nbody,xbodyold,ielprop,prop,&ntie,tieset,
-		    &itpamp,&iviewfile,jobnamec,tietol,&nslavs,thicke,ics,
-		    &nintpoint,&mortar,&ifacecount,typeboun,&islavsurf,
-		    &pslavsurf,&clearini,&nmat,xmodal,&iaxial,&inext,&nprop,
-		    &network,orname,vel,&nef,velo,veloo,energy,itempuser,
-		    ipobody,&inewton,t0g,t1g,&ifreebody);
-
-	  memmpc_=mpcinfo[0];mpcfree=mpcinfo[1];icascade=mpcinfo[2];
-	  maxlenmpc=mpcinfo[3];
-
-	  for(i=0;i<3;i++){nzsprevstep[i]=nzs[i];}
-
-	}
-      }else if((nmethod==2)||(nmethod==13)){
-      
-      /* FREQUENCY ANALYSIS */
-      
-      if((mcs==0)||(cs[1]<0)){
-#ifdef ARPACK
-	  
-	mpcinfo[0]=memmpc_;mpcinfo[1]=mpcfree;mpcinfo[2]=icascade;
-	mpcinfo[3]=maxlenmpc;
-	  
-	arpack(co,&nk,&kon,&ipkon,&lakon,&ne,nodeboun,ndirboun,xboun,&nboun,
-	       ipompc,nodempc,coefmpc,labmpc,&nmpc,nodeforc,ndirforc,xforc,
-	       &nforc,nelemload,sideload,xload,&nload,
-	       nactdof,icol,jq,&irow,neq,&nzl,&nmethod,ikmpc,
-	       ilmpc,ikboun,ilboun,elcon,nelcon,rhcon,nrhcon,
-	       shcon,nshcon,cocon,ncocon,
-	       alcon,nalcon,alzero,&ielmat,&ielorien,&norien,orab,&ntmat_,
-	       t0,t1,t1old,ithermal,prestr,&iprestr,vold,iperturb,sti,nzs,
-	       &kode,mei,fei,filab,
-	       &iexpl,plicon,nplicon,plkcon,nplkcon,
-	       &xstate,&npmat_,matname,mi,&ncmat_,&nstate_,&ener,jobnamec,
-	       output,set,&nset,istartset,iendset,ialset,&nprint,prlab,
-	       prset,&nener,&isolver,trab,inotr,&ntrans,&ttime,fmpc,ipobody,
-	       ibody,xbody,&nbody,thicke,&nslavs,tietol,&nkon,mpcinfo,
-	       &ntie,&istep,&mcs,ics,tieset,cs,&nintpoint,&mortar,&ifacecount,
-	       &islavsurf,&pslavsurf,&clearini,&nmat,typeboun,ielprop,prop,
-	       orname,&inewton,t0g,t1g);
-
-	memmpc_=mpcinfo[0];mpcfree=mpcinfo[1];icascade=mpcinfo[2];
-	maxlenmpc=mpcinfo[3];
-
-	for(i=0;i<3;i++){nzsprevstep[i]=nzs[i];}
-
-#else
-	printf("*ERROR in CalculiX: the ARPACK library is not linked\n\n");
-	FORTRAN(stop,());
-#endif
-
-      }else{
-
-#ifdef ARPACK
-
-	mpcinfo[0]=memmpc_;mpcinfo[1]=mpcfree;mpcinfo[2]=icascade;
-	mpcinfo[3]=maxlenmpc;
-	  
-	arpackcs(co,&nk,&kon,&ipkon,&lakon,&ne,nodeboun,ndirboun,
-		 xboun,&nboun,
-		 ipompc,nodempc,coefmpc,labmpc,&nmpc,nodeforc,ndirforc,xforc,
-		 &nforc,nelemload,sideload,xload,&nload,
-		 nactdof,icol,jq,&irow,neq,&nzl,&nmethod,ikmpc,
-		 ilmpc,ikboun,ilboun,elcon,nelcon,rhcon,nrhcon,
-		 alcon,nalcon,alzero,&ielmat,&ielorien,&norien,orab,&ntmat_,
-		 t0,t1,t1old,ithermal,prestr,&iprestr,
-		 vold,iperturb,sti,nzs,&kode,mei,fei,filab,
-		 &iexpl,plicon,nplicon,plkcon,nplkcon,
-		 &xstate,&npmat_,matname,mi,ics,cs,&mpcend,&ncmat_,
-		 &nstate_,&mcs,&nkon,jobnamec,output,set,&nset,istartset,
-		 iendset,ialset,&nprint,prlab,
-		 prset,&nener,&isolver,trab,inotr,&ntrans,&ttime,fmpc,ipobody,
-		 ibody,xbody,&nbody,&nevtot,thicke,&nslavs,tietol,mpcinfo,
-		 &ntie,&istep,tieset,&nintpoint,&mortar,&ifacecount,&islavsurf,
-		 &pslavsurf,&clearini,&nmat,typeboun,ielprop,prop,orname,
-		 &inewton,t0g,t1g);
-
-	memmpc_=mpcinfo[0];mpcfree=mpcinfo[1];icascade=mpcinfo[2];
-	maxlenmpc=mpcinfo[3];
-
-	for(i=0;i<3;i++){nzsprevstep[i]=nzs[i];}
-
-#else
-	printf("*ERROR in CalculiX: the ARPACK library is not linked\n\n");
-	FORTRAN(stop,());
-#endif
+        memmpc_   = mpcinfo[0];
+        mpcfree   = mpcinfo[1];
+        icascade  = mpcinfo[2];
+        maxlenmpc = mpcinfo[3];
 
       }
-    }else if(nmethod==3){
-    
+
+      else {
+
+        mpcinfo[0] = memmpc_;
+        mpcinfo[1] = mpcfree;
+        mpcinfo[2] = icascade;
+        mpcinfo[3] = maxlenmpc;
+
+        nonlingeo(&co, &nk, &kon, &ipkon, &lakon, &ne, nodeboun, ndirboun, xboun,
+                  &nboun, &ipompc, &nodempc, &coefmpc, &labmpc, &nmpc, nodeforc,
+                  ndirforc, xforc, &nforc, &nelemload, &sideload, xload, &nload,
+                  nactdof, &icol, jq, &irow, neq, &nzl, &nmethod, &ikmpc, &ilmpc,
+                  ikboun, ilboun, elcon, nelcon, rhcon, nrhcon, alcon, nalcon,
+                  alzero, &ielmat, &ielorien, &norien, orab, &ntmat_, t0, t1, t1old,
+                  ithermal, prestr, &iprestr, &vold, iperturb, sti, nzs, &kode,
+                  filab, &idrct, jmax, jout, timepar, eme, xbounold, xforcold,
+                  xloadold, veold, accold, amname, amta, namta, &nam, iamforc,
+                  &iamload, iamt1, alpha, &iexpl, iamboun, plicon, nplicon, plkcon,
+                  nplkcon, &xstate, &npmat_, &istep, &ttime, matname, qaold, mi,
+                  &isolver, &ncmat_, &nstate_, &iumat, cs, &mcs, &nkon, &ener,
+                  mpcinfo, output, shcon, nshcon, cocon, ncocon, physcon, &nflow,
+                  ctrl, set, &nset, istartset, iendset, ialset, &nprint, prlab,
+                  prset, &nener, ikforc, ilforc, trab, inotr, &ntrans, &fmpc, cbody,
+                  ibody, xbody, &nbody, xbodyold, ielprop, prop, &ntie, tieset,
+                  &itpamp, &iviewfile, jobnamec, tietol, &nslavs, thicke, ics,
+                  &nintpoint, &mortar, &ifacecount, typeboun, &islavsurf,
+                  &pslavsurf, &clearini, &nmat, xmodal, &iaxial, &inext, &nprop,
+                  &network, orname, vel, &nef, velo, veloo, energy, itempuser,
+                  ipobody, &inewton, t0g, t1g, &ifreebody);
+
+        memmpc_   = mpcinfo[0];
+        mpcfree   = mpcinfo[1];
+        icascade  = mpcinfo[2];
+        maxlenmpc = mpcinfo[3];
+
+        for (i = 0; i < 3; i++) {
+          nzsprevstep[i] = nzs[i];
+        }
+      }
+    } else if ((nmethod == 2) || (nmethod == 13)) {
+
+      /* FREQUENCY ANALYSIS */
+
+      if ((mcs == 0) || (cs[1] < 0)) {
 #ifdef ARPACK
-      arpackbu(co,&nk,kon,ipkon,lakon,&ne,nodeboun,ndirboun,xboun,&nboun,
-	       ipompc,nodempc,coefmpc,labmpc,&nmpc,nodeforc,ndirforc,xforc,
-	       &nforc,
-	       nelemload,sideload,xload,&nload,
-	       nactdof,icol,jq,irow,neq,&nzl,&nmethod,ikmpc,
-	       ilmpc,ikboun,ilboun,elcon,nelcon,rhcon,nrhcon,
-	       alcon,nalcon,alzero,ielmat,ielorien,&norien,orab,&ntmat_,
-	       t0,t1,t1old,ithermal,prestr,&iprestr,
-	       vold,iperturb,sti,nzs,&kode,mei,fei,filab,
-	       eme,&iexpl,plicon,nplicon,plkcon,nplkcon,
-	       xstate,&npmat_,matname,mi,&ncmat_,&nstate_,ener,output,
-	       set,&nset,istartset,iendset,ialset,&nprint,prlab,
-	       prset,&nener,&isolver,trab,inotr,&ntrans,&ttime,fmpc,ipobody,
-	       ibody,xbody,&nbody,thicke,jobnamec,&nmat,ielprop,prop,
-	       orname,typeboun,t0g,t1g);
+
+        mpcinfo[0] = memmpc_;
+        mpcinfo[1] = mpcfree;
+        mpcinfo[2] = icascade;
+        mpcinfo[3] = maxlenmpc;
+
+        arpack(co, &nk, &kon, &ipkon, &lakon, &ne, nodeboun, ndirboun, xboun, &nboun,
+               ipompc, nodempc, coefmpc, labmpc, &nmpc, nodeforc, ndirforc, xforc,
+               &nforc, nelemload, sideload, xload, &nload,
+               nactdof, icol, jq, &irow, neq, &nzl, &nmethod, ikmpc,
+               ilmpc, ikboun, ilboun, elcon, nelcon, rhcon, nrhcon,
+               shcon, nshcon, cocon, ncocon,
+               alcon, nalcon, alzero, &ielmat, &ielorien, &norien, orab, &ntmat_,
+               t0, t1, t1old, ithermal, prestr, &iprestr, vold, iperturb, sti, nzs,
+               &kode, mei, fei, filab,
+               &iexpl, plicon, nplicon, plkcon, nplkcon,
+               &xstate, &npmat_, matname, mi, &ncmat_, &nstate_, &ener, jobnamec,
+               output, set, &nset, istartset, iendset, ialset, &nprint, prlab,
+               prset, &nener, &isolver, trab, inotr, &ntrans, &ttime, fmpc, ipobody,
+               ibody, xbody, &nbody, thicke, &nslavs, tietol, &nkon, mpcinfo,
+               &ntie, &istep, &mcs, ics, tieset, cs, &nintpoint, &mortar, &ifacecount,
+               &islavsurf, &pslavsurf, &clearini, &nmat, typeboun, ielprop, prop,
+               orname, &inewton, t0g, t1g);
+
+        memmpc_   = mpcinfo[0];
+        mpcfree   = mpcinfo[1];
+        icascade  = mpcinfo[2];
+        maxlenmpc = mpcinfo[3];
+
+        for (i = 0; i < 3; i++) {
+          nzsprevstep[i] = nzs[i];
+        }
+
+#else
+        printf("*ERROR in CalculiX: the ARPACK library is not linked\n\n");
+        FORTRAN(stop, ());
+#endif
+
+      } else {
+
+#ifdef ARPACK
+
+        mpcinfo[0] = memmpc_;
+        mpcinfo[1] = mpcfree;
+        mpcinfo[2] = icascade;
+        mpcinfo[3] = maxlenmpc;
+
+        arpackcs(co, &nk, &kon, &ipkon, &lakon, &ne, nodeboun, ndirboun,
+                 xboun, &nboun,
+                 ipompc, nodempc, coefmpc, labmpc, &nmpc, nodeforc, ndirforc, xforc,
+                 &nforc, nelemload, sideload, xload, &nload,
+                 nactdof, icol, jq, &irow, neq, &nzl, &nmethod, ikmpc,
+                 ilmpc, ikboun, ilboun, elcon, nelcon, rhcon, nrhcon,
+                 alcon, nalcon, alzero, &ielmat, &ielorien, &norien, orab, &ntmat_,
+                 t0, t1, t1old, ithermal, prestr, &iprestr,
+                 vold, iperturb, sti, nzs, &kode, mei, fei, filab,
+                 &iexpl, plicon, nplicon, plkcon, nplkcon,
+                 &xstate, &npmat_, matname, mi, ics, cs, &mpcend, &ncmat_,
+                 &nstate_, &mcs, &nkon, jobnamec, output, set, &nset, istartset,
+                 iendset, ialset, &nprint, prlab,
+                 prset, &nener, &isolver, trab, inotr, &ntrans, &ttime, fmpc, ipobody,
+                 ibody, xbody, &nbody, &nevtot, thicke, &nslavs, tietol, mpcinfo,
+                 &ntie, &istep, tieset, &nintpoint, &mortar, &ifacecount, &islavsurf,
+                 &pslavsurf, &clearini, &nmat, typeboun, ielprop, prop, orname,
+                 &inewton, t0g, t1g);
+
+        memmpc_   = mpcinfo[0];
+        mpcfree   = mpcinfo[1];
+        icascade  = mpcinfo[2];
+        maxlenmpc = mpcinfo[3];
+
+        for (i = 0; i < 3; i++) {
+          nzsprevstep[i] = nzs[i];
+        }
+
+#else
+        printf("*ERROR in CalculiX: the ARPACK library is not linked\n\n");
+        FORTRAN(stop, ());
+#endif
+      }
+    } else if (nmethod == 3) {
+
+#ifdef ARPACK
+      arpackbu(co, &nk, kon, ipkon, lakon, &ne, nodeboun, ndirboun, xboun, &nboun,
+               ipompc, nodempc, coefmpc, labmpc, &nmpc, nodeforc, ndirforc, xforc,
+               &nforc,
+               nelemload, sideload, xload, &nload,
+               nactdof, icol, jq, irow, neq, &nzl, &nmethod, ikmpc,
+               ilmpc, ikboun, ilboun, elcon, nelcon, rhcon, nrhcon,
+               alcon, nalcon, alzero, ielmat, ielorien, &norien, orab, &ntmat_,
+               t0, t1, t1old, ithermal, prestr, &iprestr,
+               vold, iperturb, sti, nzs, &kode, mei, fei, filab,
+               eme, &iexpl, plicon, nplicon, plkcon, nplkcon,
+               xstate, &npmat_, matname, mi, &ncmat_, &nstate_, ener, output,
+               set, &nset, istartset, iendset, ialset, &nprint, prlab,
+               prset, &nener, &isolver, trab, inotr, &ntrans, &ttime, fmpc, ipobody,
+               ibody, xbody, &nbody, thicke, jobnamec, &nmat, ielprop, prop,
+               orname, typeboun, t0g, t1g);
 #else
       printf("*ERROR in CalculiX: the ARPACK library is not linked\n\n");
-      FORTRAN(stop,());
+      FORTRAN(stop, ());
 #endif
-    }
-    else if(nmethod==4)
-      {
-	if((ne1d!=0)||(ne2d!=0)){
-	  printf(" *WARNING: 1-D or 2-D elements may cause problems in modal dynamic calculations\n");
-	  printf("           ensure that point loads defined in a *MODAL DYNAMIC step\n");
-	  printf("           and applied to nodes belonging to 1-D or 2-D elements have been\n");
-	  printf("           applied to the same nodes in the preceding FREQUENCY step with\n");
-	  printf("           magnitude zero; look at example shellf.inp for a guideline.\n\n");}
-
-	printf(" Composing the dynamic response from the eigenmodes\n\n");
-
-	dyna(&co,&nk,&kon,&ipkon,&lakon,&ne,&nodeboun,&ndirboun,&xboun,&nboun,
-	     &ipompc,&nodempc,&coefmpc,&labmpc,&nmpc,nodeforc,ndirforc,xforc,
-	     &nforc,
-	     nelemload,sideload,xload,&nload,
-	     &nactdof,neq,&nzl,icol,irow,&nmethod,&ikmpc,&ilmpc,&ikboun,&ilboun,
-	     elcon,nelcon,rhcon,nrhcon,cocon,ncocon,
-	     alcon,nalcon,alzero,&ielmat,&ielorien,&norien,orab,&ntmat_,&t0,
-	     &t1,ithermal,prestr,&iprestr,&vold,iperturb,&sti,nzs,
-	     timepar,xmodal,&veold,amname,amta,
-	     namta,&nam,iamforc,iamload,&iamt1,
-	     jout,&kode,filab,&eme,xforcold,xloadold,
-	     &t1old,&iamboun,&xbounold,&iexpl,plicon,
-	     nplicon,plkcon,nplkcon,&xstate,&npmat_,matname,
-	     mi,&ncmat_,&nstate_,&ener,jobnamec,&ttime,set,&nset,
-	     istartset,iendset,&ialset,&nprint,prlab,
-	     prset,&nener,trab,&inotr,&ntrans,&fmpc,ipobody,ibody,xbody,&nbody,
-	     xbodyold,&istep,&isolver,jq,output,&mcs,&nkon,&mpcend,ics,cs,
-	     &ntie,tieset,&idrct,jmax,ctrl,&itpamp,tietol,&nalset,
-	     ikforc,ilforc,thicke,&nslavs,&nmat,typeboun,ielprop,prop,orname,
-	     t0g,t1g);
+    } else if (nmethod == 4) {
+      if ((ne1d != 0) || (ne2d != 0)) {
+        printf(" *WARNING: 1-D or 2-D elements may cause problems in modal dynamic calculations\n");
+        printf("           ensure that point loads defined in a *MODAL DYNAMIC step\n");
+        printf("           and applied to nodes belonging to 1-D or 2-D elements have been\n");
+        printf("           applied to the same nodes in the preceding FREQUENCY step with\n");
+        printf("           magnitude zero; look at example shellf.inp for a guideline.\n\n");
       }
-    else if(nmethod==5)
-      {
-	if((ne1d!=0)||(ne2d!=0)){
-	  printf(" *WARNING: 1-D or 2-D elements may cause problems in steady state calculations\n");
-	  printf("           ensure that point loads defined in a *STEADY STATE DYNAMICS step\n");
-	  printf("           and applied to nodes belonging to 1-D or 2-D elements have been\n");
-	  printf("           applied to the same nodes in the preceding FREQUENCY step with\n");
-	  printf("           magnitude zero; look at example shellf.inp for a guideline.\n\n");}
 
-	printf(" Composing the steady state response from the eigenmodes\n\n");
+      printf(" Composing the dynamic response from the eigenmodes\n\n");
 
-	steadystate(&co,&nk,&kon,&ipkon,&lakon,&ne,&nodeboun,&ndirboun,&xboun,
-		    &nboun,
-		    &ipompc,&nodempc,&coefmpc,&labmpc,&nmpc,nodeforc,ndirforc,
-		    xforc,&nforc,
-		    nelemload,sideload,xload,&nload,
-		    &nactdof,neq,&nzl,icol,irow,&nmethod,&ikmpc,&ilmpc,&ikboun,
-		    &ilboun,
-		    elcon,nelcon,rhcon,nrhcon,cocon,ncocon,
-		    alcon,nalcon,alzero,&ielmat,&ielorien,&norien,orab,&ntmat_,
-		    &t0,
-		    &t1,ithermal,prestr,&iprestr,&vold,iperturb,sti,nzs,
-		    timepar,xmodal,&veold,amname,amta,
-		    namta,&nam,iamforc,iamload,&iamt1,
-		    jout,&kode,filab,&eme,xforcold,xloadold,
-		    &t1old,&iamboun,&xbounold,&iexpl,plicon,
-		    nplicon,plkcon,nplkcon,xstate,&npmat_,matname,
-		    mi,&ncmat_,&nstate_,&ener,jobnamec,&ttime,set,&nset,
-		    istartset,iendset,ialset,&nprint,prlab,
-		    prset,&nener,trab,&inotr,&ntrans,&fmpc,ipobody,ibody,xbody,
-		    &nbody,
-		    xbodyold,&istep,&isolver,jq,output,&mcs,&nkon,ics,cs,
-		    &mpcend,
-		    ctrl,ikforc,ilforc,thicke,&nmat,typeboun,ielprop,prop,
-		    orname,
-		    &ndamp,dacon,t0g,t1g);
+      dyna(&co, &nk, &kon, &ipkon, &lakon, &ne, &nodeboun, &ndirboun, &xboun, &nboun,
+           &ipompc, &nodempc, &coefmpc, &labmpc, &nmpc, nodeforc, ndirforc, xforc,
+           &nforc,
+           nelemload, sideload, xload, &nload,
+           &nactdof, neq, &nzl, icol, irow, &nmethod, &ikmpc, &ilmpc, &ikboun, &ilboun,
+           elcon, nelcon, rhcon, nrhcon, cocon, ncocon,
+           alcon, nalcon, alzero, &ielmat, &ielorien, &norien, orab, &ntmat_, &t0,
+           &t1, ithermal, prestr, &iprestr, &vold, iperturb, &sti, nzs,
+           timepar, xmodal, &veold, amname, amta,
+           namta, &nam, iamforc, iamload, &iamt1,
+           jout, &kode, filab, &eme, xforcold, xloadold,
+           &t1old, &iamboun, &xbounold, &iexpl, plicon,
+           nplicon, plkcon, nplkcon, &xstate, &npmat_, matname,
+           mi, &ncmat_, &nstate_, &ener, jobnamec, &ttime, set, &nset,
+           istartset, iendset, &ialset, &nprint, prlab,
+           prset, &nener, trab, &inotr, &ntrans, &fmpc, ipobody, ibody, xbody, &nbody,
+           xbodyold, &istep, &isolver, jq, output, &mcs, &nkon, &mpcend, ics, cs,
+           &ntie, tieset, &idrct, jmax, ctrl, &itpamp, tietol, &nalset,
+           ikforc, ilforc, thicke, &nslavs, &nmat, typeboun, ielprop, prop, orname,
+           t0g, t1g);
+    } else if (nmethod == 5) {
+      if ((ne1d != 0) || (ne2d != 0)) {
+        printf(" *WARNING: 1-D or 2-D elements may cause problems in steady state calculations\n");
+        printf("           ensure that point loads defined in a *STEADY STATE DYNAMICS step\n");
+        printf("           and applied to nodes belonging to 1-D or 2-D elements have been\n");
+        printf("           applied to the same nodes in the preceding FREQUENCY step with\n");
+        printf("           magnitude zero; look at example shellf.inp for a guideline.\n\n");
       }
-    else if((nmethod==6)||(nmethod==7))
-      {
 
-	printf(" Composing the complex eigenmodes from the real eigenmodes\n\n");
+      printf(" Composing the steady state response from the eigenmodes\n\n");
 
-	complexfreq(&co,&nk,&kon,&ipkon,&lakon,&ne,&nodeboun,&ndirboun,&xboun,
-		    &nboun,&ipompc,&nodempc,&coefmpc,&labmpc,&nmpc,nodeforc,
-		    ndirforc,xforc,&nforc,
-		    nelemload,sideload,xload,&nload,
-		    &nactdof,neq,&nzl,icol,irow,&nmethod,&ikmpc,&ilmpc,&ikboun,
-		    &ilboun,
-		    elcon,nelcon,rhcon,nrhcon,cocon,ncocon,
-		    alcon,nalcon,alzero,&ielmat,&ielorien,&norien,orab,&ntmat_,
-		    &t0,
-		    &t1,ithermal,prestr,&iprestr,&vold,iperturb,&sti,nzs,
-		    timepar,xmodal,&veold,amname,amta,
-		    namta,&nam,iamforc,iamload,&iamt1,
-		    jout,&kode,filab,&eme,xforcold,xloadold,
-		    &t1old,&iamboun,&xbounold,&iexpl,plicon,
-		    nplicon,plkcon,nplkcon,xstate,&npmat_,matname,
-		    mi,&ncmat_,&nstate_,&ener,jobnamec,&ttime,set,&nset,
-		    istartset,iendset,&ialset,&nprint,prlab,
-		    prset,&nener,trab,&inotr,&ntrans,&fmpc,ipobody,ibody,xbody,
-		    &nbody,
-		    xbodyold,&istep,&isolver,jq,output,&mcs,&nkon,&mpcend,ics,
-		    cs,
-		    &ntie,tieset,&idrct,jmax,ctrl,&itpamp,tietol,&nalset,
-		    ikforc,ilforc,thicke,jobnamef,mei,&nmat,ielprop,prop,orname,
-		    typeboun,t0g,t1g);
+      steadystate(&co, &nk, &kon, &ipkon, &lakon, &ne, &nodeboun, &ndirboun, &xboun,
+                  &nboun,
+                  &ipompc, &nodempc, &coefmpc, &labmpc, &nmpc, nodeforc, ndirforc,
+                  xforc, &nforc,
+                  nelemload, sideload, xload, &nload,
+                  &nactdof, neq, &nzl, icol, irow, &nmethod, &ikmpc, &ilmpc, &ikboun,
+                  &ilboun,
+                  elcon, nelcon, rhcon, nrhcon, cocon, ncocon,
+                  alcon, nalcon, alzero, &ielmat, &ielorien, &norien, orab, &ntmat_,
+                  &t0,
+                  &t1, ithermal, prestr, &iprestr, &vold, iperturb, sti, nzs,
+                  timepar, xmodal, &veold, amname, amta,
+                  namta, &nam, iamforc, iamload, &iamt1,
+                  jout, &kode, filab, &eme, xforcold, xloadold,
+                  &t1old, &iamboun, &xbounold, &iexpl, plicon,
+                  nplicon, plkcon, nplkcon, xstate, &npmat_, matname,
+                  mi, &ncmat_, &nstate_, &ener, jobnamec, &ttime, set, &nset,
+                  istartset, iendset, ialset, &nprint, prlab,
+                  prset, &nener, trab, &inotr, &ntrans, &fmpc, ipobody, ibody, xbody,
+                  &nbody,
+                  xbodyold, &istep, &isolver, jq, output, &mcs, &nkon, ics, cs,
+                  &mpcend,
+                  ctrl, ikforc, ilforc, thicke, &nmat, typeboun, ielprop, prop,
+                  orname,
+                  &ndamp, dacon, t0g, t1g);
+    } else if ((nmethod == 6) || (nmethod == 7)) {
+
+      printf(" Composing the complex eigenmodes from the real eigenmodes\n\n");
+
+      complexfreq(&co, &nk, &kon, &ipkon, &lakon, &ne, &nodeboun, &ndirboun, &xboun,
+                  &nboun, &ipompc, &nodempc, &coefmpc, &labmpc, &nmpc, nodeforc,
+                  ndirforc, xforc, &nforc,
+                  nelemload, sideload, xload, &nload,
+                  &nactdof, neq, &nzl, icol, irow, &nmethod, &ikmpc, &ilmpc, &ikboun,
+                  &ilboun,
+                  elcon, nelcon, rhcon, nrhcon, cocon, ncocon,
+                  alcon, nalcon, alzero, &ielmat, &ielorien, &norien, orab, &ntmat_,
+                  &t0,
+                  &t1, ithermal, prestr, &iprestr, &vold, iperturb, &sti, nzs,
+                  timepar, xmodal, &veold, amname, amta,
+                  namta, &nam, iamforc, iamload, &iamt1,
+                  jout, &kode, filab, &eme, xforcold, xloadold,
+                  &t1old, &iamboun, &xbounold, &iexpl, plicon,
+                  nplicon, plkcon, nplkcon, xstate, &npmat_, matname,
+                  mi, &ncmat_, &nstate_, &ener, jobnamec, &ttime, set, &nset,
+                  istartset, iendset, &ialset, &nprint, prlab,
+                  prset, &nener, trab, &inotr, &ntrans, &fmpc, ipobody, ibody, xbody,
+                  &nbody,
+                  xbodyold, &istep, &isolver, jq, output, &mcs, &nkon, &mpcend, ics,
+                  cs,
+                  &ntie, tieset, &idrct, jmax, ctrl, &itpamp, tietol, &nalset,
+                  ikforc, ilforc, thicke, jobnamef, mei, &nmat, ielprop, prop, orname,
+                  typeboun, t0g, t1g);
+    } else if ((nmethod > 7) && (nmethod < 12)) {
+
+      mpcinfo[0] = memmpc_;
+      mpcinfo[1] = mpcfree;
+      mpcinfo[2] = icascade;
+      mpcinfo[3] = maxlenmpc;
+
+      electromagnetics(&co, &nk, &kon, &ipkon, &lakon, &ne, nodeboun,
+                       ndirboun, xboun, &nboun,
+                       &ipompc, &nodempc, &coefmpc, &labmpc, &nmpc, nodeforc,
+                       ndirforc, xforc,
+                       &nforc, &nelemload, &sideload, xload, &nload,
+                       nactdof, &icol, &jq, &irow, neq, &nzl, &nmethod, &ikmpc,
+                       &ilmpc, ikboun, ilboun, elcon, nelcon, rhcon, nrhcon,
+                       alcon, nalcon, alzero, &ielmat, &ielorien, &norien, orab,
+                       &ntmat_,
+                       t0, t1, t1old, ithermal, prestr, &iprestr,
+                       &vold, iperturb, sti, nzs, &kode, filab, &idrct, jmax,
+                       jout, timepar, eme, xbounold, xforcold, xloadold,
+                       veold, accold, amname, amta, namta,
+                       &nam, iamforc, &iamload, iamt1, alpha,
+                       &iexpl, iamboun, plicon, nplicon, plkcon, nplkcon,
+                       &xstate, &npmat_, &istep, &ttime, matname, qaold, mi,
+                       &isolver, &ncmat_, &nstate_, &iumat, cs, &mcs, &nkon, &ener,
+                       mpcinfo, output,
+                       shcon, nshcon, cocon, ncocon, physcon, &nflow, ctrl,
+                       &set, &nset, &istartset, &iendset, &ialset, &nprint, prlab,
+                       prset, &nener, ikforc, ilforc, trab, inotr, &ntrans, &fmpc,
+                       ipobody, ibody, xbody, &nbody, xbodyold, ielprop, prop,
+                       &ntie, &tieset, &itpamp, &iviewfile, jobnamec, &tietol,
+                       &nslavs, thicke,
+                       ics, &nalset, &nmpc_, &nmat, typeboun, &iaxial, &nload_, &nprop,
+                       &network, orname, t0g, t1g);
+
+      memmpc_   = mpcinfo[0];
+      mpcfree   = mpcinfo[1];
+      icascade  = mpcinfo[2];
+      maxlenmpc = mpcinfo[3];
+    }
+
+    else if (nmethod == 12) {
+
+      if (icoordinate == 1) {
+        sensi_coor(co, &nk, &kon, &ipkon, &lakon, &ne, nodeboun, ndirboun,
+                   xboun, &nboun, ipompc, nodempc, coefmpc, labmpc, &nmpc, nodeforc,
+                   ndirforc, xforc, &nforc, nelemload, sideload, xload, &nload,
+                   nactdof, icol, jq, &irow, neq, &nzl, &nmethod, ikmpc,
+                   ilmpc, ikboun, ilboun, elcon, nelcon, rhcon, nrhcon,
+                   alcon, nalcon, alzero, &ielmat, &ielorien, &norien, orab, &ntmat_,
+                   t0, t1, t1old, ithermal, prestr, &iprestr, vold, iperturb, sti, nzs,
+                   &kode, filab, eme, &iexpl, plicon,
+                   nplicon, plkcon, nplkcon, &xstate, &npmat_, matname,
+                   &isolver, mi, &ncmat_, &nstate_, cs, &mcs, &nkon, &ener,
+                   xbounold, xforcold, xloadold, amname, amta, namta,
+                   &nam, iamforc, iamload, iamt1, iamboun, &ttime,
+                   output, set, &nset, istartset, iendset, ialset, &nprint, prlab,
+                   prset, &nener, trab, inotr, &ntrans, fmpc, ipobody, ibody, xbody,
+                   &nbody,
+                   xbodyold, timepar, thicke, jobnamec, tieset, &ntie, &istep, &nmat,
+                   ielprop, prop, typeboun, &mortar, mpcinfo, tietol, ics,
+                   &nobject, &objectset, &istat, orname, nzsprevstep, &nlabel,
+                   physcon,
+                   jobnamef, iponor, knor, &ne2d, iponoel, inoel, &mpcend, dgdxglob,
+                   g0, &nodedesi, &ndesi, &nobjectstart, &xdesi);
+
+      } else {
+        sensi_orien(co, &nk, &kon, &ipkon, &lakon, &ne, nodeboun, ndirboun,
+                    xboun, &nboun, ipompc, nodempc, coefmpc, labmpc, &nmpc, nodeforc,
+                    ndirforc, xforc, &nforc, nelemload, sideload, xload, &nload,
+                    nactdof, icol, jq, &irow, neq, &nzl, &nmethod, ikmpc,
+                    ilmpc, ikboun, ilboun, elcon, nelcon, rhcon, nrhcon,
+                    alcon, nalcon, alzero, &ielmat, &ielorien, &norien, orab, &ntmat_,
+                    t0, t1, t1old, ithermal, prestr, &iprestr, vold, iperturb, sti, nzs,
+                    &kode, filab, eme, &iexpl, plicon,
+                    nplicon, plkcon, nplkcon, &xstate, &npmat_, matname,
+                    &isolver, mi, &ncmat_, &nstate_, cs, &mcs, &nkon, &ener,
+                    xbounold, xforcold, xloadold, amname, amta, namta,
+                    &nam, iamforc, iamload, iamt1, iamboun, &ttime,
+                    output, set, &nset, istartset, iendset, ialset, &nprint, prlab,
+                    prset, &nener, trab, inotr, &ntrans, fmpc, ipobody, ibody, xbody,
+                    &nbody,
+                    xbodyold, timepar, thicke, jobnamec, tieset, &ntie, &istep, &nmat,
+                    ielprop, prop, typeboun, &mortar, mpcinfo, tietol, ics,
+                    &nobject, &objectset, &istat, orname, nzsprevstep, &nlabel,
+                    physcon,
+                    jobnamef, iponor, knor, &ne2d, iponoel, inoel, &mpcend);
       }
-    else if((nmethod>7)&&(nmethod<12)){
 
-      mpcinfo[0]=memmpc_;mpcinfo[1]=mpcfree;mpcinfo[2]=icascade;
-      mpcinfo[3]=maxlenmpc;
-
-      electromagnetics(&co,&nk,&kon,&ipkon,&lakon,&ne,nodeboun,
-		       ndirboun,xboun,&nboun,
-		       &ipompc,&nodempc,&coefmpc,&labmpc,&nmpc,nodeforc,
-		       ndirforc,xforc,
-		       &nforc,&nelemload,&sideload,xload,&nload,
-		       nactdof,&icol,&jq,&irow,neq,&nzl,&nmethod,&ikmpc,
-		       &ilmpc,ikboun,ilboun,elcon,nelcon,rhcon,nrhcon,
-		       alcon,nalcon,alzero,&ielmat,&ielorien,&norien,orab,
-		       &ntmat_,
-		       t0,t1,t1old,ithermal,prestr,&iprestr,
-		       &vold,iperturb,sti,nzs,&kode,filab,&idrct,jmax,
-		       jout,timepar,eme,xbounold,xforcold,xloadold,
-		       veold,accold,amname,amta,namta,
-		       &nam,iamforc,&iamload,iamt1,alpha,
-		       &iexpl,iamboun,plicon,nplicon,plkcon,nplkcon,
-		       &xstate,&npmat_,&istep,&ttime,matname,qaold,mi,
-		       &isolver,&ncmat_,&nstate_,&iumat,cs,&mcs,&nkon,&ener,
-		       mpcinfo,output,
-		       shcon,nshcon,cocon,ncocon,physcon,&nflow,ctrl,
-		       &set,&nset,&istartset,&iendset,&ialset,&nprint,prlab,
-		       prset,&nener,ikforc,ilforc,trab,inotr,&ntrans,&fmpc,
-		       ipobody,ibody,xbody,&nbody,xbodyold,ielprop,prop,
-		       &ntie,&tieset,&itpamp,&iviewfile,jobnamec,&tietol,
-		       &nslavs,thicke,
-		       ics,&nalset,&nmpc_,&nmat,typeboun,&iaxial,&nload_,&nprop,
-		       &network,orname,t0g,t1g);
-
-      memmpc_=mpcinfo[0];mpcfree=mpcinfo[1];icascade=mpcinfo[2];
-      maxlenmpc=mpcinfo[3];
     }
 
-    else if(nmethod==12){
-      
-      if(icoordinate==1){
-	sensi_coor(co,&nk,&kon,&ipkon,&lakon,&ne,nodeboun,ndirboun,
-		   xboun,&nboun,ipompc,nodempc,coefmpc,labmpc,&nmpc,nodeforc,
-		   ndirforc,xforc,&nforc,nelemload,sideload,xload,&nload,
-		   nactdof,icol,jq,&irow,neq,&nzl,&nmethod,ikmpc,
-		   ilmpc,ikboun,ilboun,elcon,nelcon,rhcon,nrhcon,
-		   alcon,nalcon,alzero,&ielmat,&ielorien,&norien,orab,&ntmat_,
-		   t0,t1,t1old,ithermal,prestr,&iprestr,vold,iperturb,sti,nzs,
-		   &kode,filab,eme,&iexpl,plicon,
-		   nplicon,plkcon,nplkcon,&xstate,&npmat_,matname,
-		   &isolver,mi,&ncmat_,&nstate_,cs,&mcs,&nkon,&ener,
-		   xbounold,xforcold,xloadold,amname,amta,namta,
-		   &nam,iamforc,iamload,iamt1,iamboun,&ttime,
-		   output,set,&nset,istartset,iendset,ialset,&nprint,prlab,
-		   prset,&nener,trab,inotr,&ntrans,fmpc,ipobody,ibody,xbody,
-		   &nbody,
-		   xbodyold,timepar,thicke,jobnamec,tieset,&ntie,&istep,&nmat,
-		   ielprop,prop,typeboun,&mortar,mpcinfo,tietol,ics,
-		   &nobject,&objectset,&istat,orname,nzsprevstep,&nlabel,
-		   physcon,
-		   jobnamef,iponor,knor,&ne2d,iponoel,inoel,&mpcend,dgdxglob,
-		   g0,&nodedesi,&ndesi,&nobjectstart,&xdesi);
-    
-      }else{
-        sensi_orien(co,&nk,&kon,&ipkon,&lakon,&ne,nodeboun,ndirboun,
-		    xboun,&nboun,ipompc,nodempc,coefmpc,labmpc,&nmpc,nodeforc,
-		    ndirforc,xforc,&nforc,nelemload,sideload,xload,&nload,
-		    nactdof,icol,jq,&irow,neq,&nzl,&nmethod,ikmpc,
-		    ilmpc,ikboun,ilboun,elcon,nelcon,rhcon,nrhcon,
-		    alcon,nalcon,alzero,&ielmat,&ielorien,&norien,orab,&ntmat_,
-		    t0,t1,t1old,ithermal,prestr,&iprestr,vold,iperturb,sti,nzs,
-		    &kode,filab,eme,&iexpl,plicon,
-		    nplicon,plkcon,nplkcon,&xstate,&npmat_,matname,
-		    &isolver,mi,&ncmat_,&nstate_,cs,&mcs,&nkon,&ener,
-		    xbounold,xforcold,xloadold,amname,amta,namta,
-		    &nam,iamforc,iamload,iamt1,iamboun,&ttime,
-		    output,set,&nset,istartset,iendset,ialset,&nprint,prlab,
-		    prset,&nener,trab,inotr,&ntrans,fmpc,ipobody,ibody,xbody,
-		    &nbody,
-		    xbodyold,timepar,thicke,jobnamec,tieset,&ntie,&istep,&nmat,
-		    ielprop,prop,typeboun,&mortar,mpcinfo,tietol,ics,
-		    &nobject,&objectset,&istat,orname,nzsprevstep,&nlabel,
-		    physcon,
-		    jobnamef,iponor,knor,&ne2d,iponoel,inoel,&mpcend);
-      }
-    
-    }
-    
-    else if(nmethod==14){
-  
-      robustdesign(co,&nk,&kon,&ipkon,&lakon,&ne,nodeboun,ndirboun,xboun,
-		   &nboun,ipompc,nodempc,coefmpc,labmpc,&nmpc,nodeforc,
-		   ndirforc,xforc,&nforc,nelemload,sideload,xload,&nload,
-		   nactdof,icol,jq,&irow,neq,&nzl,&nmethod,ikmpc,ilmpc,ikboun,
-		   ilboun,elcon,nelcon,rhcon,nrhcon,alcon,nalcon,alzero,
-		   &ielmat,&ielorien,&norien,orab,&ntmat_,t0,t1,t1old,ithermal,
-		   prestr,&iprestr,vold,iperturb,sti,nzs,&kode,filab,eme,
-		   &iexpl,plicon,nplicon,plkcon,nplkcon,&xstate,&npmat_,
-		   matname,&isolver,mi,&ncmat_,&nstate_,cs,&mcs,&nkon,&ener,
-		   xbounold,xforcold,xloadold,amname,amta,namta,&nam,iamforc,
-		   iamload,iamt1,iamboun,&ttime,output,set,&nset,istartset,
-		   iendset,ialset,&nprint,prlab,prset,&nener,trab,inotr,
-		   &ntrans,fmpc,ipobody,ibody,xbody,&nbody,xbodyold,timepar,
-		   thicke,jobnamec,tieset,&ntie,&istep,&nmat,ielprop,prop,
-		   typeboun,&mortar,mpcinfo,tietol,ics,&nobject,
-		   &objectset,&istat,orname,nzsprevstep,&nlabel,physcon,
-		   jobnamef,iponor,knor,&ne2d,iponoel,inoel,&mpcend,
-		   irobustdesign,irandomtype,randomval);
+    else if (nmethod == 14) {
+
+      robustdesign(co, &nk, &kon, &ipkon, &lakon, &ne, nodeboun, ndirboun, xboun,
+                   &nboun, ipompc, nodempc, coefmpc, labmpc, &nmpc, nodeforc,
+                   ndirforc, xforc, &nforc, nelemload, sideload, xload, &nload,
+                   nactdof, icol, jq, &irow, neq, &nzl, &nmethod, ikmpc, ilmpc, ikboun,
+                   ilboun, elcon, nelcon, rhcon, nrhcon, alcon, nalcon, alzero,
+                   &ielmat, &ielorien, &norien, orab, &ntmat_, t0, t1, t1old, ithermal,
+                   prestr, &iprestr, vold, iperturb, sti, nzs, &kode, filab, eme,
+                   &iexpl, plicon, nplicon, plkcon, nplkcon, &xstate, &npmat_,
+                   matname, &isolver, mi, &ncmat_, &nstate_, cs, &mcs, &nkon, &ener,
+                   xbounold, xforcold, xloadold, amname, amta, namta, &nam, iamforc,
+                   iamload, iamt1, iamboun, &ttime, output, set, &nset, istartset,
+                   iendset, ialset, &nprint, prlab, prset, &nener, trab, inotr,
+                   &ntrans, fmpc, ipobody, ibody, xbody, &nbody, xbodyold, timepar,
+                   thicke, jobnamec, tieset, &ntie, &istep, &nmat, ielprop, prop,
+                   typeboun, &mortar, mpcinfo, tietol, ics, &nobject,
+                   &objectset, &istat, orname, nzsprevstep, &nlabel, physcon,
+                   jobnamef, iponor, knor, &ne2d, iponoel, inoel, &mpcend,
+                   irobustdesign, irandomtype, randomval);
     }
 
-    else if(nmethod==15){
-      
-      crackpropagation(&ipkon,&kon,&lakon,&ne,&nk,jobnamec,&nboun,iamboun,xboun,
-		       &nload,sideload,iamload,&nforc,iamforc,xforc,ithermal,t1,
-		       iamt1,&co,&nkon,mi,&ielmat,matname,output,&nmat,set,
-		       &nset,istartset,iendset,ialset,jmax,timepar,nelcon,
-		       elcon,&ncmat_,&ntmat_,&istep,filab,&nmethod,mei);
+    else if (nmethod == 15) {
+
+      crackpropagation(&ipkon, &kon, &lakon, &ne, &nk, jobnamec, &nboun, iamboun, xboun,
+                       &nload, sideload, iamload, &nforc, iamforc, xforc, ithermal, t1,
+                       iamt1, &co, &nkon, mi, &ielmat, matname, output, &nmat, set,
+                       &nset, istartset, iendset, ialset, jmax, timepar, nelcon,
+                       elcon, &ncmat_, &ntmat_, &istep, filab, &nmethod, mei);
     }
 
-    else if(nmethod==16){
-    
-      feasibledirection(&nobject,&objectset,&dgdxglob,g0,&ndesi,nodedesi,&nk,
-			&isolver,&ipkon,&kon,&lakon,&ne,nelemload,&nload,
-			nodeboun,&nboun,ndirboun,ithermal,co,vold,mi,&ielmat,
-			ielprop,prop,&kode,&nmethod,filab,&nstate_,&istep,cs,
-			set,&nset,istartset,iendset,ialset,jobnamec,output,
-			&ntrans,inotr,trab,orname,xdesi);         
-      
+    else if (nmethod == 16) {
+
+      feasibledirection(&nobject, &objectset, &dgdxglob, g0, &ndesi, nodedesi, &nk,
+                        &isolver, &ipkon, &kon, &lakon, &ne, nelemload, &nload,
+                        nodeboun, &nboun, ndirboun, ithermal, co, vold, mi, &ielmat,
+                        ielprop, prop, &kode, &nmethod, filab, &nstate_, &istep, cs,
+                        set, &nset, istartset, iendset, ialset, jobnamec, output,
+                        &ntrans, inotr, trab, orname, xdesi);
     }
 
-    SFREE(nactdof);SFREE(icol);SFREE(jq);SFREE(irow);SFREE(ipobody);
+    SFREE(nactdof);
+    SFREE(icol);
+    SFREE(jq);
+    SFREE(irow);
+    SFREE(ipobody);
 
     /* check whether refinement was active */
 
     //          if(irefineloop==20){
-    if(strcmp1(&filab[4089],"RM")==0){
+    if (strcmp1(&filab[4089], "RM") == 0) {
       irefineloop++;
 
-      if(irefineloop==1){
+      if (irefineloop == 1) {
 
-	/* refinement was requested in the step which was just
+        /* refinement was requested in the step which was just
 	   finished and a refined mesh was created and stored.
 	   The calculation has to restart from the beginning with
 	   this new mesh */
-       
-	memcpy(ipoinp,ipoinp_sav,sizeof(ITG)*2*nentries);
-	memcpy(inp,inp_sav,sizeof(ITG)*inp_size);
 
-	/* deallocating fields */
+        memcpy(ipoinp, ipoinp_sav, sizeof(ITG) * 2 * nentries);
+        memcpy(inp, inp_sav, sizeof(ITG) * inp_size);
 
-	dealloc_cal(&ncs_,&ics,&mcs,&cs,&tieset,&tietol,&co,
-		    &kon,&ipkon,&lakon,&nodeboun,&ndirboun,&typeboun,&xboun,
-		    &ikboun,&ilboun,&nodebounold,&ndirbounold,&xbounold,&ipompc,
-		    &labmpc,&ikmpc,&ilmpc,&fmpc,&nodempc,&coefmpc,&nodempcref,
-		    &coefmpcref,&ikmpcref,&nodeforc,&ndirforc,&xforc,
-		    &ikforc,&ilforc,&xforcold,&nelemload,&sideload,&xload,
-		    &xloadold,&cbody,&ibody,&xbody,&xbodyold,&nam,
-		    &iamboun,&iamforc,&iamload,&amname,&amta,&namta,&set,
-		    &istartset,&iendset,&ialset,&elcon,&nelcon,&rhcon,
-		    &nrhcon,&shcon,&nshcon,&cocon,&ncocon,&alcon,
-		    &nalcon,&alzero,&nprop,&ielprop,&prop,&npmat_,
-		    &plicon,&nplicon,&plkcon,&nplkcon,&ndamp,&dacon,&norien,
-		    &orname,&orab,&ielorien,&ntrans,&trab,&inotr,&iprestr,
-		    &prestr,ithermal,&t0,&t1,&t1old,&iamt1,&ne1d,
-		    &ne2d,&t0g,&t1g,irobustdesign,&irandomtype,
-		    &randomval,&prlab,&prset,&filab,&xmodal,&ielmat,
-		    &matname,&sti,&eme,&ener,&xstate,&vold,
-		    &veold,&vel,&velo,&veloo,&iponor,&xnor,
-		    &knor,&thicke,&offset,&iponoel,&inoel,&rig,
-		    &ne2boun,&islavsurf,&mortar,&pslavsurf,&clearini,
-		    &nobject_,&objectset,&nmethod,iperturb,&irefineloop,
-		    &iparentel,&iprfn,&konrfn,&ratiorfn,&heading,
-		    &nodedesi,&dgdxglob,&g0,&nuel_,&xdesi,&nfc,&coeffc,
-		    &ikdc,&edc);
+        /* deallocating fields */
 
-	/* closing and reopening the output files */
-	
-	FORTRAN(openfile,(jobnamef));
+        dealloc_cal(&ncs_, &ics, &mcs, &cs, &tieset, &tietol, &co,
+                    &kon, &ipkon, &lakon, &nodeboun, &ndirboun, &typeboun, &xboun,
+                    &ikboun, &ilboun, &nodebounold, &ndirbounold, &xbounold, &ipompc,
+                    &labmpc, &ikmpc, &ilmpc, &fmpc, &nodempc, &coefmpc, &nodempcref,
+                    &coefmpcref, &ikmpcref, &nodeforc, &ndirforc, &xforc,
+                    &ikforc, &ilforc, &xforcold, &nelemload, &sideload, &xload,
+                    &xloadold, &cbody, &ibody, &xbody, &xbodyold, &nam,
+                    &iamboun, &iamforc, &iamload, &amname, &amta, &namta, &set,
+                    &istartset, &iendset, &ialset, &elcon, &nelcon, &rhcon,
+                    &nrhcon, &shcon, &nshcon, &cocon, &ncocon, &alcon,
+                    &nalcon, &alzero, &nprop, &ielprop, &prop, &npmat_,
+                    &plicon, &nplicon, &plkcon, &nplkcon, &ndamp, &dacon, &norien,
+                    &orname, &orab, &ielorien, &ntrans, &trab, &inotr, &iprestr,
+                    &prestr, ithermal, &t0, &t1, &t1old, &iamt1, &ne1d,
+                    &ne2d, &t0g, &t1g, irobustdesign, &irandomtype,
+                    &randomval, &prlab, &prset, &filab, &xmodal, &ielmat,
+                    &matname, &sti, &eme, &ener, &xstate, &vold,
+                    &veold, &vel, &velo, &veloo, &iponor, &xnor,
+                    &knor, &thicke, &offset, &iponoel, &inoel, &rig,
+                    &ne2boun, &islavsurf, &mortar, &pslavsurf, &clearini,
+                    &nobject_, &objectset, &nmethod, iperturb, &irefineloop,
+                    &iparentel, &iprfn, &konrfn, &ratiorfn, &heading,
+                    &nodedesi, &dgdxglob, &g0, &nuel_, &xdesi, &nfc, &coeffc,
+                    &ikdc, &edc);
 
-	/* initialization of the variables */
-  
-	ini_cal(jobnamec,output,fneig,kind1,kind2,itempuser,irobustdesign,
-		&nprint,neq,&mpcfree,&nbounold,&nforcold,&nloadold,&nbody_,
-		&nbodyold,&network,&nheading_,&nmpc_,&nload_,&nforc_,&nboun_,
-		&nintpoint,iperturb,&ntmat_,ithermal,&isolver,&nslavs,&nkon_,
-		&mortar,jout,&nkon,&nevtot,&ifacecount,&iplas,&npmat_,mi,
-		&mpcend,&namtot_,&iumat,&icascade,&ne1d,&ne2d,infree,&nflow,
-		irstrt,&nener,&jrstrt,&ntie_,&mcs,&nprop_,&nprop,&itpamp,
-		&nevdamp_,&npt_,&iaxial,&inext,&icontact,&nobject,&nobject_,
-		&iit,&mpcfreeref,&isens,&namtot,&nstam,&ndamp,&nef,
-		&nk_,&ne_,&nalset_,&nmat_,&norien_,&nam_,&ntrans_,
-		&ncs_,&nstate_,&ncmat_,&memmpc_,&nprint_,energy,ctrl,alpha,
-		qaold,physcon,&istep,&istat,&iprestr,&kode,&nload,&nbody,&nforc,
-		&nboun,&nk,&nmpc,&nam,&nzs_,&nlabel,&ttime,&iheading,&nfc,
-		&nfc_,&ndc,&ndc_);
-  
-	NNEW(set,char,81*nset_);
-	NNEW(meminset,ITG,nset_);
-	NNEW(rmeminset,ITG,nset_);
-	NNEW(iuel,ITG,4*nuel_);
+        /* closing and reopening the output files */
 
-	FORTRAN(allocation,(&nload_,&nforc_,&nboun_,&nk_,&ne_,&nmpc_,&nset_,
-			    &nalset_,&nmat_,&ntmat_,&npmat_,&norien_,&nam_,
-			    &nprint_,mi,&ntrans_,set,meminset,rmeminset,&ncs_,
-			    &namtot_,&ncmat_,&memmpc_,&ne1d,&ne2d,&nflow,
-			    jobnamec,irstrt,ithermal,&nener,&nstate_,&istep,
-			    inpc,ipoinp,inp,&ntie_,&nbody_,
-			    &nprop_,ipoinpc,&nevdamp_,&npt_,&nslavs,&nkon_,&mcs,
-			    &mortar,&ifacecount,&nintpoint,infree,&nheading_,
-			    &nobject_,iuel,&iprestr,&nstam,&ndamp,&nef,
-			    &nbounold,&nforcold,&nloadold,&nbodyold,&mpcend,
-			    irobustdesign,&nfc_,&ndc_));
+        FORTRAN(openfile, (jobnamef));
 
-	//	SFREE(set);
-	SFREE(meminset);SFREE(rmeminset);mt=mi[1]+1;
-	NNEW(heading,char,66*nheading_);
+        /* initialization of the variables */
 
-	continue;
+        ini_cal(jobnamec, output, fneig, kind1, kind2, itempuser, irobustdesign,
+                &nprint, neq, &mpcfree, &nbounold, &nforcold, &nloadold, &nbody_,
+                &nbodyold, &network, &nheading_, &nmpc_, &nload_, &nforc_, &nboun_,
+                &nintpoint, iperturb, &ntmat_, ithermal, &isolver, &nslavs, &nkon_,
+                &mortar, jout, &nkon, &nevtot, &ifacecount, &iplas, &npmat_, mi,
+                &mpcend, &namtot_, &iumat, &icascade, &ne1d, &ne2d, infree, &nflow,
+                irstrt, &nener, &jrstrt, &ntie_, &mcs, &nprop_, &nprop, &itpamp,
+                &nevdamp_, &npt_, &iaxial, &inext, &icontact, &nobject, &nobject_,
+                &iit, &mpcfreeref, &isens, &namtot, &nstam, &ndamp, &nef,
+                &nk_, &ne_, &nalset_, &nmat_, &norien_, &nam_, &ntrans_,
+                &ncs_, &nstate_, &ncmat_, &memmpc_, &nprint_, energy, ctrl, alpha,
+                qaold, physcon, &istep, &istat, &iprestr, &kode, &nload, &nbody, &nforc,
+                &nboun, &nk, &nmpc, &nam, &nzs_, &nlabel, &ttime, &iheading, &nfc,
+                &nfc_, &ndc, &ndc_);
+
+        NNEW(set, char, 81 * nset_);
+        NNEW(meminset, ITG, nset_);
+        NNEW(rmeminset, ITG, nset_);
+        NNEW(iuel, ITG, 4 * nuel_);
+
+        FORTRAN(allocation, (&nload_, &nforc_, &nboun_, &nk_, &ne_, &nmpc_, &nset_,
+                             &nalset_, &nmat_, &ntmat_, &npmat_, &norien_, &nam_,
+                             &nprint_, mi, &ntrans_, set, meminset, rmeminset, &ncs_,
+                             &namtot_, &ncmat_, &memmpc_, &ne1d, &ne2d, &nflow,
+                             jobnamec, irstrt, ithermal, &nener, &nstate_, &istep,
+                             inpc, ipoinp, inp, &ntie_, &nbody_,
+                             &nprop_, ipoinpc, &nevdamp_, &npt_, &nslavs, &nkon_, &mcs,
+                             &mortar, &ifacecount, &nintpoint, infree, &nheading_,
+                             &nobject_, iuel, &iprestr, &nstam, &ndamp, &nef,
+                             &nbounold, &nforcold, &nloadold, &nbodyold, &mpcend,
+                             irobustdesign, &nfc_, &ndc_));
+
+        //	SFREE(set);
+        SFREE(meminset);
+        SFREE(rmeminset);
+        mt = mi[1] + 1;
+        NNEW(heading, char, 66 * nheading_);
+
+        continue;
       }
     }
 
     /* reset tempuserflag */
-  
-    itempuser[0]=0;
+
+    itempuser[0] = 0;
 
     /* deleting the perturbation loads and temperatures */
 
-    if((iperturb[0]==1)&&(nmethod==3)){
-      nforc=0;
-      nload=0;
-      nbody=0;
-      if(ithermal[0]==1){
-	for(k=0;k<nk;++k){
-	  t1[k]=t0[k];
-	}
+    if ((iperturb[0] == 1) && (nmethod == 3)) {
+      nforc = 0;
+      nload = 0;
+      nbody = 0;
+      if (ithermal[0] == 1) {
+        for (k = 0; k < nk; ++k) {
+          t1[k] = t0[k];
+        }
       }
-    }else{
-      nbounold=nboun;
-      for(i=0;i<nboun;i++){
-	nodebounold[i]=nodeboun[i];
-	ndirbounold[i]=ndirboun[i];
+    } else {
+      nbounold = nboun;
+      for (i = 0; i < nboun; i++) {
+        nodebounold[i] = nodeboun[i];
+        ndirbounold[i] = ndirboun[i];
       }
-      nforcold=nforc;
-      nloadold=nload;
-      nbodyold=nbody;
-      
+      nforcold = nforc;
+      nloadold = nload;
+      nbodyold = nbody;
+
       /* resetting the amplitude to none except for time=total time amplitudes */
 
-      if(nam>0){
-	for(i=0;i<nboun;i++){
-	  if(iamboun[i]>0){
-	    if(namta[3*iamboun[i]-1]>0){
-	      iamboun[i]=0;
-	      xboun[i]=xbounold[i];}
-	  }
-	}
-	for(i=0;i<nforc;i++){
-	  if(iamforc[i]>0){
-	    if(namta[3*iamforc[i]-1]>0){
-	      iamforc[i]=0;
-	      xforc[i]=xforcold[i];}
-	  }
-	}
-	for(i=0;i<2*nload;i++){
-	  if(iamload[i]>0){
-	    if(namta[3*iamload[i]-1]>0){
-	      iamload[i]=0;
-	      xload[i]=xloadold[i];}
-	  }
-	}
-	for(i=1;i<3*nbody;i=i+3){
-	  if(ibody[i]>0){
-	    if(namta[3*ibody[i]-1]>0){
-	      ibody[i]=0;
-	      xbody[7*(i-1)/3]=xbodyold[7*(i-1)/3];}
-	  }
-	}
-	if(ithermal[0]==1){
-	  if(iamt1[i]>0){
-	    if(namta[3*iamt1[i]-1]>0){
-	      iamt1[i]=0;
-	      t1[i]=t1old[i];}
-	  }
-	}
+      if (nam > 0) {
+        for (i = 0; i < nboun; i++) {
+          if (iamboun[i] > 0) {
+            if (namta[3 * iamboun[i] - 1] > 0) {
+              iamboun[i] = 0;
+              xboun[i]   = xbounold[i];
+            }
+          }
+        }
+        for (i = 0; i < nforc; i++) {
+          if (iamforc[i] > 0) {
+            if (namta[3 * iamforc[i] - 1] > 0) {
+              iamforc[i] = 0;
+              xforc[i]   = xforcold[i];
+            }
+          }
+        }
+        for (i = 0; i < 2 * nload; i++) {
+          if (iamload[i] > 0) {
+            if (namta[3 * iamload[i] - 1] > 0) {
+              iamload[i] = 0;
+              xload[i]   = xloadold[i];
+            }
+          }
+        }
+        for (i = 1; i < 3 * nbody; i = i + 3) {
+          if (ibody[i] > 0) {
+            if (namta[3 * ibody[i] - 1] > 0) {
+              ibody[i]               = 0;
+              xbody[7 * (i - 1) / 3] = xbodyold[7 * (i - 1) / 3];
+            }
+          }
+        }
+        if (ithermal[0] == 1) {
+          if (iamt1[i] > 0) {
+            if (namta[3 * iamt1[i] - 1] > 0) {
+              iamt1[i] = 0;
+              t1[i]    = t1old[i];
+            }
+          }
+        }
       }
     }
 
     /* removing the advective elements, if any */
 
-    if(network>0){
-      ne=ne0;nkon=nkon0;
-      RENEW(ipkon,ITG,ne);
-      RENEW(lakon,char,8*ne);
-      RENEW(kon,ITG,nkon);
-      RENEW(sti,double,6*mi[0]*ne);
-      RENEW(eme,double,6*mi[0]*ne);
-      if(iprestr>0) RENEW(prestr,double,6*mi[0]*ne);
-      if(nprop>0) RENEW(ielprop,ITG,ne);
-      if((ne1d!=0)||(ne2d!=0)) RENEW(offset,double,2*ne);
-      if(nener==1)RENEW(ener,double,mi[0]*ne*2);
-      if(norien>0)RENEW(ielorien,ITG,mi[2]*ne);
-      RENEW(ielmat,ITG,mi[2]*ne);
+    if (network > 0) {
+      ne   = ne0;
+      nkon = nkon0;
+      RENEW(ipkon, ITG, ne);
+      RENEW(lakon, char, 8 * ne);
+      RENEW(kon, ITG, nkon);
+      RENEW(sti, double, 6 * mi[0] * ne);
+      RENEW(eme, double, 6 * mi[0] * ne);
+      if (iprestr > 0)
+        RENEW(prestr, double, 6 * mi[0] * ne);
+      if (nprop > 0)
+        RENEW(ielprop, ITG, ne);
+      if ((ne1d != 0) || (ne2d != 0))
+        RENEW(offset, double, 2 * ne);
+      if (nener == 1)
+        RENEW(ener, double, mi[0] * ne * 2);
+      if (norien > 0)
+        RENEW(ielorien, ITG, mi[2] * ne);
+      RENEW(ielmat, ITG, mi[2] * ne);
 
       /* reactivating the original load labels */
 
-      for(i=nload-1;i>=nload0;i--){
-	if(strcmp2(&sideload[20*i],"                    ",20)==0){
-	  iload=nelemload[2*i+1];
-	  strcpy1(&sideload[20*(iload-1)],"F",1);
-	}
+      for (i = nload - 1; i >= nload0; i--) {
+        if (strcmp2(&sideload[20 * i], "                    ", 20) == 0) {
+          iload = nelemload[2 * i + 1];
+          strcpy1(&sideload[20 * (iload - 1)], "F", 1);
+        }
       }
-
     }
 
-    nload=nload0;
+    nload = nload0;
 
-    if((nmethod==4)&&(iperturb[0]>1)) SFREE(accold);
+    if ((nmethod == 4) && (iperturb[0] > 1))
+      SFREE(accold);
 
-    if(irstrt[0]>0){
+    if (irstrt[0] > 0) {
       jrstrt++;
-      if(jrstrt>=irstrt[0]){
-	jrstrt=0;
-	FORTRAN(restartwrite,(&istep,&nset,&nload,&nforc,&nboun,&nk,&ne,&nmpc,
-			      &nalset,&nmat,&ntmat_,&npmat_,&norien,&nam,
-			      &nprint,mi,&ntrans,&ncs_,&namtot,&ncmat_,&mpcend,
-			      &maxlenmpc,&ne1d,&ne2d,&nflow,&nlabel,&iplas,
-			      &nkon,ithermal,&nmethod,iperturb,&nstate_,&nener,
-			      set,istartset,iendset,ialset,co,kon,ipkon,lakon,
-			      nodeboun,ndirboun,iamboun,xboun,ikboun,ilboun,
-			      ipompc,nodempc,coefmpc,labmpc,ikmpc,ilmpc,
-			      nodeforc,ndirforc,iamforc,xforc,ikforc,ilforc,
-			      nelemload,iamload,sideload,xload,elcon,nelcon,
-			      rhcon,nrhcon,alcon,nalcon,alzero,plicon,nplicon,
-			      plkcon,nplkcon,orname,orab,ielorien,trab,inotr,
-			      amname,amta,namta,t0,t1,iamt1,veold,ielmat,
-			      matname,prlab,prset,filab,vold,nodebounold,
-			      ndirbounold,xbounold,xforcold,xloadold,t1old,eme,
-			      iponor,xnor,knor,thicke,offset,iponoel,inoel,rig,
-			      shcon,nshcon,cocon,ncocon,ics,sti,ener,xstate,
-			      jobnamec,infree,prestr,&iprestr,cbody,ibody,
-			      xbody,&nbody,xbodyold,&ttime,qaold,cs,&mcs,
-			      output,physcon,ctrl,typeboun,fmpc,tieset,&ntie,
-			      tietol,&nslavs,t0g,t1g,&nprop,ielprop,prop,
-			      &mortar,&nintpoint,&ifacecount,islavsurf,
-			      pslavsurf,clearini,irstrt,vel,&nef,velo,veloo,
-			      ne2boun,&memmpc_,heading,&nheading_,&network,
-			      &nfc,&ndc,coeffc,ikdc,edc));
+      if (jrstrt >= irstrt[0]) {
+        jrstrt = 0;
+        FORTRAN(restartwrite, (&istep, &nset, &nload, &nforc, &nboun, &nk, &ne, &nmpc,
+                               &nalset, &nmat, &ntmat_, &npmat_, &norien, &nam,
+                               &nprint, mi, &ntrans, &ncs_, &namtot, &ncmat_, &mpcend,
+                               &maxlenmpc, &ne1d, &ne2d, &nflow, &nlabel, &iplas,
+                               &nkon, ithermal, &nmethod, iperturb, &nstate_, &nener,
+                               set, istartset, iendset, ialset, co, kon, ipkon, lakon,
+                               nodeboun, ndirboun, iamboun, xboun, ikboun, ilboun,
+                               ipompc, nodempc, coefmpc, labmpc, ikmpc, ilmpc,
+                               nodeforc, ndirforc, iamforc, xforc, ikforc, ilforc,
+                               nelemload, iamload, sideload, xload, elcon, nelcon,
+                               rhcon, nrhcon, alcon, nalcon, alzero, plicon, nplicon,
+                               plkcon, nplkcon, orname, orab, ielorien, trab, inotr,
+                               amname, amta, namta, t0, t1, iamt1, veold, ielmat,
+                               matname, prlab, prset, filab, vold, nodebounold,
+                               ndirbounold, xbounold, xforcold, xloadold, t1old, eme,
+                               iponor, xnor, knor, thicke, offset, iponoel, inoel, rig,
+                               shcon, nshcon, cocon, ncocon, ics, sti, ener, xstate,
+                               jobnamec, infree, prestr, &iprestr, cbody, ibody,
+                               xbody, &nbody, xbodyold, &ttime, qaold, cs, &mcs,
+                               output, physcon, ctrl, typeboun, fmpc, tieset, &ntie,
+                               tietol, &nslavs, t0g, t1g, &nprop, ielprop, prop,
+                               &mortar, &nintpoint, &ifacecount, islavsurf,
+                               pslavsurf, clearini, irstrt, vel, &nef, velo, veloo,
+                               ne2boun, &memmpc_, heading, &nheading_, &network,
+                               &nfc, &ndc, coeffc, ikdc, edc));
       }
-    } 
-	  
+    }
   }
 
-  FORTRAN(closefile,());
+  FORTRAN(closefile, ());
 
-  strcpy(fneig,jobnamec);
-  strcat(fneig,".frd");
-  if((f1=fopen(fneig,"ab"))==NULL){
+  strcpy(fneig, jobnamec);
+  strcat(fneig, ".frd");
+  if ((f1 = fopen(fneig, "ab")) == NULL) {
     printf("*ERROR in frd: cannot open frd file for writing...");
     exit(0);
   }
-  fprintf(f1," 9999\n");
+  fprintf(f1, " 9999\n");
   fclose(f1);
 
   /* deallocating the fields
      this section is addressed immediately after leaving calinput */
 
-  SFREE(ipoinpc);SFREE(inpc);SFREE(inp);SFREE(ipoinp);SFREE(inp_sav);
+  SFREE(ipoinpc);
+  SFREE(inpc);
+  SFREE(inp);
+  SFREE(ipoinp);
+  SFREE(inp_sav);
   SFREE(ipoinp_sav);
 
-  dealloc_cal(&ncs_,&ics,&mcs,&cs,&tieset,&tietol,&co,
-	      &kon,&ipkon,&lakon,&nodeboun,&ndirboun,&typeboun,&xboun,
-	      &ikboun,&ilboun,&nodebounold,&ndirbounold,&xbounold,&ipompc,
-	      &labmpc,&ikmpc,&ilmpc,&fmpc,&nodempc,&coefmpc,
-	      &nodempcref,&coefmpcref,&ikmpcref,&nodeforc,&ndirforc,&xforc,
-	      &ikforc,&ilforc,&xforcold,&nelemload,&sideload,&xload,
-	      &xloadold,&cbody,&ibody,&xbody,&xbodyold,&nam,
-	      &iamboun,&iamforc,&iamload,&amname,&amta,&namta,&set,
-	      &istartset,&iendset,&ialset,&elcon,&nelcon,&rhcon,
-	      &nrhcon,&shcon,&nshcon,&cocon,&ncocon,&alcon,
-	      &nalcon,&alzero,&nprop,&ielprop,&prop,&npmat_,
-	      &plicon,&nplicon,&plkcon,&nplkcon,&ndamp,&dacon,&norien,
-	      &orname,&orab,&ielorien,&ntrans,&trab,&inotr,&iprestr,
-	      &prestr,ithermal,&t0,&t1,&t1old,&iamt1,&ne1d,
-	      &ne2d,&t0g,&t1g,irobustdesign,&irandomtype,
-	      &randomval,&prlab,&prset,&filab,&xmodal,&ielmat,
-	      &matname,&sti,&eme,&ener,&xstate,&vold,
-	      &veold,&vel,&velo,&veloo,&iponor,&xnor,
-	      &knor,&thicke,&offset,&iponoel,&inoel,&rig,
-	      &ne2boun,&islavsurf,&mortar,&pslavsurf,&clearini,
-	      &nobject_,&objectset,&nmethod,iperturb,&irefineloop,
-	      &iparentel,&iprfn,&konrfn,&ratiorfn,&heading,
-	      &nodedesi,&dgdxglob,&g0,&nuel_,&xdesi,&nfc,&coeffc,
-	      &ikdc,&edc);
-  
+  dealloc_cal(&ncs_, &ics, &mcs, &cs, &tieset, &tietol, &co,
+              &kon, &ipkon, &lakon, &nodeboun, &ndirboun, &typeboun, &xboun,
+              &ikboun, &ilboun, &nodebounold, &ndirbounold, &xbounold, &ipompc,
+              &labmpc, &ikmpc, &ilmpc, &fmpc, &nodempc, &coefmpc,
+              &nodempcref, &coefmpcref, &ikmpcref, &nodeforc, &ndirforc, &xforc,
+              &ikforc, &ilforc, &xforcold, &nelemload, &sideload, &xload,
+              &xloadold, &cbody, &ibody, &xbody, &xbodyold, &nam,
+              &iamboun, &iamforc, &iamload, &amname, &amta, &namta, &set,
+              &istartset, &iendset, &ialset, &elcon, &nelcon, &rhcon,
+              &nrhcon, &shcon, &nshcon, &cocon, &ncocon, &alcon,
+              &nalcon, &alzero, &nprop, &ielprop, &prop, &npmat_,
+              &plicon, &nplicon, &plkcon, &nplkcon, &ndamp, &dacon, &norien,
+              &orname, &orab, &ielorien, &ntrans, &trab, &inotr, &iprestr,
+              &prestr, ithermal, &t0, &t1, &t1old, &iamt1, &ne1d,
+              &ne2d, &t0g, &t1g, irobustdesign, &irandomtype,
+              &randomval, &prlab, &prset, &filab, &xmodal, &ielmat,
+              &matname, &sti, &eme, &ener, &xstate, &vold,
+              &veold, &vel, &velo, &veloo, &iponor, &xnor,
+              &knor, &thicke, &offset, &iponoel, &inoel, &rig,
+              &ne2boun, &islavsurf, &mortar, &pslavsurf, &clearini,
+              &nobject_, &objectset, &nmethod, iperturb, &irefineloop,
+              &iparentel, &iprfn, &konrfn, &ratiorfn, &heading,
+              &nodedesi, &dgdxglob, &g0, &nuel_, &xdesi, &nfc, &coeffc,
+              &ikdc, &edc);
+
 #ifdef CALCULIX_MPI
   MPI_Finalize();
 #endif
@@ -2028,17 +2162,16 @@ int preciceUsed = 0;
   calculix_freeExternalBehaviours();
 #endif /* CALCULIX_EXTERNAL_BEHAVIOURS_SUPPORT */
 
-  clock_gettime(CLOCK_MONOTONIC, &totalCalculixTimeEnd); 
+  clock_gettime(CLOCK_MONOTONIC, &totalCalculixTimeEnd);
 
-  totalCalculixTime = (totalCalculixTimeEnd.tv_sec - totalCalculixTimeStart.tv_sec) * 1e9; 
+  totalCalculixTime = (totalCalculixTimeEnd.tv_sec - totalCalculixTimeStart.tv_sec) * 1e9;
   totalCalculixTime = (totalCalculixTime + (totalCalculixTimeEnd.tv_nsec - totalCalculixTimeStart.tv_nsec)) * 1e-9;
-  
+
   printf("________________________________________\n\n");
-  
+
   printf("Total CalculiX Time: %lf\n", totalCalculixTime);
 
   printf("________________________________________\n");
 
   return 0;
-      
 }

--- a/nonlingeo_precice.c
+++ b/nonlingeo_precice.c
@@ -7,7 +7,7 @@
 /*                    */
 
 /*     This program is distributed in the hope that it will be useful,   */
-/*     but WITHOUT ANY WARRANTY; without even the implied warranty of    */ 
+/*     but WITHOUT ANY WARRANTY; without even the implied warranty of    */
 /*     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the      */
 /*     GNU General Public License for more details.                      */
 
@@ -15,8 +15,8 @@
 /*     along with this program; if not, write to the Free Software       */
 /*     Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.         */
 
-#include <stdio.h>
 #include <math.h>
+#include <stdio.h>
 #include <stdlib.h>
 #include "CalculiX.h"
 #include "mortar.h"
@@ -39,312 +39,334 @@
 /* Adapter: Add header */
 #include "adapter/PreciceInterface.h"
 
-#define max(a,b) ((a) >= (b) ? (a) : (b))
+#define max(a, b) ((a) >= (b) ? (a) : (b))
 
 void nonlingeo_precice(double **cop, ITG *nk, ITG **konp, ITG **ipkonp, char **lakonp,
-	       ITG *ne, 
-	       ITG *nodeboun, ITG *ndirboun, double *xboun, ITG *nboun, 
-	       ITG **ipompcp, ITG **nodempcp, double **coefmpcp, char **labmpcp,
-	       ITG *nmpc, 
-	       ITG *nodeforc, ITG *ndirforc,double *xforc, ITG *nforc, 
-	       ITG **nelemloadp, char **sideloadp, double *xload,ITG *nload, 
-	       ITG *nactdof, 
-	       ITG **icolp, ITG *jq, ITG **irowp, ITG *neq, ITG *nzl, 
-	       ITG *nmethod, ITG **ikmpcp, ITG **ilmpcp, ITG *ikboun, 
-	       ITG *ilboun,
-	       double *elcon, ITG *nelcon, double *rhcon, ITG *nrhcon,
-	       double *alcon, ITG *nalcon, double *alzero, ITG **ielmatp,
-	       ITG **ielorienp, ITG *norien, double *orab, ITG *ntmat_,
-	       double *t0, double *t1, double *t1old, 
-	       ITG *ithermal,double *prestr, ITG *iprestr, 
-	       double **voldp,ITG *iperturb, double *sti, ITG *nzs,  
-	       ITG *kode, char *filab, 
-	       ITG *idrct, ITG *jmax, ITG *jout, double *timepar,
-	       double *eme,
-	       double *xbounold, double *xforcold, double *xloadold,
-	       double *veold, double *accold,
-	       char *amname, double *amta, ITG *namta, ITG *nam,
-	       ITG *iamforc, ITG **iamloadp,
-	       ITG *iamt1, double *alpha, ITG *iexpl,
-	       ITG *iamboun, double *plicon, ITG *nplicon, double *plkcon,
-	       ITG *nplkcon,
-	       double **xstatep, ITG *npmat_, ITG *istep, double *ttime,
-	       char *matname, double *qaold, ITG *mi,
-	       ITG *isolver, ITG *ncmat_, ITG *nstate_, ITG *iumat,
-	       double *cs, ITG *mcs, ITG *nkon, double **enerp, ITG *mpcinfo,
-	       char *output,
-	       double *shcon, ITG *nshcon, double *cocon, ITG *ncocon,
-	       double *physcon, ITG *nflow, double *ctrl, 
-	       char *set, ITG *nset, ITG *istartset,
-	       ITG *iendset, ITG *ialset, ITG *nprint, char *prlab,
-	       char *prset, ITG *nener,ITG *ikforc,ITG *ilforc, double *trab, 
-	       ITG *inotr, ITG *ntrans, double **fmpcp, char *cbody,
-	       ITG *ibody, double *xbody, ITG *nbody, double *xbodyold,
-	       ITG *ielprop, double *prop, ITG *ntie, char *tieset,
-	       ITG *itpamp, ITG *iviewfile, char *jobnamec, double *tietol,
-	       ITG *nslavs, double *thicke, ITG *ics, 
-	       ITG *nintpoint,ITG *mortar,ITG *ifacecount,char *typeboun,
-	       ITG **islavsurfp,double **pslavsurfp,double **clearinip,
-	       ITG *nmat,double *xmodal,ITG *iaxial,ITG *inext,ITG *nprop,
-	       ITG *network,char *orname,double *vel,ITG *nef,
-	       double *velo,double *veloo,double *energy,ITG *itempuser,
-	       ITG *ipobody,ITG *inewton,double *t0g,double *t1g,
-	       ITG *ifreebody,
-		   /* Adapter: Add variables for the participant name and the config file */
-         char * preciceParticipantName, char * configFilename){
+                       ITG *ne,
+                       ITG *nodeboun, ITG *ndirboun, double *xboun, ITG *nboun,
+                       ITG **ipompcp, ITG **nodempcp, double **coefmpcp, char **labmpcp,
+                       ITG *nmpc,
+                       ITG *nodeforc, ITG *ndirforc, double *xforc, ITG *nforc,
+                       ITG **nelemloadp, char **sideloadp, double *xload, ITG *nload,
+                       ITG * nactdof,
+                       ITG **icolp, ITG *jq, ITG **irowp, ITG *neq, ITG *nzl,
+                       ITG *nmethod, ITG **ikmpcp, ITG **ilmpcp, ITG *ikboun,
+                       ITG *   ilboun,
+                       double *elcon, ITG *nelcon, double *rhcon, ITG *nrhcon,
+                       double *alcon, ITG *nalcon, double *alzero, ITG **ielmatp,
+                       ITG **ielorienp, ITG *norien, double *orab, ITG *ntmat_,
+                       double *t0, double *t1, double *t1old,
+                       ITG *ithermal, double *prestr, ITG *iprestr,
+                       double **voldp, ITG *iperturb, double *sti, ITG *nzs,
+                       ITG *kode, char *filab,
+                       ITG *idrct, ITG *jmax, ITG *jout, double *timepar,
+                       double *eme,
+                       double *xbounold, double *xforcold, double *xloadold,
+                       double *veold, double *accold,
+                       char *amname, double *amta, ITG *namta, ITG *nam,
+                       ITG *iamforc, ITG **iamloadp,
+                       ITG *iamt1, double *alpha, ITG *iexpl,
+                       ITG *iamboun, double *plicon, ITG *nplicon, double *plkcon,
+                       ITG *    nplkcon,
+                       double **xstatep, ITG *npmat_, ITG *istep, double *ttime,
+                       char *matname, double *qaold, ITG *mi,
+                       ITG *isolver, ITG *ncmat_, ITG *nstate_, ITG *iumat,
+                       double *cs, ITG *mcs, ITG *nkon, double **enerp, ITG *mpcinfo,
+                       char *  output,
+                       double *shcon, ITG *nshcon, double *cocon, ITG *ncocon,
+                       double *physcon, ITG *nflow, double *ctrl,
+                       char *set, ITG *nset, ITG *istartset,
+                       ITG *iendset, ITG *ialset, ITG *nprint, char *prlab,
+                       char *prset, ITG *nener, ITG *ikforc, ITG *ilforc, double *trab,
+                       ITG *inotr, ITG *ntrans, double **fmpcp, char *cbody,
+                       ITG *ibody, double *xbody, ITG *nbody, double *xbodyold,
+                       ITG *ielprop, double *prop, ITG *ntie, char *tieset,
+                       ITG *itpamp, ITG *iviewfile, char *jobnamec, double *tietol,
+                       ITG *nslavs, double *thicke, ITG *ics,
+                       ITG *nintpoint, ITG *mortar, ITG *ifacecount, char *typeboun,
+                       ITG **islavsurfp, double **pslavsurfp, double **clearinip,
+                       ITG *nmat, double *xmodal, ITG *iaxial, ITG *inext, ITG *nprop,
+                       ITG *network, char *orname, double *vel, ITG *nef,
+                       double *velo, double *veloo, double *energy, ITG *itempuser,
+                       ITG *ipobody, ITG *inewton, double *t0g, double *t1g,
+                       ITG *ifreebody,
+                       /* Adapter: Add variables for the participant name and the config file */
+                       char *preciceParticipantName, char *configFilename)
+{
 
-  char description[13]="            ",*lakon=NULL,jobnamef[396]="",
-    *sideface=NULL,*labmpc=NULL,*lakonf=NULL,*env,*envsys,fneig[132]="",
-    *sideloadref=NULL,*sideload=NULL,stiffmatrix[132]="",
-    *sideloadf=NULL; 
- 
-  ITG *inum=NULL,k,iout=0,icntrl,iinc=0,jprint=0,iit=-1,jnz=0,
-    icutb=0,istab=0,uncoupled,n1,n2,itruecontact,
-    iperturb_sav[2],ilin,*icol=NULL,*irow=NULL,ielas=0,icmd=0,
-    memmpc_,mpcfree,icascade,maxlenmpc,*nodempc=NULL,*iaux=NULL,
-    *nodempcref=NULL,memmpcref_,mpcfreeref,*itg=NULL,*ineighe=NULL,
-    *ieg=NULL,ntg=0,ntr,*kontri=NULL,*nloadtr=NULL,idamping=0,
-    *ipiv=NULL,ntri,newstep,mode=-1,noddiam=-1,nasym=0,im,
-    ntrit,*inocs=NULL,*nacteq=NULL,*ipface=NULL,
-    *nactdog=NULL,nteq,*itietri=NULL,*koncont=NULL,istrainfree=0,
-    ncont,ne0,nkon0,*ipkon=NULL,*kon=NULL,*ielorien=NULL,
-    *ielmat=NULL,itp=0,symmetryflag=0,inputformat=0,kscale=1,
-    *iruc=NULL,iitterm=0,iturbulent,ngraph=1,ismallsliding=0,
-    *ipompc=NULL,*ikmpc=NULL,*ilmpc=NULL,i0ref,irref,icref,
-    *itiefac=NULL,*islavsurf=NULL,*islavnode=NULL,*imastnode=NULL,
-    *nslavnode=NULL,*nmastnode=NULL,*imastop=NULL,imat,
-    *iponoels=NULL,*inoels=NULL,*islavsurfold=NULL,maxlenmpcref,
-    *islavact=NULL,mt=mi[1]+1,*nactdofinv=NULL,*ipe=NULL, 
-    *ime=NULL,*ikactmech=NULL,nactmech,inode,idir,neold,neini,
-    iemchange=0,nzsrad,*mast1rad=NULL,*irowrad=NULL,*icolrad=NULL,
-    *jqrad=NULL,*ipointerrad=NULL,*integerglob=NULL,negpres=0,
-    mass[2]={0,0},stiffness=1, buckling=0, rhsi=1, intscheme=0,idiscon=0,
-    coriolis=0,*ipneigh=NULL,*neigh=NULL,maxprevcontel,nslavs_prev_step,
-    *nelemface=NULL,*ipoface=NULL,*nodface=NULL,*ifreestream=NULL,
-    *isolidsurf=NULL,*neighsolidsurf=NULL,*iponoel=NULL,*inoel=NULL,
-    nface,nfreestream,nsolidsurf,i,icfd=0,id,
-    node,networknode,iflagact=0,*nodorig=NULL,*ipivr=NULL,iglob=0,
-    *inomat=NULL,*ipnei=NULL,ntrimax,*nx=NULL,*ny=NULL,*nz=NULL,
-    idampingwithoutcontact=0,*nactdoh=NULL,*nactdohinv=NULL,*ipkonf=NULL,
-    *ielmatf=NULL,*ielorienf=NULL,ialeatoric=0,nloadref,isym,
-    *nelemloadref=NULL,*iamloadref=NULL,*idefload=NULL,nload_,
-    *nelemload=NULL,*iamload=NULL,ncontacts=0,inccontact=0,nrhs=1,
-    j=0,n,inoelsize=0,isensitivity=0,*konf=NULL,
-    *iwork=NULL,nelt,lrgw,*igwk=NULL,itol,itmax,iter,ierr,iunit,ligw,
-    mei[4]={0,0,0,0},*itreated=NULL,mscalmethod=-1,inoelfree,
-    isiz=0,num_cpus,sys_cpus,ne1d2d=0,kchdep,nkftot,
-    ifreesurface=0,*iponoelf=NULL,*inoelf=NULL,
-    mortartrafoflag=0,*nelold=NULL,*nelnew=NULL,*nkold=NULL,*nknew=NULL,
-    *ipompcf=NULL,*nodempcf=NULL,*nodebounf=NULL,*ndirbounf=NULL,
-    *nelemloadf=NULL,*ipobodyf=NULL,nkf,nkonf,memmpcf,nbounf,nloadf,nmpcf,
-    *ikbounf=NULL,*ilbounf=NULL,*ikmpcf=NULL,*ilmpcf=NULL,*iambounf=NULL,
-    *iamloadf=NULL,*inotrf=NULL,*jqtherm=NULL,*jqw=NULL,*iroww=NULL,nzsw,
-    *kslav=NULL,*lslav=NULL,*ktot=NULL,*ltot=NULL,nmasts,neqslav,neqtot;
+  char description[13] = "            ", *lakon = NULL, jobnamef[396] = "",
+       *sideface = NULL, *labmpc = NULL, *lakonf = NULL, *env, *envsys, fneig[132] = "",
+       *sideloadref = NULL, *sideload = NULL, stiffmatrix[132] = "",
+       *sideloadf = NULL;
 
-  double *stn=NULL,*v=NULL,*een=NULL,cam[5],*epn=NULL,*cg=NULL,
-    *cdn=NULL,*pslavsurfold=NULL,
-    *f=NULL,*fn=NULL,qa[4]={0.,0.,-1.,0.},qam[2]={0.,0.},dtheta,theta,
-    err,ram[6]={0.,0.,0.,0.,0.,0.},*areaslav=NULL,
-    *springarea=NULL,ram1[6]={0.,0.,0.,0.,0.,0.},
-    ram2[6]={0.,0.,0.,0.,0.,0.},deltmx,ptime,smaxls,sminls,
-    uam[2]={0.,0.},*vini=NULL,*ac=NULL,qa0,qau,ea,*straight=NULL,
-    *t1act=NULL,qamold[2],*xbounact=NULL,*bc=NULL,
-    *xforcact=NULL,*xloadact=NULL,*fext=NULL,*clearini=NULL,
-    reltime,time,bet=0.,gam=0.,*aux2=NULL,dtime,*fini=NULL,
-    *fextini=NULL,*veini=NULL,*accini=NULL,*xstateini=NULL,
-    *ampli=NULL,scal1,*eei=NULL,*t1ini=NULL,pressureratio,
-    *xbounini=NULL,dev,*xstiff=NULL,*stx=NULL,*stiini=NULL,
-    *enern=NULL,*coefmpc=NULL,*aux=NULL,*xstaten=NULL,
-    *coefmpcref=NULL,*enerini=NULL,*emn=NULL,alpham,betam,
-    *tarea=NULL,*tenv=NULL,*erad=NULL,*fnr=NULL,*fni=NULL,
-    *adview=NULL,*auview=NULL,*qfx=NULL,*cvini=NULL,*cv=NULL,
-    *qfn=NULL,*co=NULL,*vold=NULL,*fenv=NULL,sigma=0.,
-    *xbodyact=NULL,*cgr=NULL,dthetaref, *vr=NULL,*vi=NULL,
-    *stnr=NULL,*stni=NULL,*vmax=NULL,*stnmax=NULL,*fmpc=NULL,*ener=NULL,
-    *f_cm=NULL, *f_cs=NULL,*adc=NULL,*auc=NULL,*res=NULL,
-    *xstate=NULL,*eenmax=NULL,*adrad=NULL,*aurad=NULL,*bcr=NULL,
-    *xmastnor=NULL,*emeini=NULL,*tinc,*tper,*tmin,*tmax,*tincf,
-    *doubleglob=NULL,*xnoels=NULL,*au=NULL,*resold=NULL,
-    *ad=NULL,*b=NULL,*aub=NULL,*adb=NULL,*pslavsurf=NULL,*pmastsurf=NULL,
-    *x=NULL,*y=NULL,*z=NULL,*xo=NULL,sum1,sum2,flinesearch,
-    *yo=NULL,*zo=NULL,*cdnr=NULL,*cdni=NULL,*fnext=NULL,*fnextini=NULL,
-    allwk=0.,allwkini,energyini[4]={0.,0.,0.,0.},*cof=NULL,
-    energyref,denergymax,dtcont,dtvol,wavespeed[*nmat],emax,r_abs,
-    enetoll,dampwk=0.,dampwkini=0.,temax,*tmp=NULL,energystartstep[4],
-    sizemaxinc,*adblump=NULL,*adcpy=NULL,*aucpy=NULL,*rwork=NULL,
-    *sol=NULL,*rgwk=NULL,tol,*sb=NULL,*sx=NULL,delcon,alea,
-    *smscale=NULL,dtset,energym=0.,energymold=0.,*voldf=NULL,
-    *coefmpcf=NULL,*xbounf=NULL,*xloadf=NULL,*xbounoldf=NULL,
-    *xbounactf=NULL,*xloadoldf=NULL,*xloadactf=NULL,*auw=NULL,*volddof=NULL,
-    *qb=NULL;
-	 
+  ITG *inum = NULL, k, iout = 0, icntrl, iinc = 0, jprint = 0, iit = -1, jnz = 0,
+      icutb = 0, istab = 0, uncoupled, n1, n2, itruecontact,
+      iperturb_sav[2], ilin, *icol = NULL, *irow = NULL, ielas = 0, icmd = 0,
+      memmpc_, mpcfree, icascade, maxlenmpc, *nodempc = NULL, *iaux = NULL,
+      *nodempcref = NULL, memmpcref_, mpcfreeref, *itg = NULL, *ineighe = NULL,
+      *ieg = NULL, ntg = 0, ntr, *kontri = NULL, *nloadtr = NULL, idamping = 0,
+      *ipiv = NULL, ntri, newstep, mode = -1, noddiam = -1, nasym = 0, im,
+      ntrit, *inocs = NULL, *nacteq = NULL, *ipface = NULL,
+      *nactdog = NULL, nteq, *itietri = NULL, *koncont = NULL, istrainfree = 0,
+      ncont, ne0, nkon0, *ipkon = NULL, *kon = NULL, *ielorien = NULL,
+      *ielmat = NULL, itp = 0, symmetryflag = 0, inputformat = 0, kscale = 1,
+      *iruc = NULL, iitterm = 0, iturbulent, ngraph = 1, ismallsliding = 0,
+      *ipompc = NULL, *ikmpc = NULL, *ilmpc = NULL, i0ref, irref, icref,
+      *itiefac = NULL, *islavsurf = NULL, *islavnode = NULL, *imastnode = NULL,
+      *nslavnode = NULL, *nmastnode = NULL, *imastop = NULL, imat,
+      *iponoels = NULL, *inoels = NULL, *islavsurfold = NULL, maxlenmpcref,
+      *islavact = NULL, mt = mi[1] + 1, *nactdofinv = NULL, *ipe = NULL,
+      *ime = NULL, *ikactmech = NULL, nactmech, inode, idir, neold, neini,
+      iemchange = 0, nzsrad, *mast1rad = NULL, *irowrad = NULL, *icolrad = NULL,
+      *jqrad = NULL, *ipointerrad = NULL, *integerglob = NULL, negpres = 0,
+      mass[2] = {0, 0}, stiffness = 1, buckling = 0, rhsi = 1, intscheme = 0, idiscon = 0,
+      coriolis = 0, *ipneigh = NULL, *neigh = NULL, maxprevcontel, nslavs_prev_step,
+      *nelemface = NULL, *ipoface = NULL, *nodface = NULL, *ifreestream = NULL,
+      *isolidsurf = NULL, *neighsolidsurf = NULL, *iponoel = NULL, *inoel = NULL,
+      nface, nfreestream, nsolidsurf, i, icfd = 0, id,
+      node, networknode, iflagact = 0, *nodorig = NULL, *ipivr = NULL, iglob = 0,
+      *inomat = NULL, *ipnei = NULL, ntrimax, *nx = NULL, *ny = NULL, *nz = NULL,
+      idampingwithoutcontact = 0, *nactdoh = NULL, *nactdohinv = NULL, *ipkonf = NULL,
+      *ielmatf = NULL, *ielorienf = NULL, ialeatoric = 0, nloadref, isym,
+      *nelemloadref = NULL, *iamloadref = NULL, *idefload = NULL, nload_,
+      *nelemload = NULL, *iamload = NULL, ncontacts = 0, inccontact = 0, nrhs = 1,
+      j = 0, n, inoelsize = 0, isensitivity = 0, *konf = NULL,
+      *iwork = NULL, nelt, lrgw, *igwk = NULL, itol, itmax, iter, ierr, iunit, ligw,
+      mei[4] = {0, 0, 0, 0}, *itreated = NULL, mscalmethod = -1, inoelfree,
+      isiz = 0, num_cpus, sys_cpus, ne1d2d = 0, kchdep, nkftot,
+      ifreesurface = 0, *iponoelf = NULL, *inoelf = NULL,
+      mortartrafoflag = 0, *nelold = NULL, *nelnew = NULL, *nkold = NULL, *nknew = NULL,
+      *ipompcf = NULL, *nodempcf = NULL, *nodebounf = NULL, *ndirbounf = NULL,
+      *nelemloadf = NULL, *ipobodyf = NULL, nkf, nkonf, memmpcf, nbounf, nloadf, nmpcf,
+      *ikbounf = NULL, *ilbounf = NULL, *ikmpcf = NULL, *ilmpcf = NULL, *iambounf = NULL,
+      *iamloadf = NULL, *inotrf = NULL, *jqtherm = NULL, *jqw = NULL, *iroww = NULL, nzsw,
+      *kslav = NULL, *lslav = NULL, *ktot = NULL, *ltot = NULL, nmasts, neqslav, neqtot;
+
+  double *stn = NULL, *v = NULL, *een = NULL, cam[5], *epn = NULL, *cg = NULL,
+         *cdn = NULL, *pslavsurfold = NULL,
+         *f = NULL, *fn = NULL, qa[4] = {0., 0., -1., 0.}, qam[2] = {0., 0.}, dtheta, theta,
+         err, ram[6] = {0., 0., 0., 0., 0., 0.}, *areaslav = NULL,
+         *springarea = NULL, ram1[6] = {0., 0., 0., 0., 0., 0.},
+         ram2[6] = {0., 0., 0., 0., 0., 0.}, deltmx, ptime, smaxls, sminls,
+         uam[2] = {0., 0.}, *vini = NULL, *ac = NULL, qa0, qau, ea, *straight = NULL,
+         *t1act = NULL, qamold[2], *xbounact = NULL, *bc = NULL,
+         *xforcact = NULL, *xloadact = NULL, *fext = NULL, *clearini = NULL,
+         reltime, time, bet = 0., gam = 0., *aux2 = NULL, dtime, *fini = NULL,
+         *fextini = NULL, *veini = NULL, *accini = NULL, *xstateini = NULL,
+         *ampli = NULL, scal1, *eei = NULL, *t1ini = NULL, pressureratio,
+         *xbounini = NULL, dev, *xstiff = NULL, *stx = NULL, *stiini = NULL,
+         *enern = NULL, *coefmpc = NULL, *aux = NULL, *xstaten = NULL,
+         *coefmpcref = NULL, *enerini = NULL, *emn = NULL, alpham, betam,
+         *tarea = NULL, *tenv = NULL, *erad = NULL, *fnr = NULL, *fni = NULL,
+         *adview = NULL, *auview = NULL, *qfx = NULL, *cvini = NULL, *cv = NULL,
+         *qfn = NULL, *co = NULL, *vold = NULL, *fenv = NULL, sigma = 0.,
+         *xbodyact = NULL, *cgr = NULL, dthetaref, *vr = NULL, *vi = NULL,
+         *stnr = NULL, *stni = NULL, *vmax = NULL, *stnmax = NULL, *fmpc = NULL, *ener = NULL,
+         *f_cm = NULL, *f_cs = NULL, *adc = NULL, *auc = NULL, *res = NULL,
+         *xstate = NULL, *eenmax = NULL, *adrad = NULL, *aurad = NULL, *bcr = NULL,
+         *xmastnor = NULL, *emeini = NULL, *tinc, *tper, *tmin, *tmax, *tincf,
+         *doubleglob = NULL, *xnoels = NULL, *au = NULL, *resold = NULL,
+         *ad = NULL, *b = NULL, *aub = NULL, *adb = NULL, *pslavsurf = NULL, *pmastsurf = NULL,
+         *x = NULL, *y = NULL, *z = NULL, *xo = NULL, sum1, sum2, flinesearch,
+         *yo = NULL, *zo = NULL, *cdnr = NULL, *cdni = NULL, *fnext = NULL, *fnextini = NULL,
+         allwk = 0., allwkini, energyini[4] = {0., 0., 0., 0.}, *cof = NULL,
+         energyref, denergymax, dtcont, dtvol, wavespeed[*nmat], emax, r_abs,
+         enetoll, dampwk = 0., dampwkini = 0., temax, *tmp = NULL, energystartstep[4],
+         sizemaxinc, *adblump = NULL, *adcpy = NULL, *aucpy = NULL, *rwork = NULL,
+         *sol = NULL, *rgwk = NULL, tol, *sb = NULL, *sx = NULL, delcon, alea,
+         *smscale = NULL, dtset, energym = 0., energymold = 0., *voldf = NULL,
+         *coefmpcf = NULL, *xbounf = NULL, *xloadf = NULL, *xbounoldf = NULL,
+         *xbounactf = NULL, *xloadoldf = NULL, *xloadactf = NULL, *auw = NULL, *volddof = NULL,
+         *qb = NULL;
+
   FILE *f1;
 
-  if(filab[4]!=' ') ne1d2d=1;
+  if (filab[4] != ' ')
+    ne1d2d = 1;
 
-  num_cpus=0;
-  sys_cpus=0;
-  
+  num_cpus = 0;
+  sys_cpus = 0;
+
   /* explicit user declaration prevails */
-  
-  envsys=getenv("NUMBER_OF_CPUS");
-  if(envsys){
-    sys_cpus=atoi(envsys);
-    if(sys_cpus<0) sys_cpus=0;
+
+  envsys = getenv("NUMBER_OF_CPUS");
+  if (envsys) {
+    sys_cpus = atoi(envsys);
+    if (sys_cpus < 0)
+      sys_cpus = 0;
   }
-  
+
   /* automatic detection of available number of processors */
-  
-  if(sys_cpus==0){
-    sys_cpus=getSystemCPUs();
-    if(sys_cpus<1) sys_cpus=1;
+
+  if (sys_cpus == 0) {
+    sys_cpus = getSystemCPUs();
+    if (sys_cpus < 1)
+      sys_cpus = 1;
   }
-  
+
   /* else global declaration, if any, applies */
-  
+
   env = getenv("OMP_NUM_THREADS");
-  if(num_cpus==0){
-    if(env)
-      num_cpus=atoi(env);
-    if(num_cpus<1) {
-      num_cpus=1;
-    }else if(num_cpus>sys_cpus){
-      num_cpus=sys_cpus;
+  if (num_cpus == 0) {
+    if (env)
+      num_cpus = atoi(env);
+    if (num_cpus < 1) {
+      num_cpus = 1;
+    } else if (num_cpus > sys_cpus) {
+      num_cpus = sys_cpus;
     }
   }
-  
+
   // MPADD: initialize rmin to the tolerance
-  enetoll=0.02;
-  r_abs=0.0;
-  emax=0.0;
+  enetoll = 0.02;
+  r_abs   = 0.0;
+  emax    = 0.0;
   // MPADD end
 
-  delcon=ctrl[53];alea=ctrl[54];
+  delcon = ctrl[53];
+  alea   = ctrl[54];
 
 #ifdef SGI
   ITG token;
 #endif
-  
+
   /* declarations for mortar contact */
 
-  char *labmpc2=NULL;
+  char *labmpc2 = NULL;
 
-  ITG *nslavspc=NULL,*islavspc=NULL,nsspc,*nslavmpc=NULL,*islavmpc=NULL,nsmpc,
-    *nslavspc2=NULL,*islavspc2=NULL,nsspc2,*nslavmpc2=NULL,*islavmpc2=NULL,
-    nsmpc2,
-    *nmastspc=NULL,*imastspc=NULL,nmspc,*nmastmpc=NULL,*imastmpc=NULL,nmmpc,
-    *nmastmpc2=NULL,*imastmpc2=NULL,nmmpc2,*islavactdof=NULL,iflag_fric,iwan,
-    *islavactini=NULL,iflagact_old,*islavactdoftie=NULL,
-    *irowtloc=NULL,*jqtloc=NULL,
-    nboun2,*ndirboun2=NULL,*nodeboun2=NULL,*irowtlocinv=NULL,*jqtlocinv=NULL,
-    nmpc2,*ipompc2=NULL,*nodempc2=NULL,iflagdualquad,
-    *ikboun2=NULL,*ilboun2=NULL,*ikmpc2=NULL,*ilmpc2=NULL,nk2,
-    *irowb=NULL,*jqb=NULL,*irowd=NULL,*jqd=NULL,*irowdtil=NULL,*jqdtil=NULL,
-    *irowbtil=NULL,*jqbtil=NULL,*irowbhelp=NULL,*jqbhelp=NULL,
-    *islavnodeinv=NULL,*islavelinv=NULL,*irowc2=NULL,*jqc2=NULL,nzsc2,
-    *icolc2=NULL,
-    *jqbd=NULL,*irowbd=NULL,*jqbdtil=NULL,*irowbdtil=NULL,*jqbdtil2=NULL,
-    *irowbdtil2=NULL,
-    *jqdd=NULL,*irowdd=NULL,*jqddtil=NULL,*irowddtil=NULL,*jqddtil2=NULL,
-    *irowddtil2=NULL,
-    *jqddinv=NULL,*irowddinv=NULL,*jqtemp=NULL,*irowtemp=NULL,*icoltemp=NULL,
-    nzstemp[3],
-    *irowbpg=NULL,*jqbpg=NULL,*irowbpgtil=NULL,*jqbpgtil=NULL,
-    *irowdpg=NULL,*jqdpg=NULL,*irowdpgtil=NULL,*jqdpgtil=NULL,
-    *nodeforc2=NULL,*ndirforc2=NULL,nforc2;
-  
-  double *lambdaiwan=NULL,*lambdaiwanini=NULL,
-    *xboun2=NULL,*coefmpc2=NULL,*bp=NULL,*gap=NULL,*slavnor=NULL,
-    *slavtan=NULL,*cdisp=NULL,*cstress=NULL,*cfs=NULL,*cfm=NULL,*cfsini=NULL,
-    *cfstil=NULL,*cfsinitil=NULL,*bpini=NULL,
-    *cstressini=NULL,*pslavdual=NULL,*pslavdualpg=NULL,*autloc=NULL,
-    *autlocinv=NULL,*Bd=NULL,*Bdhelp=NULL,
-    *Dd=NULL,*Ddtil=NULL,*Bdtil=NULL,*auc2=NULL,*adc2=NULL,*aubd=NULL,
-    *audd=NULL,*auddtil=NULL,*auddtil2=NULL,*auddinv=NULL,*bhat=NULL,
-    *aubdtil=NULL,
-    *aubdtil2=NULL,*Bpgd=NULL,*Bpgdtil=NULL,*auxtil2=NULL,*cvtil=NULL,
-    *cvtilini=NULL,
-    *Dpgd=NULL,*Dpgdtil=NULL,*xforc2=NULL;
+  ITG *nslavspc = NULL, *islavspc = NULL, nsspc, *nslavmpc = NULL, *islavmpc = NULL, nsmpc,
+      *nslavspc2 = NULL, *islavspc2 = NULL, nsspc2, *nslavmpc2 = NULL, *islavmpc2 = NULL,
+      nsmpc2,
+      *nmastspc = NULL, *imastspc = NULL, nmspc, *nmastmpc = NULL, *imastmpc = NULL, nmmpc,
+      *nmastmpc2 = NULL, *imastmpc2 = NULL, nmmpc2, *islavactdof = NULL, iflag_fric, iwan,
+      *islavactini = NULL, iflagact_old, *islavactdoftie = NULL,
+      *irowtloc = NULL, *jqtloc = NULL,
+      nboun2, *ndirboun2 = NULL, *nodeboun2 = NULL, *irowtlocinv = NULL, *jqtlocinv = NULL,
+      nmpc2, *ipompc2 = NULL, *nodempc2 = NULL, iflagdualquad,
+      *ikboun2 = NULL, *ilboun2 = NULL, *ikmpc2 = NULL, *ilmpc2 = NULL, nk2,
+      *irowb = NULL, *jqb = NULL, *irowd = NULL, *jqd = NULL, *irowdtil = NULL, *jqdtil = NULL,
+      *irowbtil = NULL, *jqbtil = NULL, *irowbhelp = NULL, *jqbhelp = NULL,
+      *islavnodeinv = NULL, *islavelinv = NULL, *irowc2 = NULL, *jqc2 = NULL, nzsc2,
+      *icolc2 = NULL,
+      *jqbd = NULL, *irowbd = NULL, *jqbdtil = NULL, *irowbdtil = NULL, *jqbdtil2 = NULL,
+      *irowbdtil2 = NULL,
+      *jqdd = NULL, *irowdd = NULL, *jqddtil = NULL, *irowddtil = NULL, *jqddtil2 = NULL,
+      *irowddtil2 = NULL,
+      *jqddinv = NULL, *irowddinv = NULL, *jqtemp = NULL, *irowtemp = NULL, *icoltemp = NULL,
+      nzstemp[3],
+      *irowbpg = NULL, *jqbpg = NULL, *irowbpgtil = NULL, *jqbpgtil = NULL,
+      *irowdpg = NULL, *jqdpg = NULL, *irowdpgtil = NULL, *jqdpgtil = NULL,
+      *nodeforc2 = NULL, *ndirforc2 = NULL, nforc2;
+
+  double *lambdaiwan = NULL, *lambdaiwanini = NULL,
+         *xboun2 = NULL, *coefmpc2 = NULL, *bp = NULL, *gap = NULL, *slavnor = NULL,
+         *slavtan = NULL, *cdisp = NULL, *cstress = NULL, *cfs = NULL, *cfm = NULL, *cfsini = NULL,
+         *cfstil = NULL, *cfsinitil = NULL, *bpini = NULL,
+         *cstressini = NULL, *pslavdual = NULL, *pslavdualpg = NULL, *autloc = NULL,
+         *autlocinv = NULL, *Bd = NULL, *Bdhelp = NULL,
+         *Dd = NULL, *Ddtil = NULL, *Bdtil = NULL, *auc2 = NULL, *adc2 = NULL, *aubd = NULL,
+         *audd = NULL, *auddtil = NULL, *auddtil2 = NULL, *auddinv = NULL, *bhat = NULL,
+         *aubdtil  = NULL,
+         *aubdtil2 = NULL, *Bpgd = NULL, *Bpgdtil = NULL, *auxtil2 = NULL, *cvtil = NULL,
+         *cvtilini = NULL,
+         *Dpgd = NULL, *Dpgdtil = NULL, *xforc2 = NULL;
 
   /* end of declarations for mortar contact */
 
-  icol=*icolp;irow=*irowp;co=*cop;vold=*voldp;
-  ipkon=*ipkonp;lakon=*lakonp;kon=*konp;ielorien=*ielorienp;
-  ielmat=*ielmatp;ener=*enerp;xstate=*xstatep;
-  
-  ipompc=*ipompcp;labmpc=*labmpcp;ikmpc=*ikmpcp;ilmpc=*ilmpcp;
-  fmpc=*fmpcp;nodempc=*nodempcp;coefmpc=*coefmpcp;nelemload=*nelemloadp;
-  iamload=*iamloadp;sideload=*sideloadp;
+  icol     = *icolp;
+  irow     = *irowp;
+  co       = *cop;
+  vold     = *voldp;
+  ipkon    = *ipkonp;
+  lakon    = *lakonp;
+  kon      = *konp;
+  ielorien = *ielorienp;
+  ielmat   = *ielmatp;
+  ener     = *enerp;
+  xstate   = *xstatep;
 
-  islavsurf=*islavsurfp;pslavsurf=*pslavsurfp;clearini=*clearinip;
+  ipompc    = *ipompcp;
+  labmpc    = *labmpcp;
+  ikmpc     = *ikmpcp;
+  ilmpc     = *ilmpcp;
+  fmpc      = *fmpcp;
+  nodempc   = *nodempcp;
+  coefmpc   = *coefmpcp;
+  nelemload = *nelemloadp;
+  iamload   = *iamloadp;
+  sideload  = *sideloadp;
 
-  tinc=&timepar[0];
-  tper=&timepar[1];
-  tmin=&timepar[2];
-  tmax=&timepar[3];
-  tincf=&timepar[4];
+  islavsurf = *islavsurfp;
+  pslavsurf = *pslavsurfp;
+  clearini  = *clearinip;
 
-    /* Adapter: Put all the CalculiX data that is needed for the coupling into an array */
+  tinc  = &timepar[0];
+  tper  = &timepar[1];
+  tmin  = &timepar[2];
+  tmax  = &timepar[3];
+  tincf = &timepar[4];
+
+  /* Adapter: Put all the CalculiX data that is needed for the coupling into an array */
   struct SimulationData simulationData = {
-      .ialset = ialset,
-      .ielmat = ielmat,
+      .ialset    = ialset,
+      .ielmat    = ielmat,
       .istartset = istartset,
-      .iendset = iendset,
-      .kon = kon,
-      .ipkon = ipkon,
-      .lakon = &lakon,
-      .co = co,
-      .set = set,
-      .nset = *nset,
-      .ikboun = ikboun,
-      .ikforc = ikforc,
-      .ilboun = ilboun,
-      .ilforc = ilforc,
-      .nboun = *nboun,
-      .nforc = *nforc,
+      .iendset   = iendset,
+      .kon       = kon,
+      .ipkon     = ipkon,
+      .lakon     = &lakon,
+      .co        = co,
+      .set       = set,
+      .nset      = *nset,
+      .ikboun    = ikboun,
+      .ikforc    = ikforc,
+      .ilboun    = ilboun,
+      .ilforc    = ilforc,
+      .nboun     = *nboun,
+      .nforc     = *nforc,
       .nelemload = nelemload,
-      .nload = *nload,
-      .sideload = sideload,
-      .mt = mt,
-      .nk = *nk,
-      .theta = &theta,
-      .dtheta = &dtheta,
-      .tper = tper,
-      .nmethod = nmethod,
-      .xload = xload,
-      .xforc = xforc,
-      .xboun = xboun,
-      .ntmat_ = ntmat_,
-      .vold = vold,
-      .veold = veold,
-      .fn = fn,
-      .cocon = cocon,
-      .ncocon = ncocon,
-      .mi = mi
-  };
+      .nload     = *nload,
+      .sideload  = sideload,
+      .mt        = mt,
+      .nk        = *nk,
+      .theta     = &theta,
+      .dtheta    = &dtheta,
+      .tper      = tper,
+      .nmethod   = nmethod,
+      .xload     = xload,
+      .xforc     = xforc,
+      .xboun     = xboun,
+      .ntmat_    = ntmat_,
+      .vold      = vold,
+      .veold     = veold,
+      .fn        = fn,
+      .cocon     = cocon,
+      .ncocon    = ncocon,
+      .mi        = mi};
 
-
-  if(*ithermal==4){
-    uncoupled=1;
-    *ithermal=3;
-  }else{
-    uncoupled=0;
+  if (*ithermal == 4) {
+    uncoupled = 1;
+    *ithermal = 3;
+  } else {
+    uncoupled = 0;
   }
-  
-  if(*mortar!=1){
-    maxprevcontel=*nslavs;
-  }else if(*mortar==1){
-    maxprevcontel=*nintpoint;
-    if(*nstate_!=0){
-      if(maxprevcontel!=0){
-	MNEW(islavsurfold,ITG,2**ifacecount+2);
-	MNEW(pslavsurfold,double,3**nintpoint);
-	isiz=2**ifacecount+2;cpyparitg(islavsurfold,islavsurf,&isiz,&num_cpus);
-	isiz=3**nintpoint;cpypardou(pslavsurfold,pslavsurf,&isiz,&num_cpus);
+
+  if (*mortar != 1) {
+    maxprevcontel = *nslavs;
+  } else if (*mortar == 1) {
+    maxprevcontel = *nintpoint;
+    if (*nstate_ != 0) {
+      if (maxprevcontel != 0) {
+        MNEW(islavsurfold, ITG, 2 * *ifacecount + 2);
+        MNEW(pslavsurfold, double, 3 * *nintpoint);
+        isiz = 2 * *ifacecount + 2;
+        cpyparitg(islavsurfold, islavsurf, &isiz, &num_cpus);
+        isiz = 3 * *nintpoint;
+        cpypardou(pslavsurfold, pslavsurf, &isiz, &num_cpus);
       }
     }
   }
-  nslavs_prev_step=*nslavs;
+  nslavs_prev_step = *nslavs;
 
   /* turbulence model 
      iturbulent==0: laminar
@@ -352,704 +374,772 @@ void nonlingeo_precice(double **cop, ITG *nk, ITG **konp, ITG **ipkonp, char **l
      iturbulent==2: q-omega
      iturbulent==3: BSL
      iturbulent==4: SST */
-  
-  iturbulent=(ITG)physcon[8];
-  
-  for(k=0;k<3;k++){
-    strcpy1(&jobnamef[k*132],&jobnamec[k*132],132);
+
+  iturbulent = (ITG) physcon[8];
+
+  for (k = 0; k < 3; k++) {
+    strcpy1(&jobnamef[k * 132], &jobnamec[k * 132], 132);
   }
-  
-  qa0=ctrl[20];qau=ctrl[21];ea=ctrl[23];deltmx=ctrl[26];
-  i0ref=ctrl[0];irref=ctrl[1];icref=ctrl[3];
 
-  sminls=ctrl[28];smaxls=ctrl[29];
-  
-  memmpc_=mpcinfo[0];mpcfree=mpcinfo[1];icascade=mpcinfo[2];
-  maxlenmpc=mpcinfo[3];
+  qa0    = ctrl[20];
+  qau    = ctrl[21];
+  ea     = ctrl[23];
+  deltmx = ctrl[26];
+  i0ref  = ctrl[0];
+  irref  = ctrl[1];
+  icref  = ctrl[3];
 
-  alpham=xmodal[0];
-  betam=xmodal[1];
+  sminls = ctrl[28];
+  smaxls = ctrl[29];
+
+  memmpc_   = mpcinfo[0];
+  mpcfree   = mpcinfo[1];
+  icascade  = mpcinfo[2];
+  maxlenmpc = mpcinfo[3];
+
+  alpham = xmodal[0];
+  betam  = xmodal[1];
 
   /* check whether, for a dynamic calculation, damping is involved */
-  
-  if(*nmethod==4){
-    if(*iexpl<=1){
-	  
+
+  if (*nmethod == 4) {
+    if (*iexpl <= 1) {
+
       /* implicit dynamics */
-	  
-      if((fabs(alpham)>1.e-30)||(fabs(betam)>1.e-30)){
-	idamping=1;idampingwithoutcontact=1;
-      }else{
-	for(i=0;i<*ne;i++){
-	  if(ipkon[i]<0) continue;
-	  if(strcmp1(&lakon[i*8],"ED")==0){
-	    idamping=1;idampingwithoutcontact=1;break;
-	  }
-	}
+
+      if ((fabs(alpham) > 1.e-30) || (fabs(betam) > 1.e-30)) {
+        idamping               = 1;
+        idampingwithoutcontact = 1;
+      } else {
+        for (i = 0; i < *ne; i++) {
+          if (ipkon[i] < 0)
+            continue;
+          if (strcmp1(&lakon[i * 8], "ED") == 0) {
+            idamping               = 1;
+            idampingwithoutcontact = 1;
+            break;
+          }
+        }
       }
-    }else{
-	  
+    } else {
+
       /* explicit dynamics */
-	  
-      if(fabs(alpham)>1.e-30){
-	idamping=1;idampingwithoutcontact=1;
+
+      if (fabs(alpham) > 1.e-30) {
+        idamping               = 1;
+        idampingwithoutcontact = 1;
       }
-      if(fabs(betam)>1.e-30){ // TODO cmt adapt to massless: we can take BETA
-	printf
-	  (" *ERROR: in explicit dynamic calculations the damping is only\n");
-	printf
-	  ("         allowed to be mass proportional: the coefficient beta\n");
-	printf("         of the stiffness proportional term must be zero\n");
-	FORTRAN(stop,());
+      if (fabs(betam) > 1.e-30) { // TODO cmt adapt to massless: we can take BETA
+        printf(" *ERROR: in explicit dynamic calculations the damping is only\n");
+        printf("         allowed to be mass proportional: the coefficient beta\n");
+        printf("         of the stiffness proportional term must be zero\n");
+        FORTRAN(stop, ());
       }
     }
   }
-  
+
   /* check whether a sensitivity step may follow (whether design variables
      were defined */
 
-  for(i=0;i<*ntie;i++){
-    if(strcmp1(&tieset[i*243+80],"D")==0){
-      isensitivity=1;
-      NNEW(adcpy,double,neq[1]);
+  for (i = 0; i < *ntie; i++) {
+    if (strcmp1(&tieset[i * 243 + 80], "D") == 0) {
+      isensitivity = 1;
+      NNEW(adcpy, double, neq[1]);
       /* no asymmetric matrices allowed for sensitivity */
-      NNEW(aucpy,double,nzs[1]);
+      NNEW(aucpy, double, nzs[1]);
       break;
     }
   }
 
-  if((icascade==2)&&(*iexpl>1)){
-    printf
-      (" *ERROR in nonlingeo: linear and nonlinear MPC's depend on each other\n");
+  if ((icascade == 2) && (*iexpl > 1)) {
+    printf(" *ERROR in nonlingeo: linear and nonlinear MPC's depend on each other\n");
     printf("        This is not allowed in a explicit dynamic calculation\n");
-    FORTRAN(stop,());
+    FORTRAN(stop, ());
   }
-      
+
   /* determining the global values to be used as boundary conditions
      for a submodel */
 
-  ITG irefine=0;
-  getglobalresults(&jobnamec[396],&integerglob,&doubleglob,nboun,iamboun,xboun,
-		   nload,sideload,iamload,&iglob,nforc,iamforc,xforc,
-		   ithermal,nk,t1,iamt1,&sigma,&irefine);
-  
-  if(iglob<0){
+  ITG irefine = 0;
+  getglobalresults(&jobnamec[396], &integerglob, &doubleglob, nboun, iamboun, xboun,
+                   nload, sideload, iamload, &iglob, nforc, iamforc, xforc,
+                   ithermal, nk, t1, iamt1, &sigma, &irefine);
+
+  if (iglob < 0) {
     printf(" *ERROR in nonlingeo: a submodel calculation for which\n");
     printf("        the global model results from a *FREQUENCY\n");
     printf("        calculation must be geometrically linear\n");
-    FORTRAN(stop,());
+    FORTRAN(stop, ());
   }
 
   /* reading temperatures from frd-file */
-  
-  if((itempuser[0]==2)&&(itempuser[1]!=itempuser[2])) {
-    utempread(t1,&itempuser[2],jobnamec);
-  }      
-  
+
+  if ((itempuser[0] == 2) && (itempuser[1] != itempuser[2])) {
+    utempread(t1, &itempuser[2], jobnamec);
+  }
+
   /* invert nactdof */
-  
-  NNEW(nactdofinv,ITG,mt**nk);
-  MNEW(nodorig,ITG,*nk);
-  FORTRAN(gennactdofinv,(nactdof,nactdofinv,nk,mi,nodorig,
-			 ipkon,lakon,kon,ne));
+
+  NNEW(nactdofinv, ITG, mt * *nk);
+  MNEW(nodorig, ITG, *nk);
+  FORTRAN(gennactdofinv, (nactdof, nactdofinv, nk, mi, nodorig,
+                          ipkon, lakon, kon, ne));
   SFREE(nodorig);
-  
+
   /* allocating a field for the stiffness matrix */
-  
-  NNEW(xstiff,double,(long long)27*mi[0]**ne);
-  
+
+  NNEW(xstiff, double, (long long) 27 * mi[0] * *ne);
+
   /* allocating force fields */
-  
-  NNEW(f,double,neq[1]);
-  NNEW(fext,double,neq[1]);
-  
-  NNEW(b,double,neq[1]);
-  NNEW(vini,double,mt**nk);
-  
-  NNEW(aux,double,7*maxlenmpc);
-  NNEW(iaux,ITG,2*maxlenmpc);
-  
+
+  NNEW(f, double, neq[1]);
+  NNEW(fext, double, neq[1]);
+
+  NNEW(b, double, neq[1]);
+  NNEW(vini, double, mt **nk);
+
+  NNEW(aux, double, 7 * maxlenmpc);
+  NNEW(iaux, ITG, 2 * maxlenmpc);
+
   /* allocating fields for the actual external loading */
-  
-  NNEW(xbounact,double,*nboun);
-  NNEW(xbounini,double,*nboun);
-  for(k=0;k<*nboun;++k){
-    xbounact[k]=xbounold[k];}
-  NNEW(xforcact,double,*nforc);
-  NNEW(xloadact,double,2**nload);
-  NNEW(xbodyact,double,7**nbody);
+
+  NNEW(xbounact, double, *nboun);
+  NNEW(xbounini, double, *nboun);
+  for (k = 0; k < *nboun; ++k) {
+    xbounact[k] = xbounold[k];
+  }
+  NNEW(xforcact, double, *nforc);
+  NNEW(xloadact, double, 2 * *nload);
+  NNEW(xbodyact, double, 7 * *nbody);
   /* copying the rotation axis and/or acceleration vector */
-  for(k=0;k<7**nbody;k++){
-    xbodyact[k]=xbody[k];}
-  
-  /* assigning the body forces to the elements */ 
-  
-  if(*nbody>0){
+  for (k = 0; k < 7 * *nbody; k++) {
+    xbodyact[k] = xbody[k];
+  }
+
+  /* assigning the body forces to the elements */
+
+  if (*nbody > 0) {
 
     /* check whether there the previous step was in the relative
        system and a change to the absolute system was requested */
-      
-    if((*nmethod==4)&&(alpha[1]>1.)){
-      NNEW(itreated,ITG,*nk);
-      FORTRAN(velinireltoabs,(ibody,xbody,cbody,nbody,set,
-			      istartset,iendset,ialset,nset,veold,mi,
-			      ipkon,kon,lakon,co,itreated));
+
+    if ((*nmethod == 4) && (alpha[1] > 1.)) {
+      NNEW(itreated, ITG, *nk);
+      FORTRAN(velinireltoabs, (ibody, xbody, cbody, nbody, set,
+                               istartset, iendset, ialset, nset, veold, mi,
+                               ipkon, kon, lakon, co, itreated));
       SFREE(itreated);
     }
-    if(*inewton==1){NNEW(cgr,double,4**ne);}
+    if (*inewton == 1) {
+      NNEW(cgr, double, 4 * *ne);
+    }
   }
-  
+
   /* for mechanical calculations: updating boundary conditions
      calculated in a previous thermal step */
-  
-  if(*ithermal<2) FORTRAN(gasmechbc,(vold,nload,sideload,
-				     nelemload,xload,mi));
-  
+
+  if (*ithermal < 2)
+    FORTRAN(gasmechbc, (vold, nload, sideload,
+                        nelemload, xload, mi));
+
   /* for thermal calculations: forced convection and cavity
      radiation*/
-  
-  if(*ithermal>1){
-    NNEW(itg,ITG,*nload+3**nflow);
-    NNEW(ieg,ITG,*nflow);
+
+  if (*ithermal > 1) {
+    NNEW(itg, ITG, *nload + 3 * *nflow);
+    NNEW(ieg, ITG, *nflow);
     /* max 6 triangles per face, 4 entries per triangle */
-    NNEW(kontri,ITG,24**nload);
-    NNEW(nloadtr,ITG,*nload);
-    NNEW(nacteq,ITG,4**nk);
-    NNEW(nactdog,ITG,4**nk);
-    NNEW(v,double,mt**nk);
-    FORTRAN(envtemp,(itg,ieg,&ntg,&ntr,sideload,nelemload,
-		     ipkon,kon,lakon,ielmat,ne,nload,
-		     kontri,&ntri,nloadtr,nflow,ndirboun,nactdog,
-		     nodeboun,nacteq,nboun,ielprop,prop,&nteq,
-		     v,network,physcon,shcon,ntmat_,co,
-		     vold,set,nshcon,rhcon,nrhcon,mi,nmpc,nodempc,
-		     ipompc,labmpc,ikboun,&nasym,ttime,&time,iaxial));
+    NNEW(kontri, ITG, 24 * *nload);
+    NNEW(nloadtr, ITG, *nload);
+    NNEW(nacteq, ITG, 4 * *nk);
+    NNEW(nactdog, ITG, 4 * *nk);
+    NNEW(v, double, mt **nk);
+    FORTRAN(envtemp, (itg, ieg, &ntg, &ntr, sideload, nelemload,
+                      ipkon, kon, lakon, ielmat, ne, nload,
+                      kontri, &ntri, nloadtr, nflow, ndirboun, nactdog,
+                      nodeboun, nacteq, nboun, ielprop, prop, &nteq,
+                      v, network, physcon, shcon, ntmat_, co,
+                      vold, set, nshcon, rhcon, nrhcon, mi, nmpc, nodempc,
+                      ipompc, labmpc, ikboun, &nasym, ttime, &time, iaxial));
     SFREE(v);
-      
-    if((*mcs>0)&&(ntr>0)){
-      NNEW(inocs,ITG,*nk);
-      radcyc(nk,kon,ipkon,lakon,ne,cs,mcs,nkon,ialset,istartset,
-	     iendset,&kontri,&ntri,&co,&vold,&ntrit,inocs,mi);
+
+    if ((*mcs > 0) && (ntr > 0)) {
+      NNEW(inocs, ITG, *nk);
+      radcyc(nk, kon, ipkon, lakon, ne, cs, mcs, nkon, ialset, istartset,
+             iendset, &kontri, &ntri, &co, &vold, &ntrit, inocs, mi);
+    } else {
+      ntrit = ntri;
     }
-    else{ntrit=ntri;}
-      
-    nzsrad=100*ntr;
-    NNEW(mast1rad,ITG,nzsrad);
-    NNEW(irowrad,ITG,nzsrad);
-    NNEW(icolrad,ITG,ntr);
-    NNEW(jqrad,ITG,ntr+1);
-    NNEW(ipointerrad,ITG,ntr);
-      
-    if(ntr>0){
-      mastructrad(&ntr,nloadtr,sideload,ipointerrad,
-		  &mast1rad,&irowrad,&nzsrad,
-		  jqrad,icolrad);
+
+    nzsrad = 100 * ntr;
+    NNEW(mast1rad, ITG, nzsrad);
+    NNEW(irowrad, ITG, nzsrad);
+    NNEW(icolrad, ITG, ntr);
+    NNEW(jqrad, ITG, ntr + 1);
+    NNEW(ipointerrad, ITG, ntr);
+
+    if (ntr > 0) {
+      mastructrad(&ntr, nloadtr, sideload, ipointerrad,
+                  &mast1rad, &irowrad, &nzsrad,
+                  jqrad, icolrad);
     }
-      
+
     /* determine the network elements belonging to a given node (for usage
        in user subroutine film */
 
-    if((*network>0)||(ntg>0)){
-      NNEW(iponoel,ITG,*nk);
-      NNEW(inoel,ITG,2**nkon);
-      if(*network>0){
-	FORTRAN(networkelementpernode,(iponoel,inoel,lakon,ipkon,kon,
-				       &inoelsize,nflow,ieg,ne,network));
+    if ((*network > 0) || (ntg > 0)) {
+      NNEW(iponoel, ITG, *nk);
+      NNEW(inoel, ITG, 2 * *nkon);
+      if (*network > 0) {
+        FORTRAN(networkelementpernode, (iponoel, inoel, lakon, ipkon, kon,
+                                        &inoelsize, nflow, ieg, ne, network));
       }
-      RENEW(inoel,ITG,2*inoelsize);
+      RENEW(inoel, ITG, 2 * inoelsize);
     }
 
-    SFREE(ipointerrad);SFREE(mast1rad);
-    RENEW(irowrad,ITG,nzsrad);
-      
-    RENEW(itg,ITG,ntg);
-    NNEW(ineighe,ITG,ntg);
-    RENEW(kontri,ITG,4*ntrit);
-    RENEW(nloadtr,ITG,ntr);
-      
-    NNEW(adview,double,ntr);
-    NNEW(auview,double,2*nzsrad);
-    NNEW(tarea,double,ntr);
-    NNEW(tenv,double,ntr);
-    NNEW(fenv,double,ntr);
-    NNEW(erad,double,ntr);
-      
-    NNEW(ac,double,nteq*nteq);
-    NNEW(bc,double,nteq);
-    NNEW(ipiv,ITG,nteq);
-    NNEW(adrad,double,ntr);
-    NNEW(aurad,double,2*nzsrad);
-    NNEW(bcr,double,ntr);
-    NNEW(ipivr,ITG,ntr);
+    SFREE(ipointerrad);
+    SFREE(mast1rad);
+    RENEW(irowrad, ITG, nzsrad);
+
+    RENEW(itg, ITG, ntg);
+    NNEW(ineighe, ITG, ntg);
+    RENEW(kontri, ITG, 4 * ntrit);
+    RENEW(nloadtr, ITG, ntr);
+
+    NNEW(adview, double, ntr);
+    NNEW(auview, double, 2 * nzsrad);
+    NNEW(tarea, double, ntr);
+    NNEW(tenv, double, ntr);
+    NNEW(fenv, double, ntr);
+    NNEW(erad, double, ntr);
+
+    NNEW(ac, double, nteq *nteq);
+    NNEW(bc, double, nteq);
+    NNEW(ipiv, ITG, nteq);
+    NNEW(adrad, double, ntr);
+    NNEW(aurad, double, 2 * nzsrad);
+    NNEW(bcr, double, ntr);
+    NNEW(ipivr, ITG, ntr);
   }
-  
+
   /* check for fluid elements
      check for strain-less elements */
-  
-  NNEW(nactdoh,ITG,*ne);
-  NNEW(nactdohinv,ITG,*ne);
-  *nef=0;
-  for(i=0;i<*ne;++i){
-    if(ipkon[i]<0) continue;
-    if(strcmp1(&lakon[8*i],"F")==0){
-      icfd=1;nactdohinv[*nef]=i+1;++*nef;nactdoh[i]=*nef;}
-    if(istrainfree==0){
-      if(ielmat[i]<0){istrainfree=1;}
+
+  NNEW(nactdoh, ITG, *ne);
+  NNEW(nactdohinv, ITG, *ne);
+  *nef = 0;
+  for (i = 0; i < *ne; ++i) {
+    if (ipkon[i] < 0)
+      continue;
+    if (strcmp1(&lakon[8 * i], "F") == 0) {
+      icfd             = 1;
+      nactdohinv[*nef] = i + 1;
+      ++*nef;
+      nactdoh[i] = *nef;
+    }
+    if (istrainfree == 0) {
+      if (ielmat[i] < 0) {
+        istrainfree = 1;
+      }
     }
   }
 
-  if(icfd==1){
-    if(iturbulent>=20){
+  if (icfd == 1) {
+    if (iturbulent >= 20) {
 
       /* CBS method for shallow water equations */
-      
-      iturbulent=iturbulent-20;
-      ifreesurface=1;
-      icfd=2;
-    }else if(iturbulent>=10){
+
+      iturbulent   = iturbulent - 20;
+      ifreesurface = 1;
+      icfd         = 2;
+    } else if (iturbulent >= 10) {
 
       /* CBS method for all other applications */
-      
-      iturbulent=iturbulent-10;
-      icfd=2;
+
+      iturbulent = iturbulent - 10;
+      icfd       = 2;
     }
   }
-  
-  if(icfd==1){
-  }else if(icfd==2){
-      SFREE(nactdoh);SFREE(nactdohinv);
 
-      /* rearranging the fluid nodes and elements such that
+  if (icfd == 1) {
+  } else if (icfd == 2) {
+    SFREE(nactdoh);
+    SFREE(nactdohinv);
+
+    /* rearranging the fluid nodes and elements such that
 	 no gaps occur */
 
-      NNEW(ipkonf,ITG,*nef);
-      NNEW(lakonf,char,8**nef);
-      NNEW(ielmatf,ITG,mi[2]**nef);
-      if(*norien>0) NNEW(ielorienf,ITG,mi[2]**nef);
-      NNEW(nelold,ITG,*nef);
-      NNEW(nelnew,ITG,*ne);
-      NNEW(cof,double,3**nk);
-      NNEW(voldf,double,mt**nk);
-      NNEW(nkold,ITG,*nk);
-      NNEW(nknew,ITG,*nk);
-      NNEW(inotrf,ITG,2**nk);
-      NNEW(konf,ITG,*nkon);
-      NNEW(ipompcf,ITG,*nmpc);
-      NNEW(ikmpcf,ITG,*nmpc);
-      NNEW(ilmpcf,ITG,*nmpc);
-      NNEW(nodempcf,ITG,3*memmpc_);
-      NNEW(coefmpcf,double,memmpc_);
-      NNEW(nodebounf,ITG,*nboun);
-      NNEW(ndirbounf,ITG,*nboun);
-      NNEW(ikbounf,ITG,*nboun);
-      NNEW(ilbounf,ITG,*nboun);
-      if(*nam>0) NNEW(iambounf,ITG,*nboun);
-      NNEW(xbounf,double,*nboun);
-      NNEW(xbounoldf,double,*nboun);
-      NNEW(xbounactf,double,*nboun);
-      NNEW(nelemloadf,ITG,2**nload);
-      if(*nam>0) NNEW(iamloadf,ITG,2**nload);
-      NNEW(xloadf,double,2**nload);
-      NNEW(xloadoldf,double,2**nload);
-      NNEW(xloadactf,double,2**nload);
-      NNEW(sideloadf,char,20**nload);
-      if(*nbody>0) NNEW(ipobodyf,ITG,2*(*ifreebody-1));
+    NNEW(ipkonf, ITG, *nef);
+    NNEW(lakonf, char, 8 * *nef);
+    NNEW(ielmatf, ITG, mi[2] * *nef);
+    if (*norien > 0)
+      NNEW(ielorienf, ITG, mi[2] * *nef);
+    NNEW(nelold, ITG, *nef);
+    NNEW(nelnew, ITG, *ne);
+    NNEW(cof, double, 3 * *nk);
+    NNEW(voldf, double, mt **nk);
+    NNEW(nkold, ITG, *nk);
+    NNEW(nknew, ITG, *nk);
+    NNEW(inotrf, ITG, 2 * *nk);
+    NNEW(konf, ITG, *nkon);
+    NNEW(ipompcf, ITG, *nmpc);
+    NNEW(ikmpcf, ITG, *nmpc);
+    NNEW(ilmpcf, ITG, *nmpc);
+    NNEW(nodempcf, ITG, 3 * memmpc_);
+    NNEW(coefmpcf, double, memmpc_);
+    NNEW(nodebounf, ITG, *nboun);
+    NNEW(ndirbounf, ITG, *nboun);
+    NNEW(ikbounf, ITG, *nboun);
+    NNEW(ilbounf, ITG, *nboun);
+    if (*nam > 0)
+      NNEW(iambounf, ITG, *nboun);
+    NNEW(xbounf, double, *nboun);
+    NNEW(xbounoldf, double, *nboun);
+    NNEW(xbounactf, double, *nboun);
+    NNEW(nelemloadf, ITG, 2 * *nload);
+    if (*nam > 0)
+      NNEW(iamloadf, ITG, 2 * *nload);
+    NNEW(xloadf, double, 2 * *nload);
+    NNEW(xloadoldf, double, 2 * *nload);
+    NNEW(xloadactf, double, 2 * *nload);
+    NNEW(sideloadf, char, 20 * *nload);
+    if (*nbody > 0)
+      NNEW(ipobodyf, ITG, 2 * (*ifreebody - 1));
 
-      FORTRAN(rearrangecfd,(ne,ipkon,lakon,ielmat,ielorien,norien,nef,ipkonf,
-			    lakonf,ielmatf,ielorienf,mi,nelold,nelnew,nkold,
-			    nknew,nk,&nkf,konf,&nkonf,nmpc,ipompc,nodempc,
-			    coefmpc,&memmpc_,&nmpcf,ipompcf,nodempcf,coefmpcf,
-			    &memmpcf,nboun,nodeboun,ndirboun,xboun,&nbounf,
-			    nodebounf,ndirbounf,xbounf,nload,nelemload,
-			    sideload,xload,&nloadf,nelemloadf,sideloadf,xloadf,
-			    ipobody,ipobodyf,kon,&nkftot,co,cof,vold,voldf,
-			    ikbounf,ilbounf,ikmpcf,ilmpcf,iambounf,iamloadf,
-			    iamboun,iamload,xbounold,xbounoldf,xbounact,
-			    xbounactf,xloadold,xloadoldf,xloadact,xloadactf,
-			    inotr,inotrf,nam,ntrans,nbody));
+    FORTRAN(rearrangecfd, (ne, ipkon, lakon, ielmat, ielorien, norien, nef, ipkonf,
+                           lakonf, ielmatf, ielorienf, mi, nelold, nelnew, nkold,
+                           nknew, nk, &nkf, konf, &nkonf, nmpc, ipompc, nodempc,
+                           coefmpc, &memmpc_, &nmpcf, ipompcf, nodempcf, coefmpcf,
+                           &memmpcf, nboun, nodeboun, ndirboun, xboun, &nbounf,
+                           nodebounf, ndirbounf, xbounf, nload, nelemload,
+                           sideload, xload, &nloadf, nelemloadf, sideloadf, xloadf,
+                           ipobody, ipobodyf, kon, &nkftot, co, cof, vold, voldf,
+                           ikbounf, ilbounf, ikmpcf, ilmpcf, iambounf, iamloadf,
+                           iamboun, iamload, xbounold, xbounoldf, xbounact,
+                           xbounactf, xloadold, xloadoldf, xloadact, xloadactf,
+                           inotr, inotrf, nam, ntrans, nbody));
 
-      /* call rearrangecfd */
-      
-      RENEW(nkold,ITG,nkftot);
-      RENEW(cof,double,3*nkftot);
-      RENEW(voldf,double,mt*nkftot);
-      NNEW(inotrf,ITG,2*nkftot);
-      RENEW(konf,ITG,nkonf);
-      RENEW(ipompcf,ITG,nmpcf);
-      RENEW(ikmpcf,ITG,nmpcf);
-      RENEW(ilmpcf,ITG,nmpcf);
-      RENEW(nodempcf,ITG,3*memmpcf);
-      RENEW(coefmpcf,double,memmpcf);
-      RENEW(nodebounf,ITG,nbounf);
-      RENEW(ndirbounf,ITG,nbounf);
-      RENEW(ikbounf,ITG,nbounf);
-      RENEW(ilbounf,ITG,nbounf);
-      if(*nam>0) RENEW(iambounf,ITG,nbounf);
-      RENEW(xbounf,double,nbounf);
-      RENEW(xbounoldf,double,nbounf);
-      RENEW(xbounactf,double,nbounf);
-      RENEW(nelemloadf,ITG,2*nloadf);
-      if(*nam>0) NNEW(iamloadf,ITG,2*nloadf);
-      RENEW(xloadf,double,2*nloadf);
-      RENEW(xloadoldf,double,2*nloadf);
-      RENEW(xloadactf,double,2*nloadf);
-      RENEW(sideloadf,char,20*nloadf);
-      
-      /* calculating topological properties for CFD */
-      
-      NNEW(sideface,char,6**nef);
-      NNEW(nelemface,ITG,6**nef);
-      NNEW(ipface,ITG,*nef);
-      NNEW(ipoface,ITG,nkf);
-      NNEW(nodface,ITG,5*6**nef);
-      NNEW(ifreestream,ITG,nkf);
-      NNEW(isolidsurf,ITG,nkf);
-      NNEW(neighsolidsurf,ITG,nkf);
-      NNEW(iponoelf,ITG,nkf);
-      NNEW(inoelf,ITG,2*8**nef);
-      NNEW(inomat,ITG,nkftot);
-      FORTRAN(topocfdfem,(nelemface,sideface,&nface,ipoface,nodface,nef,ipkonf,
-			  konf,lakonf,&nkf,
-			  isolidsurf,&nsolidsurf,ifreestream,&nfreestream,
-			  neighsolidsurf,iponoelf,inoelf,&inoelfree,cof,
-			  set,istartset,iendset,
-			  ialset,nset,&iturbulent,inomat,ielmatf,ipface));
-      RENEW(sideface,char,nface);
-      RENEW(nelemface,ITG,nface);
-      SFREE(ipoface);SFREE(nodface);
-      RENEW(ifreestream,ITG,nfreestream);
-      RENEW(isolidsurf,ITG,nsolidsurf);
-      RENEW(neighsolidsurf,ITG,nsolidsurf);
-      RENEW(inoelf,ITG,2*inoelfree);
-      if(*ithermal==1){
-	NNEW(qfx,double,3*mi[0]**ne);}
-  }else{
-    SFREE(nactdoh);SFREE(nactdohinv);
+    /* call rearrangecfd */
+
+    RENEW(nkold, ITG, nkftot);
+    RENEW(cof, double, 3 * nkftot);
+    RENEW(voldf, double, mt *nkftot);
+    NNEW(inotrf, ITG, 2 * nkftot);
+    RENEW(konf, ITG, nkonf);
+    RENEW(ipompcf, ITG, nmpcf);
+    RENEW(ikmpcf, ITG, nmpcf);
+    RENEW(ilmpcf, ITG, nmpcf);
+    RENEW(nodempcf, ITG, 3 * memmpcf);
+    RENEW(coefmpcf, double, memmpcf);
+    RENEW(nodebounf, ITG, nbounf);
+    RENEW(ndirbounf, ITG, nbounf);
+    RENEW(ikbounf, ITG, nbounf);
+    RENEW(ilbounf, ITG, nbounf);
+    if (*nam > 0)
+      RENEW(iambounf, ITG, nbounf);
+    RENEW(xbounf, double, nbounf);
+    RENEW(xbounoldf, double, nbounf);
+    RENEW(xbounactf, double, nbounf);
+    RENEW(nelemloadf, ITG, 2 * nloadf);
+    if (*nam > 0)
+      NNEW(iamloadf, ITG, 2 * nloadf);
+    RENEW(xloadf, double, 2 * nloadf);
+    RENEW(xloadoldf, double, 2 * nloadf);
+    RENEW(xloadactf, double, 2 * nloadf);
+    RENEW(sideloadf, char, 20 * nloadf);
+
+    /* calculating topological properties for CFD */
+
+    NNEW(sideface, char, 6 * *nef);
+    NNEW(nelemface, ITG, 6 * *nef);
+    NNEW(ipface, ITG, *nef);
+    NNEW(ipoface, ITG, nkf);
+    NNEW(nodface, ITG, 5 * 6 * *nef);
+    NNEW(ifreestream, ITG, nkf);
+    NNEW(isolidsurf, ITG, nkf);
+    NNEW(neighsolidsurf, ITG, nkf);
+    NNEW(iponoelf, ITG, nkf);
+    NNEW(inoelf, ITG, 2 * 8 * *nef);
+    NNEW(inomat, ITG, nkftot);
+    FORTRAN(topocfdfem, (nelemface, sideface, &nface, ipoface, nodface, nef, ipkonf,
+                         konf, lakonf, &nkf,
+                         isolidsurf, &nsolidsurf, ifreestream, &nfreestream,
+                         neighsolidsurf, iponoelf, inoelf, &inoelfree, cof,
+                         set, istartset, iendset,
+                         ialset, nset, &iturbulent, inomat, ielmatf, ipface));
+    RENEW(sideface, char, nface);
+    RENEW(nelemface, ITG, nface);
+    SFREE(ipoface);
+    SFREE(nodface);
+    RENEW(ifreestream, ITG, nfreestream);
+    RENEW(isolidsurf, ITG, nsolidsurf);
+    RENEW(neighsolidsurf, ITG, nsolidsurf);
+    RENEW(inoelf, ITG, 2 * inoelfree);
+    if (*ithermal == 1) {
+      NNEW(qfx, double, 3 * mi[0] * *ne);
+    }
+  } else {
+    SFREE(nactdoh);
+    SFREE(nactdohinv);
   }
-  
-  if(*ithermal>1){
-    NNEW(qfx,double,3*mi[0]**ne);}
-  
+
+  if (*ithermal > 1) {
+    NNEW(qfx, double, 3 * mi[0] * *ne);
+  }
+
   /* contact conditions */
-  
-  inicont(nk,&ncont,ntie,tieset,nset,set,istartset,iendset,ialset,&itietri,
-	  lakon,ipkon,kon,&koncont,nslavs,tietol,&ismallsliding,&itiefac,
-          &islavsurf,&islavnode,&imastnode,&nslavnode,&nmastnode,
-          mortar,&imastop,nkon,&iponoels,&inoels,&ipe,&ime,ne,ifacecount,
-	  iperturb,ikboun,nboun,co,istep,&xnoels);
-  
-  if(ncont!=0){
-      
-    NNEW(cg,double,3*ncont);
-    NNEW(straight,double,16*ncont);
-	  
+
+  inicont(nk, &ncont, ntie, tieset, nset, set, istartset, iendset, ialset, &itietri,
+          lakon, ipkon, kon, &koncont, nslavs, tietol, &ismallsliding, &itiefac,
+          &islavsurf, &islavnode, &imastnode, &nslavnode, &nmastnode,
+          mortar, &imastop, nkon, &iponoels, &inoels, &ipe, &ime, ne, ifacecount,
+          iperturb, ikboun, nboun, co, istep, &xnoels);
+
+  if (ncont != 0) {
+
+    NNEW(cg, double, 3 * ncont);
+    NNEW(straight, double, 16 * ncont);
+
     /* 11 instead of 10: last position is reserved for the
        local contact spring element number; needed as
        pointer into springarea */
-      
-    if(*mortar<=0){
-      RENEW(kon,ITG,*nkon+11**nslavs);
-      NNEW(springarea,double,2**nslavs);
-      if(*nener==1){
-	RENEW(ener,double,mi[0]*(*ne+*nslavs)*2);
 
-	/* setting the entries for the friction contact energy to zero */
+    if (*mortar <= 0) {
+      RENEW(kon, ITG, *nkon + 11 * *nslavs);
+      NNEW(springarea, double, 2 * *nslavs);
+      if (*nener == 1) {
+        RENEW(ener, double, mi[0] * (*ne + *nslavs) * 2);
 
-	for(k=mi[0]*(2**ne+*nslavs);k<mi[0]*(*ne+*nslavs)*2;k++){
-	  ener[k]=0.;}
+        /* setting the entries for the friction contact energy to zero */
+
+        for (k = mi[0] * (2 * *ne + *nslavs); k < mi[0] * (*ne + *nslavs) * 2; k++) {
+          ener[k] = 0.;
+        }
       }
-      RENEW(ipkon,ITG,*ne+*nslavs);
-      RENEW(lakon,char,8*(*ne+*nslavs));
-	  
-      if(*norien>0){
-	RENEW(ielorien,ITG,mi[2]*(*ne+*nslavs));
-	for(k=mi[2]**ne;k<mi[2]*(*ne+*nslavs);k++){
-	  ielorien[k]=0;}
+      RENEW(ipkon, ITG, *ne + *nslavs);
+      RENEW(lakon, char, 8 * (*ne + *nslavs));
+
+      if (*norien > 0) {
+        RENEW(ielorien, ITG, mi[2] * (*ne + *nslavs));
+        for (k = mi[2] * *ne; k < mi[2] * (*ne + *nslavs); k++) {
+          ielorien[k] = 0;
+        }
       }
 
-      RENEW(ielmat,ITG,mi[2]*(*ne+*nslavs));
-      for(k=mi[2]**ne;k<mi[2]*(*ne+*nslavs);k++){
-	ielmat[k]=1;}
-
-      if((maxprevcontel==0)&&(*nslavs!=0)){
-	RENEW(xstate,double,*nstate_*mi[0]*(*ne+*nslavs));
-	for(k=*nstate_*mi[0]**ne;k<*nstate_*mi[0]*(*ne+*nslavs);k++){
-	  xstate[k]=0.;
-	}
+      RENEW(ielmat, ITG, mi[2] * (*ne + *nslavs));
+      for (k = mi[2] * *ne; k < mi[2] * (*ne + *nslavs); k++) {
+        ielmat[k] = 1;
       }
-      maxprevcontel=*nslavs;
 
-      NNEW(areaslav,double,*ifacecount);
-    }else if(*mortar==1){
-      NNEW(islavact,ITG,nslavnode[*ntie]);
-      if((*istep==1)||(nslavs_prev_step==0))
-	NNEW(clearini,double,3*9**ifacecount);
+      if ((maxprevcontel == 0) && (*nslavs != 0)) {
+        RENEW(xstate, double, *nstate_ *mi[0] * (*ne + *nslavs));
+        for (k = *nstate_ * mi[0] * *ne; k < *nstate_ * mi[0] * (*ne + *nslavs); k++) {
+          xstate[k] = 0.;
+        }
+      }
+      maxprevcontel = *nslavs;
+
+      NNEW(areaslav, double, *ifacecount);
+    } else if (*mortar == 1) {
+      NNEW(islavact, ITG, nslavnode[*ntie]);
+      if ((*istep == 1) || (nslavs_prev_step == 0))
+        NNEW(clearini, double, 3 * 9 * *ifacecount);
 
       /* check whether at least one contact definition involves true contact
 	 and not just tied contact */
 
-      FORTRAN(checktruecontact,(ntie,tieset,tietol,elcon,&itruecontact,
-				ncmat_,ntmat_));
-    }else if(*mortar>1){
-      inimortar(&ener,mi,ne,nslavs,nk,nener,&ipkon,&lakon,&kon,nkon,
-		&maxprevcontel,&xstate,nstate_,&islavactdoftie,&bp,&islavact,
-		&gap,&slavnor,&slavtan,&cdisp,&cstress,&cfs,&cfm,&cfsini,
-		&cfsinitil,&cfstil,&bpini,&islavactini,&cstressini,&iwan,ntie,
-		tieset,nslavnode,islavnode,&islavnodeinv,&islavelinv,
-		&pslavdual,&pslavdualpg,&autloc,&irowtloc,&jqtloc,&autlocinv,
-		&irowtlocinv,&jqtlocinv,&Bd,&irowb,&jqb,&Bdhelp,&irowbhelp,
-		&jqbhelp,&Dd,&irowd,&jqd,&Ddtil,&irowdtil,&jqdtil,&Bdtil,
-		&irowbtil,&jqbtil,&Bpgd,&irowbpg,&jqbpg,&Dpgd,&irowdpg,&jqdpg,
-		&Dpgdtil,&irowdpgtil,&jqdpgtil,&Bpgdtil,&irowbpgtil,&jqbpgtil,
-		&iflagdualquad,itiefac,islavsurf,nboun,ndirboun,nodeboun,
-		xbounact,nmpc,ipompc,nodempc,coefmpc,labmpc,ikboun,ilboun,
-		ikmpc,ilmpc,&nboun2,&ndirboun2,&nodeboun2,&xboun2,&nmpc2,
-		&ipompc2,&nodempc2,&coefmpc2,&labmpc2,&ikboun2,&ilboun2,
-		&ikmpc2,&ilmpc2,&nslavspc,&islavspc,&nslavmpc,&islavmpc,
-		&nslavspc2,&islavspc2,&nslavmpc2,&islavmpc2,&nmastspc,
-		&imastspc,&nmastmpc,&imastmpc,&nmastmpc2,&imastmpc2,&nmmpc2,
-		&nsspc,&nsspc2,&nsmpc,&nsmpc2,imastnode,nmastnode,&nmspc,
-		&nmmpc,iponoels,inoels,tietol,elcon,ncmat_,ntmat_,&nasym,
-		&iflag_fric,&lambdaiwan,&lambdaiwanini,&nk2,vold,nset,set,
-		mortar,&memmpc_,&ielmat,&ielorien,norien,nmethod,nodeforc,
-		ndirforc,xforc,nforc,&nodeforc2,&ndirforc2,&xforc2,&nforc2);
+      FORTRAN(checktruecontact, (ntie, tieset, tietol, elcon, &itruecontact,
+                                 ncmat_, ntmat_));
+    } else if (*mortar > 1) {
+      inimortar(&ener, mi, ne, nslavs, nk, nener, &ipkon, &lakon, &kon, nkon,
+                &maxprevcontel, &xstate, nstate_, &islavactdoftie, &bp, &islavact,
+                &gap, &slavnor, &slavtan, &cdisp, &cstress, &cfs, &cfm, &cfsini,
+                &cfsinitil, &cfstil, &bpini, &islavactini, &cstressini, &iwan, ntie,
+                tieset, nslavnode, islavnode, &islavnodeinv, &islavelinv,
+                &pslavdual, &pslavdualpg, &autloc, &irowtloc, &jqtloc, &autlocinv,
+                &irowtlocinv, &jqtlocinv, &Bd, &irowb, &jqb, &Bdhelp, &irowbhelp,
+                &jqbhelp, &Dd, &irowd, &jqd, &Ddtil, &irowdtil, &jqdtil, &Bdtil,
+                &irowbtil, &jqbtil, &Bpgd, &irowbpg, &jqbpg, &Dpgd, &irowdpg, &jqdpg,
+                &Dpgdtil, &irowdpgtil, &jqdpgtil, &Bpgdtil, &irowbpgtil, &jqbpgtil,
+                &iflagdualquad, itiefac, islavsurf, nboun, ndirboun, nodeboun,
+                xbounact, nmpc, ipompc, nodempc, coefmpc, labmpc, ikboun, ilboun,
+                ikmpc, ilmpc, &nboun2, &ndirboun2, &nodeboun2, &xboun2, &nmpc2,
+                &ipompc2, &nodempc2, &coefmpc2, &labmpc2, &ikboun2, &ilboun2,
+                &ikmpc2, &ilmpc2, &nslavspc, &islavspc, &nslavmpc, &islavmpc,
+                &nslavspc2, &islavspc2, &nslavmpc2, &islavmpc2, &nmastspc,
+                &imastspc, &nmastmpc, &imastmpc, &nmastmpc2, &imastmpc2, &nmmpc2,
+                &nsspc, &nsspc2, &nsmpc, &nsmpc2, imastnode, nmastnode, &nmspc,
+                &nmmpc, iponoels, inoels, tietol, elcon, ncmat_, ntmat_, &nasym,
+                &iflag_fric, &lambdaiwan, &lambdaiwanini, &nk2, vold, nset, set,
+                mortar, &memmpc_, &ielmat, &ielorien, norien, nmethod, nodeforc,
+                ndirforc, xforc, nforc, &nodeforc2, &ndirforc2, &xforc2, &nforc2);
     }
-    NNEW(xmastnor,double,3*nmastnode[*ntie]);
+    NNEW(xmastnor, double, 3 * nmastnode[*ntie]);
   }
-  
-  if(icascade==2){
-    memmpcref_=memmpc_;mpcfreeref=mpcfree;maxlenmpcref=maxlenmpc;
-    NNEW(nodempcref,ITG,3*memmpc_);
-    for(k=0;k<3*memmpc_;k++){
-      nodempcref[k]=nodempc[k];}
-    NNEW(coefmpcref,double,memmpc_);
-    for(k=0;k<memmpc_;k++){
-      coefmpcref[k]=coefmpc[k];}
+
+  if (icascade == 2) {
+    memmpcref_   = memmpc_;
+    mpcfreeref   = mpcfree;
+    maxlenmpcref = maxlenmpc;
+    NNEW(nodempcref, ITG, 3 * memmpc_);
+    for (k = 0; k < 3 * memmpc_; k++) {
+      nodempcref[k] = nodempc[k];
+    }
+    NNEW(coefmpcref, double, memmpc_);
+    for (k = 0; k < memmpc_; k++) {
+      coefmpcref[k] = coefmpc[k];
+    }
   }
-  
-  if((*ithermal==1)||(*ithermal>=3)){
-    NNEW(t1ini,double,*nk);
-    NNEW(t1act,double,*nk);
-    for(k=0;k<*nk;++k){
-      t1act[k]=t1old[k];}
+
+  if ((*ithermal == 1) || (*ithermal >= 3)) {
+    NNEW(t1ini, double, *nk);
+    NNEW(t1act, double, *nk);
+    for (k = 0; k < *nk; ++k) {
+      t1act[k] = t1old[k];
+    }
   }
-  
+
   /* allocating a field for the instantaneous amplitude */
-  
-  NNEW(ampli,double,*nam);
-  
+
+  NNEW(ampli, double, *nam);
+
   /* fini is also needed in static calculations if ilin=1
      to get correct values of f after a divergent increment */
 
-  NNEW(fini,double,neq[1]);
-  
+  NNEW(fini, double, neq[1]);
+
   /* allocating fields for nonlinear dynamics */
-  
-  if(*nmethod==4){
-    mass[0]=1;
-    mass[1]=1;
-    NNEW(aux2,double,neq[1]);
-    NNEW(fextini,double,neq[1]);
-    NNEW(fnext,double,mt**nk);
-    NNEW(fnextini,double,mt**nk);
-    NNEW(veini,double,mt**nk);
-    NNEW(accini,double,mt**nk);
-    NNEW(adb,double,neq[1]);
-    NNEW(aub,double,nzs[1]);
-    NNEW(cvini,double,neq[1]);
-    NNEW(cv,double,neq[1]);
+
+  if (*nmethod == 4) {
+    mass[0] = 1;
+    mass[1] = 1;
+    NNEW(aux2, double, neq[1]);
+    NNEW(fextini, double, neq[1]);
+    NNEW(fnext, double, mt **nk);
+    NNEW(fnextini, double, mt **nk);
+    NNEW(veini, double, mt **nk);
+    NNEW(accini, double, mt **nk);
+    NNEW(adb, double, neq[1]);
+    NNEW(aub, double, nzs[1]);
+    NNEW(cvini, double, neq[1]);
+    NNEW(cv, double, neq[1]);
   }
 
-  if((*nstate_!=0)&&((*mortar!=1)||(ncont==0))){
-    NNEW(xstateini,double,*nstate_*mi[0]*(*ne+*nslavs));
-    for(k=0;k<*nstate_*mi[0]*(*ne+*nslavs);++k){
-      xstateini[k]=xstate[k];
+  if ((*nstate_ != 0) && ((*mortar != 1) || (ncont == 0))) {
+    NNEW(xstateini, double, *nstate_ *mi[0] * (*ne + *nslavs));
+    for (k = 0; k < *nstate_ * mi[0] * (*ne + *nslavs); ++k) {
+      xstateini[k] = xstate[k];
     }
   }
-  if((*nstate_!=0)&&(*mortar==1)) NNEW(xstateini,double,1);
-  NNEW(eei,double,6*mi[0]**ne);
-  NNEW(stiini,double,6*mi[0]**ne);
-  NNEW(emeini,double,6*mi[0]**ne);
-  if(*nener==1)
-    NNEW(enerini,double,mi[0]**ne);
-  
-  qa[0]=qaold[0];
-  qa[1]=qaold[1];
-  
+  if ((*nstate_ != 0) && (*mortar == 1))
+    NNEW(xstateini, double, 1);
+  NNEW(eei, double, 6 * mi[0] * *ne);
+  NNEW(stiini, double, 6 * mi[0] * *ne);
+  NNEW(emeini, double, 6 * mi[0] * *ne);
+  if (*nener == 1)
+    NNEW(enerini, double, mi[0] * *ne);
+
+  qa[0] = qaold[0];
+  qa[1] = qaold[1];
+
   /* normalizing the time */
-  
-  FORTRAN(checktime,(itpamp,namta,tinc,ttime,amta,tmin,inext,&itp,istep,tper));
-  dtheta=(*tinc)/(*tper);
+
+  FORTRAN(checktime, (itpamp, namta, tinc, ttime, amta, tmin, inext, &itp, istep, tper));
+  dtheta = (*tinc) / (*tper);
 
   /* taking care of a small increment at the end of the step
      for face-to-face penalty contact */
 
-  dthetaref=dtheta;
-  if((dtheta<=1.e-6)&&(*iexpl<=1)){
+  dthetaref = dtheta;
+  if ((dtheta <= 1.e-6) && (*iexpl <= 1)) {
     printf("\n *ERROR in nonlingeo\n");
     printf(" increment size smaller than one millionth of step size\n");
     printf(" increase increment size\n\n");
   }
-  *tmin=*tmin/(*tper);
-  *tmax=*tmax/(*tper);
-  theta=0.;
-  
+  *tmin = *tmin / (*tper);
+  *tmax = *tmax / (*tper);
+  theta = 0.;
+
   /* calculating an initial flux norm */
-  
-  if(*ithermal!=2){
-    if(qau>1.e-10){qam[0]=qau;}
-    else if(qa0>1.e-10){qam[0]=qa0;}
-    else if(qa[0]>1.e-10){qam[0]=qa[0];}
-    else {qam[0]=1.e-2;}
+
+  if (*ithermal != 2) {
+    if (qau > 1.e-10) {
+      qam[0] = qau;
+    } else if (qa0 > 1.e-10) {
+      qam[0] = qa0;
+    } else if (qa[0] > 1.e-10) {
+      qam[0] = qa[0];
+    } else {
+      qam[0] = 1.e-2;
+    }
   }
-  if(*ithermal>1){
-    if(qau>1.e-10){
-      qam[1]=qau;}
-    else if(qa0>1.e-10){
-      qam[1]=qa0;}
-    else if(qa[1]>1.e-10){
-      qam[1]=qa[1];}
-    else {qam[1]=1.e-2;}
+  if (*ithermal > 1) {
+    if (qau > 1.e-10) {
+      qam[1] = qau;
+    } else if (qa0 > 1.e-10) {
+      qam[1] = qa0;
+    } else if (qa[1] > 1.e-10) {
+      qam[1] = qa[1];
+    } else {
+      qam[1] = 1.e-2;
+    }
   }
-  
+
   /* storing the element and topology information before introducing 
      contact elements */
-  
-  ne0=*ne;nkon0=*nkon;neold=*ne;
-  
+
+  ne0   = *ne;
+  nkon0 = *nkon;
+  neold = *ne;
+
   /*********************************************************************/
-  
+
   /* calculating of the acceleration due to force discontinuities
      (external - internal force) at the start of a step */
-  
+
   /*********************************************************************/
-  
-  if((*nmethod==4)&&(*ithermal!=2)&&(icfd==0)){
-    bet=(1.-alpha[0])*(1.-alpha[0])/4.;
-    gam=0.5-alpha[0];
+
+  if ((*nmethod == 4) && (*ithermal != 2) && (icfd == 0)) {
+    bet = (1. - alpha[0]) * (1. - alpha[0]) / 4.;
+    gam = 0.5 - alpha[0];
 
     /* initialization of the energy */
 
-    if(ithermal[0]<=1){
-      isiz=mi[0]*ne0;cpypardou(enerini,ener,&isiz,&num_cpus);
+    if (ithermal[0] <= 1) {
+      isiz = mi[0] * ne0;
+      cpypardou(enerini, ener, &isiz, &num_cpus);
     }
-      
+
     /* calculating the stiffness and mass matrix */
-      
-    reltime=0.;
-    time=0.;
-    dtime=0.;
-      
-    FORTRAN(tempload,(xforcold,xforc,xforcact,iamforc,nforc,xloadold,xload,
-		      xloadact,iamload,nload,ibody,xbody,nbody,xbodyold,
-		      xbodyact,t1old,t1,t1act,iamt1,nk,amta,namta,nam,ampli,
-		      &time,&reltime,ttime,&dtime,ithermal,nmethod,xbounold,
-		      xboun,xbounact,iamboun,nboun,nodeboun,ndirboun,nodeforc,
-		      ndirforc,istep,&iinc,co,vold,itg,&ntg,amname,ikboun,
-		      ilboun,nelemload,sideload,mi,ntrans,trab,inotr,veold,
-		      integerglob,doubleglob,tieset,istartset,iendset,ialset,
-		      ntie,nmpc,ipompc,ikmpc,ilmpc,nodempc,coefmpc,ipobody,
-		      iponoel,inoel,ipkon,kon,ielprop,prop,ielmat,shcon,nshcon,
-		      rhcon,nrhcon,cocon,ncocon,ntmat_,lakon,set,nset));
-      
-    time=0.;
-    dtime=1.;
-    
+
+    reltime = 0.;
+    time    = 0.;
+    dtime   = 0.;
+
+    FORTRAN(tempload, (xforcold, xforc, xforcact, iamforc, nforc, xloadold, xload,
+                       xloadact, iamload, nload, ibody, xbody, nbody, xbodyold,
+                       xbodyact, t1old, t1, t1act, iamt1, nk, amta, namta, nam, ampli,
+                       &time, &reltime, ttime, &dtime, ithermal, nmethod, xbounold,
+                       xboun, xbounact, iamboun, nboun, nodeboun, ndirboun, nodeforc,
+                       ndirforc, istep, &iinc, co, vold, itg, &ntg, amname, ikboun,
+                       ilboun, nelemload, sideload, mi, ntrans, trab, inotr, veold,
+                       integerglob, doubleglob, tieset, istartset, iendset, ialset,
+                       ntie, nmpc, ipompc, ikmpc, ilmpc, nodempc, coefmpc, ipobody,
+                       iponoel, inoel, ipkon, kon, ielprop, prop, ielmat, shcon, nshcon,
+                       rhcon, nrhcon, cocon, ncocon, ntmat_, lakon, set, nset));
+
+    time  = 0.;
+    dtime = 1.;
+
     /*  updating the nonlinear mpc's (also affects the boundary
 	conditions through the nonhomogeneous part of the mpc's)
 	if contact arises the number of MPC's can also change */
-      
-    cam[0]=0.;cam[1]=0.;cam[2]=0.;
-      
-    if(icascade==2){
-      memmpc_=memmpcref_;mpcfree=mpcfreeref;maxlenmpc=maxlenmpcref;
-      RENEW(nodempc,ITG,3*memmpcref_);
-      for(k=0;k<3*memmpcref_;k++){
-	nodempc[k]=nodempcref[k];}
-      RENEW(coefmpc,double,memmpcref_);
-      for(k=0;k<memmpcref_;k++){
-	coefmpc[k]=coefmpcref[k];}
+
+    cam[0] = 0.;
+    cam[1] = 0.;
+    cam[2] = 0.;
+
+    if (icascade == 2) {
+      memmpc_   = memmpcref_;
+      mpcfree   = mpcfreeref;
+      maxlenmpc = maxlenmpcref;
+      RENEW(nodempc, ITG, 3 * memmpcref_);
+      for (k = 0; k < 3 * memmpcref_; k++) {
+        nodempc[k] = nodempcref[k];
+      }
+      RENEW(coefmpc, double, memmpcref_);
+      for (k = 0; k < memmpcref_; k++) {
+        coefmpc[k] = coefmpcref[k];
+      }
     }
 
-    newstep=0;
-    FORTRAN(nonlinmpc,(co,vold,ipompc,nodempc,coefmpc,labmpc,
-		       nmpc,ikboun,ilboun,nboun,xbounold,aux,iaux,
-		       &maxlenmpc,ikmpc,ilmpc,&icascade,
-		       kon,ipkon,lakon,ne,&reltime,&newstep,xboun,fmpc,
-		       &iit,&idiscon,&ncont,trab,ntrans,ithermal,mi,&kchdep));
-    if(icascade==2){
-      for(k=0;k<3*memmpc_;k++){
-	nodempcref[k]=nodempc[k];}
-      for(k=0;k<memmpc_;k++){
-	coefmpcref[k]=coefmpc[k];}
+    newstep = 0;
+    FORTRAN(nonlinmpc, (co, vold, ipompc, nodempc, coefmpc, labmpc,
+                        nmpc, ikboun, ilboun, nboun, xbounold, aux, iaux,
+                        &maxlenmpc, ikmpc, ilmpc, &icascade,
+                        kon, ipkon, lakon, ne, &reltime, &newstep, xboun, fmpc,
+                        &iit, &idiscon, &ncont, trab, ntrans, ithermal, mi, &kchdep));
+    if (icascade == 2) {
+      for (k = 0; k < 3 * memmpc_; k++) {
+        nodempcref[k] = nodempc[k];
+      }
+      for (k = 0; k < memmpc_; k++) {
+        coefmpcref[k] = coefmpc[k];
+      }
     }
 
     /* recalculating the matrix structure */
-    
-    if(icascade>0){
-      remastruct(ipompc,&coefmpc,&nodempc,nmpc,
-		 &mpcfree,nodeboun,ndirboun,nboun,ikmpc,ilmpc,ikboun,ilboun,
-		 labmpc,nk,&memmpc_,&icascade,&maxlenmpc,
-		 kon,ipkon,lakon,ne,nactdof,icol,jq,&irow,isolver,
-		 neq,nzs,nmethod,&f,&fext,&b,&aux2,&fini,&fextini,
-		 &adb,&aub,ithermal,iperturb,mass,mi,iexpl,mortar,
-		 typeboun,&cv,&cvini,&iit,network,itiefac,&ne0,&nkon0,
-		 nintpoint,islavsurf,pmastsurf,tieset,ntie,&num_cpus);
+
+    if (icascade > 0) {
+      remastruct(ipompc, &coefmpc, &nodempc, nmpc,
+                 &mpcfree, nodeboun, ndirboun, nboun, ikmpc, ilmpc, ikboun, ilboun,
+                 labmpc, nk, &memmpc_, &icascade, &maxlenmpc,
+                 kon, ipkon, lakon, ne, nactdof, icol, jq, &irow, isolver,
+                 neq, nzs, nmethod, &f, &fext, &b, &aux2, &fini, &fextini,
+                 &adb, &aub, ithermal, iperturb, mass, mi, iexpl, mortar,
+                 typeboun, &cv, &cvini, &iit, network, itiefac, &ne0, &nkon0,
+                 nintpoint, islavsurf, pmastsurf, tieset, ntie, &num_cpus);
     }
 
     /* invert nactdof */
 
     SFREE(nactdofinv);
-    NNEW(nactdofinv,ITG,1);
-      
-    iout=-1;
-    ielas=1;
-      
-    MNEW(fn,double,mt**nk);
-    NNEW(stx,double,6*mi[0]**ne);
-      
-    if(*iexpl<=1){intscheme=1;}
-      
-    if(ne1d2d==1)NNEW(inum,ITG,*nk);
-    results(co,nk,kon,ipkon,lakon,ne,vold,stn,inum,stx,
-	    elcon,nelcon,rhcon,nrhcon,alcon,nalcon,alzero,ielmat,
-	    ielorien,norien,orab,ntmat_,t0,t1old,ithermal,
-	    prestr,iprestr,filab,eme,emn,een,iperturb,
-	    f,fn,nactdof,&iout,qa,vold,b,nodeboun,
-	    ndirboun,xbounold,nboun,ipompc,
-	    nodempc,coefmpc,labmpc,nmpc,nmethod,cam,&neq[1],veold,accold,&bet,
-	    &gam,&dtime,&time,ttime,plicon,nplicon,plkcon,nplkcon,
-	    xstateini,xstiff,xstate,npmat_,epn,matname,mi,&ielas,&icmd,
-	    ncmat_,nstate_,sti,vini,ikboun,ilboun,ener,enern,emeini,xstaten,
-	    eei,enerini,cocon,ncocon,set,nset,istartset,iendset,
-	    ialset,nprint,prlab,prset,qfx,qfn,trab,inotr,ntrans,fmpc,
-	    nelemload,nload,ikmpc,ilmpc,istep,&iinc,springarea,&reltime,
-	    &ne0,thicke,shcon,nshcon,
-	    sideload,xloadact,xloadold,&icfd,inomat,pslavsurf,pmastsurf,
-	    mortar,islavact,cdn,islavnode,nslavnode,ntie,clearini,
-	    islavsurf,ielprop,prop,energyini,energy,&kscale,iponoel,
-	    inoel,nener,orname,network,ipobody,xbodyact,ibody,typeboun,
-	    itiefac,tieset,smscale,&mscalmethod,nbody,t0g,t1g,
-	    islavelinv,autloc,irowtloc,jqtloc,&nboun2,
-	    ndirboun2,nodeboun2,xboun2,&nmpc2,ipompc2,nodempc2,coefmpc2,
-	    labmpc2,ikboun2,ilboun2,ikmpc2,ilmpc2,&mortartrafoflag,
-	    &intscheme);
-      
-    SFREE(fn);SFREE(stx);if(ne1d2d==1)SFREE(inum);
-      
-    if(*mortar<2){
-      iout=0;
-      ielas=0;
-	  
-      reltime=0.;
-      time=0.;
-      dtime=0.;
-    }
-      
-    if(*iexpl>1){
+    NNEW(nactdofinv, ITG, 1);
 
-      mscalmethod=0;
-	  
+    iout  = -1;
+    ielas = 1;
+
+    MNEW(fn, double, mt **nk);
+    NNEW(stx, double, 6 * mi[0] * *ne);
+
+    if (*iexpl <= 1) {
+      intscheme = 1;
+    }
+
+    if (ne1d2d == 1)
+      NNEW(inum, ITG, *nk);
+    results(co, nk, kon, ipkon, lakon, ne, vold, stn, inum, stx,
+            elcon, nelcon, rhcon, nrhcon, alcon, nalcon, alzero, ielmat,
+            ielorien, norien, orab, ntmat_, t0, t1old, ithermal,
+            prestr, iprestr, filab, eme, emn, een, iperturb,
+            f, fn, nactdof, &iout, qa, vold, b, nodeboun,
+            ndirboun, xbounold, nboun, ipompc,
+            nodempc, coefmpc, labmpc, nmpc, nmethod, cam, &neq[1], veold, accold, &bet,
+            &gam, &dtime, &time, ttime, plicon, nplicon, plkcon, nplkcon,
+            xstateini, xstiff, xstate, npmat_, epn, matname, mi, &ielas, &icmd,
+            ncmat_, nstate_, sti, vini, ikboun, ilboun, ener, enern, emeini, xstaten,
+            eei, enerini, cocon, ncocon, set, nset, istartset, iendset,
+            ialset, nprint, prlab, prset, qfx, qfn, trab, inotr, ntrans, fmpc,
+            nelemload, nload, ikmpc, ilmpc, istep, &iinc, springarea, &reltime,
+            &ne0, thicke, shcon, nshcon,
+            sideload, xloadact, xloadold, &icfd, inomat, pslavsurf, pmastsurf,
+            mortar, islavact, cdn, islavnode, nslavnode, ntie, clearini,
+            islavsurf, ielprop, prop, energyini, energy, &kscale, iponoel,
+            inoel, nener, orname, network, ipobody, xbodyact, ibody, typeboun,
+            itiefac, tieset, smscale, &mscalmethod, nbody, t0g, t1g,
+            islavelinv, autloc, irowtloc, jqtloc, &nboun2,
+            ndirboun2, nodeboun2, xboun2, &nmpc2, ipompc2, nodempc2, coefmpc2,
+            labmpc2, ikboun2, ilboun2, ikmpc2, ilmpc2, &mortartrafoflag,
+            &intscheme);
+
+    SFREE(fn);
+    SFREE(stx);
+    if (ne1d2d == 1)
+      SFREE(inum);
+
+    if (*mortar < 2) {
+      iout  = 0;
+      ielas = 0;
+
+      reltime = 0.;
+      time    = 0.;
+      dtime   = 0.;
+    }
+
+    if (*iexpl > 1) {
+
+      mscalmethod = 0;
+
       /* Explicit: Calculation of stable time increment according to
 	 Courant's Law  Carlo Monjaraz Tec (CMT) and Selctive Mass Scaling CC*/
 
@@ -1063,35 +1153,35 @@ void nonlingeo_precice(double **cop, ITG *nk, ITG **konp, ITG **ipkonp, char **l
         respectively with in addition contact scaling active; contact
         scaling is activated if the user time increment cannot be satisfied */
 
-      dtset=*tmin*(*tper);
-      NNEW(smscale,double,*ne);
-	  
-      FORTRAN(calcstabletimeincvol,(&ne0,elcon,nelcon,rhcon,nrhcon,alcon,
-				    nalcon,orab,ntmat_,ithermal,alzero,plicon,
-				    nplicon,plkcon,nplkcon,npmat_,mi,&dtime,
-				    xstiff,ncmat_,vold,ielmat,t0,t1,matname,
-				    lakon,wavespeed,nmat,ipkon,co,kon,&dtvol,
-				    alpha,smscale,&dtset,&mscalmethod));
+      dtset = *tmin * (*tper);
+      NNEW(smscale, double, *ne);
+
+      FORTRAN(calcstabletimeincvol, (&ne0, elcon, nelcon, rhcon, nrhcon, alcon,
+                                     nalcon, orab, ntmat_, ithermal, alzero, plicon,
+                                     nplicon, plkcon, nplkcon, npmat_, mi, &dtime,
+                                     xstiff, ncmat_, vold, ielmat, t0, t1, matname,
+                                     lakon, wavespeed, nmat, ipkon, co, kon, &dtvol,
+                                     alpha, smscale, &dtset, &mscalmethod));
 
       //printf("\033[1;33m"); // yellow
-      printf("Explicit time integration: Volumetric COURANT initial stable time increment:%e\n\n",dtvol);
+      printf("Explicit time integration: Volumetric COURANT initial stable time increment:%e\n\n", dtvol);
       //printf("\033[0m"); // reset color
 
-      if(dtvol>(*tmax*(*tper))){
-	*tinc=*tmax*(*tper);}
-      else if(dtvol<dtset){
-	*tinc=dtset;}
-      else {
-	*tinc=dtvol;
+      if (dtvol > (*tmax * (*tper))) {
+        *tinc = *tmax * (*tper);
+      } else if (dtvol < dtset) {
+        *tinc = dtset;
+      } else {
+        *tinc = dtvol;
       }
-	  
-      dtheta=(*tinc)/(*tper);
-      dthetaref=dtheta;
+
+      dtheta    = (*tinc) / (*tper);
+      dthetaref = dtheta;
       //printf("\033[1;33m"); // yellow
-      printf("SELECTED time increment:%e\n\n",*tinc);
+      printf("SELECTED time increment:%e\n\n", *tinc);
       //printf("\033[0m"); // reset color
     }
-      
+
     /* in mafillsm the stiffness and mass matrix are computed;
        The primary aim is to calculate the mass matrix (not 
        lumped for an implicit dynamic calculation, lumped for an
@@ -1103,959 +1193,980 @@ void nonlingeo_precice(double **cop, ITG *nk, ITG **konp, ITG **ipkonp, char **l
        needed at all. Since the calculation of the mass matrix alone
        is not possible in mafillsm, the determination of the stiffness
        matrix is taken as unavoidable "ballast". */
-      
-    NNEW(ad,double,neq[1]);
-    NNEW(au,double,nzs[1]);
 
-    mafillsmmain(co,nk,kon,ipkon,lakon,ne,nodeboun,ndirboun,xbounact,nboun,
-		 ipompc,nodempc,coefmpc,nmpc,nodeforc,ndirforc,xforcact,
-		 nforc,nelemload,sideload,xloadact,nload,xbodyact,ipobody,
-		 nbody,cgr,ad,au,fext,nactdof,icol,jq,irow,neq,nzl,
-		 nmethod,ikmpc,ilmpc,ikboun,ilboun,
-		 elcon,nelcon,rhcon,nrhcon,alcon,nalcon,alzero,
-		 ielmat,ielorien,norien,orab,ntmat_,
-		 t0,t1act,ithermal,prestr,iprestr,vold,iperturb,sti,
-		 nzs,stx,adb,aub,iexpl,plicon,nplicon,plkcon,nplkcon,
-		 xstiff,npmat_,&dtime,matname,mi,
-		 ncmat_,mass,&stiffness,&buckling,&rhsi,&intscheme,
-		 physcon,shcon,nshcon,cocon,ncocon,ttime,&time,istep,&iinc,
-		 &coriolis,ibody,xloadold,&reltime,veold,springarea,nstate_,
-		 xstateini,xstate,thicke,integerglob,doubleglob,
-		 tieset,istartset,iendset,ialset,ntie,&nasym,pslavsurf,
-		 pmastsurf,mortar,clearini,ielprop,prop,&ne0,fnext,&kscale,
-		 iponoel,inoel,network,ntrans,inotr,trab,smscale,&mscalmethod,
-		 set,nset,islavelinv,autloc,irowtloc,jqtloc,&mortartrafoflag);
-    
-    if(*nmethod==0){
-	  
+    NNEW(ad, double, neq[1]);
+    NNEW(au, double, nzs[1]);
+
+    mafillsmmain(co, nk, kon, ipkon, lakon, ne, nodeboun, ndirboun, xbounact, nboun,
+                 ipompc, nodempc, coefmpc, nmpc, nodeforc, ndirforc, xforcact,
+                 nforc, nelemload, sideload, xloadact, nload, xbodyact, ipobody,
+                 nbody, cgr, ad, au, fext, nactdof, icol, jq, irow, neq, nzl,
+                 nmethod, ikmpc, ilmpc, ikboun, ilboun,
+                 elcon, nelcon, rhcon, nrhcon, alcon, nalcon, alzero,
+                 ielmat, ielorien, norien, orab, ntmat_,
+                 t0, t1act, ithermal, prestr, iprestr, vold, iperturb, sti,
+                 nzs, stx, adb, aub, iexpl, plicon, nplicon, plkcon, nplkcon,
+                 xstiff, npmat_, &dtime, matname, mi,
+                 ncmat_, mass, &stiffness, &buckling, &rhsi, &intscheme,
+                 physcon, shcon, nshcon, cocon, ncocon, ttime, &time, istep, &iinc,
+                 &coriolis, ibody, xloadold, &reltime, veold, springarea, nstate_,
+                 xstateini, xstate, thicke, integerglob, doubleglob,
+                 tieset, istartset, iendset, ialset, ntie, &nasym, pslavsurf,
+                 pmastsurf, mortar, clearini, ielprop, prop, &ne0, fnext, &kscale,
+                 iponoel, inoel, network, ntrans, inotr, trab, smscale, &mscalmethod,
+                 set, nset, islavelinv, autloc, irowtloc, jqtloc, &mortartrafoflag);
+
+    if (*nmethod == 0) {
+
       /* error occurred in mafill: storing the geometry in frd format */
-	  
+
       ++*kode;
-      if(strcmp1(&filab[1044],"ZZS")==0){
-	NNEW(neigh,ITG,40**ne);
-	MNEW(ipneigh,ITG,*nk);
+      if (strcmp1(&filab[1044], "ZZS") == 0) {
+        NNEW(neigh, ITG, 40 * *ne);
+        MNEW(ipneigh, ITG, *nk);
       }
-	  
-      ptime=*ttime+time;
-      frd(co,nk,kon,ipkon,lakon,&ne0,v,stn,inum,nmethod,
-	  kode,filab,een,t1,fn,&ptime,epn,ielmat,matname,enern,xstaten,
-	  nstate_,istep,&iinc,ithermal,qfn,&mode,&noddiam,trab,inotr,
-	  ntrans,orab,ielorien,norien,description,ipneigh,neigh,
-	  mi,sti,vr,vi,stnr,stni,vmax,stnmax,&ngraph,veold,ener,ne,
-	  cs,set,nset,istartset,iendset,ialset,eenmax,fnr,fni,emn,
-	  thicke,jobnamec,output,qfx,cdn,mortar,cdnr,cdni,nmat,
-	  ielprop,prop,sti);
-	  
-      if(strcmp1(&filab[1044],"ZZS")==0){SFREE(ipneigh);SFREE(neigh);}      
+
+      ptime = *ttime + time;
+      frd(co, nk, kon, ipkon, lakon, &ne0, v, stn, inum, nmethod,
+          kode, filab, een, t1, fn, &ptime, epn, ielmat, matname, enern, xstaten,
+          nstate_, istep, &iinc, ithermal, qfn, &mode, &noddiam, trab, inotr,
+          ntrans, orab, ielorien, norien, description, ipneigh, neigh,
+          mi, sti, vr, vi, stnr, stni, vmax, stnmax, &ngraph, veold, ener, ne,
+          cs, set, nset, istartset, iendset, ialset, eenmax, fnr, fni, emn,
+          thicke, jobnamec, output, qfx, cdn, mortar, cdnr, cdni, nmat,
+          ielprop, prop, sti);
+
+      if (strcmp1(&filab[1044], "ZZS") == 0) {
+        SFREE(ipneigh);
+        SFREE(neigh);
+      }
 #ifdef COMPANY
-      FORTRAN(uout,(v,mi,ithermal,filab,kode,output,jobnamec));
-#endif	  
-      FORTRAN(stop,());
-	  
+      FORTRAN(uout, (v, mi, ithermal, filab, kode, output, jobnamec));
+#endif
+      FORTRAN(stop, ());
     }
 
     /* massless contact: setting up the system matrices based on
        the stiffness and mass matrix; these matrices are not
        assumed to change during the step;
        factorization of the LHS matrix */
-    
-    if(*mortar==-1){
-      nmasts=nmastnode[*ntie];
 
-      NNEW(kslav,ITG,3**nslavs);
-      NNEW(lslav,ITG,3**nslavs);
-      NNEW(ktot,ITG,3**nslavs+3*nmasts);
-      NNEW(ltot,ITG,3**nslavs+3*nmasts);
+    if (*mortar == -1) {
+      nmasts = nmastnode[*ntie];
+
+      NNEW(kslav, ITG, 3 * *nslavs);
+      NNEW(lslav, ITG, 3 * *nslavs);
+      NNEW(ktot, ITG, 3 * *nslavs + 3 * nmasts);
+      NNEW(ltot, ITG, 3 * *nslavs + 3 * nmasts);
 
       /*  Create set of slave and slave+master contact DOFS (sorted) */
-      
-      FORTRAN(create_contactdofs,(kslav,lslav,ktot,ltot,nslavs,islavnode,
-				&nmasts,imastnode,nactdof,mi,&neqslav,&neqtot));
 
-      RENEW(kslav,ITG,neqslav);
-      RENEW(lslav,ITG,neqslav);
-      RENEW(ktot,ITG,neqtot);
-      RENEW(ltot,ITG,neqtot);
+      FORTRAN(create_contactdofs, (kslav, lslav, ktot, ltot, nslavs, islavnode,
+                                   &nmasts, imastnode, nactdof, mi, &neqslav, &neqtot));
+
+      RENEW(kslav, ITG, neqslav);
+      RENEW(lslav, ITG, neqslav);
+      RENEW(ktot, ITG, neqtot);
+      RENEW(ltot, ITG, neqtot);
 
       /* create RHS of system:  M/dt - (aM + bK)/2 and store in adc,auc */
-      
-      NNEW(adc,double,neq[0]);
-      for(k=0;k<neq[0];k++){
-	adc[k]=adb[k]/(*tinc)-(alpham*adb[k]+betam*ad[k])/2.0;
+
+      NNEW(adc, double, neq[0]);
+      for (k = 0; k < neq[0]; k++) {
+        adc[k] = adb[k] / (*tinc) - (alpham * adb[k] + betam * ad[k]) / 2.0;
       }
 
-      NNEW(auc,double,nzs[0]);
-      for(k=0;k<nzs[0];k++){
-	auc[k]=aub[k]/(*tinc)-(alpham*aub[k]+betam*au[k])/2.0;
+      NNEW(auc, double, nzs[0]);
+      for (k = 0; k < nzs[0]; k++) {
+        auc[k] = aub[k] / (*tinc) - (alpham * aub[k] + betam * au[k]) / 2.0;
       }
 
       /* create LHS of system:  M/dt + (aM + bK)/2  and store in adb,aub */
 
-      for(k=0;k<neq[0];k++){
-	adb[k]=adb[k]/(*tinc)+(alpham*adb[k]+betam*ad[k])/2.0;
+      for (k = 0; k < neq[0]; k++) {
+        adb[k] = adb[k] / (*tinc) + (alpham * adb[k] + betam * ad[k]) / 2.0;
       }
 
-      for(k=0;k<nzs[0];k++){
-	aub[k]=aub[k]/(*tinc)+(alpham*aub[k]+betam*au[k])/2.0;
+      for (k = 0; k < nzs[0]; k++) {
+        aub[k] = aub[k] / (*tinc) + (alpham * aub[k] + betam * au[k]) / 2.0;
       }
 
       /* reduce LHS and RHS by removing contact dofs (diagonal terms
          are set to 1, off-diagonal terms to 0 */
 
-      FORTRAN(reducematrix,(aub,adb,jq,irow,neq,&neqtot,ktot));
-      FORTRAN(reducematrix,(auc,adc,jq,irow,neq,&neqtot,ktot));
+      FORTRAN(reducematrix, (aub, adb, jq, irow, neq, &neqtot, ktot));
+      FORTRAN(reducematrix, (auc, adc, jq, irow, neq, &neqtot, ktot));
 
       /* factorize the LHS */
 
-      if(*isolver==0){
+      if (*isolver == 0) {
 #ifdef SPOOLES
 
-	spooles_factor(adb,aub,adb,aub,&sigma,icol,irow,
-		       &neq[0],&nzs[0],&symmetryflag,&inputformat,&nzs[0]);
+        spooles_factor(adb, aub, adb, aub, &sigma, icol, irow,
+                       &neq[0], &nzs[0], &symmetryflag, &inputformat, &nzs[0]);
 
 #else
-	printf(" *ERROR in nonlingeo: the SPOOLES library is not linked\n\n");
-	FORTRAN(stop,());
+        printf(" *ERROR in nonlingeo: the SPOOLES library is not linked\n\n");
+        FORTRAN(stop, ());
 #endif
-      }
-      else if(*isolver==4){
+      } else if (*isolver == 4) {
 #ifdef SGI
-	token=1;
-	sgi_factor(adb,aub,adb,aub,&sigma,icol,irow,&neq[0],&nzs[0],token);
+        token = 1;
+        sgi_factor(adb, aub, adb, aub, &sigma, icol, irow, &neq[0], &nzs[0], token);
 #else
-	printf(" *ERROR in nonlingeo: the SGI library is not linked\n\n");
-	FORTRAN(stop,());
+        printf(" *ERROR in nonlingeo: the SGI library is not linked\n\n");
+        FORTRAN(stop, ());
 #endif
-      }
-      else if(*isolver==5){
+      } else if (*isolver == 5) {
 #ifdef TAUCS
-	tau_factor(adb,&aub,adb,aub,&sigma,icol,&irow,&neq[0],&nzs[0]);
+        tau_factor(adb, &aub, adb, aub, &sigma, icol, &irow, &neq[0], &nzs[0]);
 #else
-	printf(" *ERROR in nonlingeo: the TAUCS library is not linked\n\n");
-	FORTRAN(stop,());
+        printf(" *ERROR in nonlingeo: the TAUCS library is not linked\n\n");
+        FORTRAN(stop, ());
 #endif
-      }
-      else if(*isolver==7){
+      } else if (*isolver == 7) {
 #ifdef PARDISO
-	pardiso_factor(adb,aub,adb,aub,&sigma,icol,irow,&neq[0],&nzs[0],
-		       &symmetryflag,&inputformat,jq,&nzs[0]);
+        pardiso_factor(adb, aub, adb, aub, &sigma, icol, irow, &neq[0], &nzs[0],
+                       &symmetryflag, &inputformat, jq, &nzs[0]);
 #else
-	printf(" *ERROR in nonlingeo: the PARDISO library is not linked\n\n");
-	FORTRAN(stop,());
+        printf(" *ERROR in nonlingeo: the PARDISO library is not linked\n\n");
+        FORTRAN(stop, ());
 #endif
-      }
-      else if(*isolver==8){
+      } else if (*isolver == 8) {
 #ifdef PASTIX
-	pastix_factor_main(adb,aub,adb,aub,&sigma,icol,irow,&neq[0],&nzs[0],
-			   &symmetryflag,&inputformat,jq,&nzs[0]);
+        pastix_factor_main(adb, aub, adb, aub, &sigma, icol, irow, &neq[0], &nzs[0],
+                           &symmetryflag, &inputformat, jq, &nzs[0]);
 #else
-	printf(" *ERROR in nonlingeo: the PASTIX library is not linked\n\n");
-	FORTRAN(stop,());
+        printf(" *ERROR in nonlingeo: the PASTIX library is not linked\n\n");
+        FORTRAN(stop, ());
 #endif
       }
 
     } //endif massless
-      
+
     /* mass x acceleration = f(external)-f(internal) 
        only for the mechanical loading*/
-      
+
     /* not needed for massless contact */
-    
-    if(*mortar!=-1){
-      for(k=0;k<neq[0];++k){b[k]=fext[k]-f[k];}
+
+    if (*mortar != -1) {
+      for (k = 0; k < neq[0]; ++k) {
+        b[k] = fext[k] - f[k];
+      }
     }
-      
-    if(*iexpl<=1){
-	  
+
+    if (*iexpl <= 1) {
+
       /* a small amount of stiffness is added to the mass matrix
 	 otherwise the system leads to huge accelerations in 
 	 case of discontinuous load changes at the start of the step */
-	  
-      dtime=*tinc/10.;
-      scal1=bet*dtime*dtime*(1.+alpha[0]);
-      for(k=0;k<neq[0];++k){
-	ad[k]=adb[k]+scal1*ad[k];
+
+      dtime = *tinc / 10.;
+      scal1 = bet * dtime * dtime * (1. + alpha[0]);
+      for (k = 0; k < neq[0]; ++k) {
+        ad[k] = adb[k] + scal1 * ad[k];
       }
-      for(k=0;k<nzs[0];++k){
-	au[k]=aub[k]+scal1*au[k];
+      for (k = 0; k < nzs[0]; ++k) {
+        au[k] = aub[k] + scal1 * au[k];
       }
-      if(*isolver==0){
+      if (*isolver == 0) {
 #ifdef SPOOLES
-	spooles(ad,au,adb,aub,&sigma,b,icol,irow,&neq[0],&nzs[0],
-		&symmetryflag,&inputformat,&nzs[2]);
+        spooles(ad, au, adb, aub, &sigma, b, icol, irow, &neq[0], &nzs[0],
+                &symmetryflag, &inputformat, &nzs[2]);
 #else
-	printf(" *ERROR in nonlingeo: the SPOOLES library is not linked\n\n");
-	FORTRAN(stop,());
+        printf(" *ERROR in nonlingeo: the SPOOLES library is not linked\n\n");
+        FORTRAN(stop, ());
 #endif
-      }
-      else if((*isolver==2)||(*isolver==3)){
-	preiter(ad,&au,b,&icol,&irow,&neq[0],&nzs[0],isolver,iperturb);
-      }
-      else if(*isolver==4){
+      } else if ((*isolver == 2) || (*isolver == 3)) {
+        preiter(ad, &au, b, &icol, &irow, &neq[0], &nzs[0], isolver, iperturb);
+      } else if (*isolver == 4) {
 #ifdef SGI
-	token=1;
-	sgi_main(ad,au,adb,aub,&sigma,b,icol,irow,&neq[0],&nzs[0],token);
+        token = 1;
+        sgi_main(ad, au, adb, aub, &sigma, b, icol, irow, &neq[0], &nzs[0], token);
 #else
-	printf(" *ERROR in nonlingeo: the SGI library is not linked\n\n");
-	FORTRAN(stop,());
+        printf(" *ERROR in nonlingeo: the SGI library is not linked\n\n");
+        FORTRAN(stop, ());
 #endif
-      }
-      else if(*isolver==5){
+      } else if (*isolver == 5) {
 #ifdef TAUCS
-	tau(ad,&au,adb,aub,&sigma,b,icol,&irow,&neq[0],&nzs[0]);
+        tau(ad, &au, adb, aub, &sigma, b, icol, &irow, &neq[0], &nzs[0]);
 #else
-	printf(" *ERROR in nonlingeo: the TAUCS library is not linked\n\n");
-	FORTRAN(stop,());
+        printf(" *ERROR in nonlingeo: the TAUCS library is not linked\n\n");
+        FORTRAN(stop, ());
 #endif
-      }
-      else if(*isolver==7){
+      } else if (*isolver == 7) {
 #ifdef PARDISO
-	pardiso_main(ad,au,adb,aub,&sigma,b,icol,irow,&neq[0],&nzs[0],
-		     &symmetryflag,&inputformat,jq,&nzs[2],&nrhs);
+        pardiso_main(ad, au, adb, aub, &sigma, b, icol, irow, &neq[0], &nzs[0],
+                     &symmetryflag, &inputformat, jq, &nzs[2], &nrhs);
 #else
-	printf(" *ERROR in nonlingeo: the PARDISO library is not linked\n\n");
-	FORTRAN(stop,());
+        printf(" *ERROR in nonlingeo: the PARDISO library is not linked\n\n");
+        FORTRAN(stop, ());
 #endif
-      }
-      else if(*isolver==8){
+      } else if (*isolver == 8) {
 #ifdef PASTIX
-	pastix_main(ad,au,adb,aub,&sigma,b,icol,irow,&neq[0],&nzs[0],
-		    &symmetryflag,&inputformat,jq,&nzs[2],&nrhs);
+        pastix_main(ad, au, adb, aub, &sigma, b, icol, irow, &neq[0], &nzs[0],
+                    &symmetryflag, &inputformat, jq, &nzs[2], &nrhs);
 #else
-	printf(" *ERROR in nonlingeo: the PASTIX library is not linked\n\n");
-	FORTRAN(stop,());
+        printf(" *ERROR in nonlingeo: the PASTIX library is not linked\n\n");
+        FORTRAN(stop, ());
 #endif
       }
     }
-      
-    else{
+
+    else {
 
       /* explicit dynamics; no selective mass scaling
          (at most spring scaling) */
-      
+
       /* if massless contact: no acceleration needed */
-      
-      if((mscalmethod==0)||(mscalmethod==2)){
-        if(*mortar!=-1){
-	  for(k=0;k<neq[0];++k){b[k]=(fext[k]-f[k])/adb[k];}
-	}
+
+      if ((mscalmethod == 0) || (mscalmethod == 2)) {
+        if (*mortar != -1) {
+          for (k = 0; k < neq[0]; ++k) {
+            b[k] = (fext[k] - f[k]) / adb[k];
+          }
+        }
       }
-	  
-      else{
 
-	/* explicit dynamics with selective mass scaling */
+      else {
 
-	inputformat=0;
-	if(*isolver==0){
+        /* explicit dynamics with selective mass scaling */
+
+        inputformat = 0;
+        if (*isolver == 0) {
 #ifdef SPOOLES
-	  spooles_factor(adb,aub,adb,aub,&sigma,icol,irow,&neq[0],&nzs[0],
-			 &symmetryflag,&inputformat,&nzs[2]);
-	  spooles_solve(b,&neq[0]);
+          spooles_factor(adb, aub, adb, aub, &sigma, icol, irow, &neq[0], &nzs[0],
+                         &symmetryflag, &inputformat, &nzs[2]);
+          spooles_solve(b, &neq[0]);
 #else
-	  printf("*ERROR in arpack: the SPOOLES library is not linked\n\n");
-	  FORTRAN(stop,());
+          printf("*ERROR in arpack: the SPOOLES library is not linked\n\n");
+          FORTRAN(stop, ());
 #endif
-	}
-	else if(*isolver==4){
+        } else if (*isolver == 4) {
 #ifdef SGI
-	  token=1;
-	  sgi_factor(adb,aub,adb,aub,&sigma,icol,irow,&neq[0],&nzs[0],token);
-	  sgi_solve(b,token);
+          token = 1;
+          sgi_factor(adb, aub, adb, aub, &sigma, icol, irow, &neq[0], &nzs[0], token);
+          sgi_solve(b, token);
 #else
-	  printf("*ERROR in arpack: the SGI library is not linked\n\n");
-	  FORTRAN(stop,());
+          printf("*ERROR in arpack: the SGI library is not linked\n\n");
+          FORTRAN(stop, ());
 #endif
-	}
-	else if(*isolver==5){
+        } else if (*isolver == 5) {
 #ifdef TAUCS
-	  tau_factor(adb,&aub,adb,aub,&sigma,icol,&irow,&neq[0],&nzs[0]);
-	  tau_solve(b,&neq[0]);
+          tau_factor(adb, &aub, adb, aub, &sigma, icol, &irow, &neq[0], &nzs[0]);
+          tau_solve(b, &neq[0]);
 #else
-	  printf("*ERROR in arpack: the TAUCS library is not linked\n\n");
-	  FORTRAN(stop,());
+          printf("*ERROR in arpack: the TAUCS library is not linked\n\n");
+          FORTRAN(stop, ());
 #endif
-	}
-	else if(*isolver==7){
+        } else if (*isolver == 7) {
 #ifdef PARDISO
-	  pardiso_factor(adb,aub,adb,aub,&sigma,icol,irow,&neq[0],&nzs[0],
-			 &symmetryflag,&inputformat,jq,&nzs[0]);
+          pardiso_factor(adb, aub, adb, aub, &sigma, icol, irow, &neq[0], &nzs[0],
+                         &symmetryflag, &inputformat, jq, &nzs[0]);
 
-	  pardiso_solve(b,&neq[0],&symmetryflag,&inputformat,&nrhs);
+          pardiso_solve(b, &neq[0], &symmetryflag, &inputformat, &nrhs);
 #else
-	  printf("*ERROR in arpack: the PARDISO library is not linked\n\n");
-	  FORTRAN(stop,());
+          printf("*ERROR in arpack: the PARDISO library is not linked\n\n");
+          FORTRAN(stop, ());
 #endif
-	}
-	else if(*isolver==8){
+        } else if (*isolver == 8) {
 #ifdef PASTIX
-	  pastix_factor_main(adb,aub,adb,aub,&sigma,icol,irow,&neq[0],&nzs[0],
-			&symmetryflag,&inputformat,jq,&nzs[0]);
+          pastix_factor_main(adb, aub, adb, aub, &sigma, icol, irow, &neq[0], &nzs[0],
+                             &symmetryflag, &inputformat, jq, &nzs[0]);
 
-	  pastix_solve(b,&neq[0],&symmetryflag,&nrhs);
+          pastix_solve(b, &neq[0], &symmetryflag, &nrhs);
 #else
-	  printf("*ERROR in arpack: the PASTIX library is not linked\n\n");
-	  FORTRAN(stop,());
+          printf("*ERROR in arpack: the PASTIX library is not linked\n\n");
+          FORTRAN(stop, ());
 #endif
-	}
+        }
       }
     }
-      
+
     /* for thermal loading the acceleration is set to zero */
-      
-    for(k=neq[0];k<neq[1];++k){
-      b[k]=0.;
+
+    for (k = neq[0]; k < neq[1]; ++k) {
+      b[k] = 0.;
     }
-      
+
     /* calculating the displacements, stresses and forces */
-      
-    if(*mortar!=-1){
-      NNEW(v,double,mt**nk);
-      isiz=mt**nk;cpypardou(v,vold,&isiz,&num_cpus);
-      
-      NNEW(stx,double,6*mi[0]**ne);
-      MNEW(fn,double,mt**nk);
-      
+
+    if (*mortar != -1) {
+      NNEW(v, double, mt **nk);
+      isiz = mt * *nk;
+      cpypardou(v, vold, &isiz, &num_cpus);
+
+      NNEW(stx, double, 6 * mi[0] * *ne);
+      MNEW(fn, double, mt **nk);
+
       /* setting a "special" time consisting of the first primes;
 	 used to recognize the initial acceleration procedure
 	 in file resultsini.f */
 
-      if(ne1d2d==1)NNEW(inum,ITG,*nk);
-      dtime=1.235711130e-20;
-      results(co,nk,kon,ipkon,lakon,ne,v,stn,inum,stx,
-	      elcon,nelcon,rhcon,nrhcon,alcon,nalcon,alzero,ielmat,
-	      ielorien,norien,orab,ntmat_,t0,t1act,ithermal,
-	      prestr,iprestr,filab,eme,emn,een,iperturb,
-	      f,fn,nactdof,&iout,qa,vold,b,nodeboun,
-	      ndirboun,xbounact,nboun,ipompc,
-	      nodempc,coefmpc,labmpc,nmpc,nmethod,cam,&neq[1],veold,accold,
-	      &bet,&gam,&dtime,&time,ttime,plicon,nplicon,plkcon,nplkcon,
-	      xstateini,xstiff,xstate,npmat_,epn,matname,mi,&ielas,
-	      &icmd,ncmat_,nstate_,stiini,vini,ikboun,ilboun,ener,enern,
-	      emeini,xstaten,eei,enerini,cocon,ncocon,set,nset,istartset,
-	      iendset,ialset,nprint,prlab,prset,qfx,qfn,trab,inotr,ntrans,
-	      fmpc,nelemload,nload,ikmpc,ilmpc,istep,&iinc,springarea,
-	      &reltime,&ne0,thicke,shcon,nshcon,
-	      sideload,xloadact,xloadold,&icfd,inomat,pslavsurf,pmastsurf,
-	      mortar,islavact,cdn,islavnode,nslavnode,ntie,clearini,
-	      islavsurf,ielprop,prop,energyini,energy,&kscale,iponoel,
-	      inoel,nener,orname,network,ipobody,xbodyact,ibody,typeboun,
-	      itiefac,tieset,smscale,&mscalmethod,nbody,t0g,t1g,
-	      islavelinv,autloc,irowtloc,jqtloc,&nboun2,
-	      ndirboun2,nodeboun2,xboun2,&nmpc2,ipompc2,nodempc2,coefmpc2,
-	      labmpc2,ikboun2,ilboun2,ikmpc2,ilmpc2,&mortartrafoflag,
-	      &intscheme);
-      if(ne1d2d==1)SFREE(inum);
-      dtime=0.;
+      if (ne1d2d == 1)
+        NNEW(inum, ITG, *nk);
+      dtime = 1.235711130e-20;
+      results(co, nk, kon, ipkon, lakon, ne, v, stn, inum, stx,
+              elcon, nelcon, rhcon, nrhcon, alcon, nalcon, alzero, ielmat,
+              ielorien, norien, orab, ntmat_, t0, t1act, ithermal,
+              prestr, iprestr, filab, eme, emn, een, iperturb,
+              f, fn, nactdof, &iout, qa, vold, b, nodeboun,
+              ndirboun, xbounact, nboun, ipompc,
+              nodempc, coefmpc, labmpc, nmpc, nmethod, cam, &neq[1], veold, accold,
+              &bet, &gam, &dtime, &time, ttime, plicon, nplicon, plkcon, nplkcon,
+              xstateini, xstiff, xstate, npmat_, epn, matname, mi, &ielas,
+              &icmd, ncmat_, nstate_, stiini, vini, ikboun, ilboun, ener, enern,
+              emeini, xstaten, eei, enerini, cocon, ncocon, set, nset, istartset,
+              iendset, ialset, nprint, prlab, prset, qfx, qfn, trab, inotr, ntrans,
+              fmpc, nelemload, nload, ikmpc, ilmpc, istep, &iinc, springarea,
+              &reltime, &ne0, thicke, shcon, nshcon,
+              sideload, xloadact, xloadold, &icfd, inomat, pslavsurf, pmastsurf,
+              mortar, islavact, cdn, islavnode, nslavnode, ntie, clearini,
+              islavsurf, ielprop, prop, energyini, energy, &kscale, iponoel,
+              inoel, nener, orname, network, ipobody, xbodyact, ibody, typeboun,
+              itiefac, tieset, smscale, &mscalmethod, nbody, t0g, t1g,
+              islavelinv, autloc, irowtloc, jqtloc, &nboun2,
+              ndirboun2, nodeboun2, xboun2, &nmpc2, ipompc2, nodempc2, coefmpc2,
+              labmpc2, ikboun2, ilboun2, ikmpc2, ilmpc2, &mortartrafoflag,
+              &intscheme);
+      if (ne1d2d == 1)
+        SFREE(inum);
+      dtime = 0.;
 
-      isiz=mt**nk;cpypardou(vold,v,&isiz,&num_cpus);
-      if(*ithermal!=2){
-	isiz=6*mi[0]*ne0;	    
-	cpypardou(sti,stx,&isiz,&num_cpus);
+      isiz = mt * *nk;
+      cpypardou(vold, v, &isiz, &num_cpus);
+      if (*ithermal != 2) {
+        isiz = 6 * mi[0] * ne0;
+        cpypardou(sti, stx, &isiz, &num_cpus);
       }
 
-      SFREE(v);SFREE(stx);SFREE(fn);
+      SFREE(v);
+      SFREE(stx);
+      SFREE(fn);
     }
-    SFREE(ad);SFREE(au);
-      
+    SFREE(ad);
+    SFREE(au);
+
     /* the mass matrix is kept for subsequent calculations, therefore,
        no new mass calculation is necessary for the remaining iterations
        in the present step */
-      
-    mass[0]=0;intscheme=0;
-    energyref=energy[0]+energy[1]+energy[2]+energy[3];
 
-    if(*iexpl<=1){
-	  
+    mass[0]   = 0;
+    intscheme = 0;
+    energyref = energy[0] + energy[1] + energy[2] + energy[3];
+
+    if (*iexpl <= 1) {
+
       // # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
       // MPADD start
       /* lumping of the mass matrix for implicit calculations to 
 	 modify the increment time when contact is involved
       */
-	  
-      NNEW(tmp,double,neq[1]);
-      NNEW(adblump,double,neq[1]);
-      for(k=0;k<neq[1];k++){
-	tmp[k] = 1;
+
+      NNEW(tmp, double, neq[1]);
+      NNEW(adblump, double, neq[1]);
+      for (k = 0; k < neq[1]; k++) {
+        tmp[k] = 1;
       }
-      if(nasym==0){
-	FORTRAN(op,(&neq[1],tmp,adblump,adb,aub,jq,irow)); 
-      }else{
-	FORTRAN(opas,(&neq[1],tmp,adblump,adb,aub,jq,irow,nzs)); 
+      if (nasym == 0) {
+        FORTRAN(op, (&neq[1], tmp, adblump, adb, aub, jq, irow));
+      } else {
+        FORTRAN(opas, (&neq[1], tmp, adblump, adb, aub, jq, irow, nzs));
       }
       SFREE(tmp);
-	  
+
       // MPADD end
       // # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
     }
   }
-  
-  if(*iexpl>1) icmd=3;
-  
+
+  if (*iexpl > 1)
+    icmd = 3;
+
   /**************************************************************/
   /* starting the loop over the increments                      */
   /**************************************************************/
-  
+
   //printf("\033[0;34m"); // blue
   //printf("Starting the loop over the increments\n");
   //printf("\033[0m"); // reset color
-  
-  newstep=1;
-	  
+
+  newstep = 1;
+
   //    MPADD start
-  if((*nmethod==4)&&(*ithermal<2)&&(*iexpl<=1)){
-    neini=*ne;
-    for(k=0;k<4;k++){
-      energystartstep[k]=energy[k];
+  if ((*nmethod == 4) && (*ithermal < 2) && (*iexpl <= 1)) {
+    neini = *ne;
+    for (k = 0; k < 4; k++) {
+      energystartstep[k] = energy[k];
     }
-    emax=0.1*energyref;
+    emax = 0.1 * energyref;
     // Anti-stick at the beginning of simulation
-  } 
+  }
   //    MPADD end
 
   /* saving the distributed loads (volume heating will be
      added because of friction heating) */
 
-  if((*ithermal==3)&&(ncont!=0)&&(*mortar==1)&&(*ncmat_>=11)){
-    nloadref=*nload;
-    NNEW(nelemloadref,ITG,2**nload);
-    if(*nam>0) NNEW(iamloadref,ITG,2**nload);
-    NNEW(sideloadref,char,20**nload);
-      
-    isiz=2**nload;cpyparitg(nelemloadref,nelemload,&isiz,&num_cpus);
-    if(*nam>0){
-      isiz=2**nload;cpyparitg(iamloadref,iamload,&isiz,&num_cpus);
+  if ((*ithermal == 3) && (ncont != 0) && (*mortar == 1) && (*ncmat_ >= 11)) {
+    nloadref = *nload;
+    NNEW(nelemloadref, ITG, 2 * *nload);
+    if (*nam > 0)
+      NNEW(iamloadref, ITG, 2 * *nload);
+    NNEW(sideloadref, char, 20 * *nload);
+
+    isiz = 2 * *nload;
+    cpyparitg(nelemloadref, nelemload, &isiz, &num_cpus);
+    if (*nam > 0) {
+      isiz = 2 * *nload;
+      cpyparitg(iamloadref, iamload, &isiz, &num_cpus);
     }
-    memcpy(&sideloadref[0],&sideload[0],sizeof(char)*20**nload);
+    memcpy(&sideloadref[0], &sideload[0], sizeof(char) * 20 * *nload);
   }
 
   /* Adapter: Give preCICE the control of the time stepping */
   // while((1.-theta>1.e-6)||(negpres==1)){
 
   /* Adapter: Create the interfaces and initialize the coupling */
-  Precice_Setup( configFilename, preciceParticipantName, &simulationData );
-    
-  while( Precice_IsCouplingOngoing() ){ 
+  Precice_Setup(configFilename, preciceParticipantName, &simulationData);
 
-	 /* Adapter: Adjust solver time step */
-      Precice_AdjustSolverTimestep( &simulationData );
-      /* Adapter read coupling data if available */
-      Precice_ReadCouplingData( &simulationData );
+  while (Precice_IsCouplingOngoing()) {
 
-    if(icutb==0){
-	  
+    /* Adapter: Adjust solver time step */
+    Precice_AdjustSolverTimestep(&simulationData);
+    /* Adapter read coupling data if available */
+    Precice_ReadCouplingData(&simulationData);
+
+    if (icutb == 0) {
+
       /* previous increment converged: update the initial values */
-	  
+
       iinc++;
       jprint++;
 
       /* store number of elements (important for implicit dynamic
 	 contact */
 
-      neini=*ne;
-	  
+      neini = *ne;
+
       /* vold is copied into vini */
-	  
-      isiz=mt**nk;cpypardou(vini,vold,&isiz,&num_cpus);
 
-	  if (Precice_IsWriteCheckpointRequired())
-	  {
-		  Precice_WriteIterationCheckpoint(&simulationData, vini);
-		  Precice_FulfilledWriteCheckpoint();
-	  }
+      isiz = mt * *nk;
+      cpypardou(vini, vold, &isiz, &num_cpus);
 
-	  isiz=*nboun;cpypardou(xbounini,xbounact,&isiz,&num_cpus);
-      if((*ithermal==1)||(*ithermal>=3)){
-	isiz=*nk;cpypardou(t1ini,t1act,&isiz,&num_cpus);
+      if (Precice_IsWriteCheckpointRequired()) {
+        Precice_WriteIterationCheckpoint(&simulationData, vini);
+        Precice_FulfilledWriteCheckpoint();
       }
-      isiz=neq[1];cpypardou(fini,f,&isiz,&num_cpus);
-      if(*nmethod==4){
-	if(*iexpl<=1){
-	  isiz=mt**nk;
-	  cpypardou(veini,veold,&isiz,&num_cpus);
-	  cpypardou(accini,accold,&isiz,&num_cpus);
-	}
-	isiz=mt**nk;cpypardou(fnextini,fnext,&isiz,&num_cpus);
 
-	isiz=neq[1];
-	cpypardou(fextini,fext,&isiz,&num_cpus);
-	cpypardou(cvini,cv,&isiz,&num_cpus);
-	      
-	if(*ithermal<2){
-	  allwkini=allwk;
-	  // MPADD start
-	  if(idamping==1)dampwkini = dampwk;
-	  for(k=0;k<4;k++){
-	    energyini[k]=energy[k];
-	  }
-	  // MPADD end
-	}
+      isiz = *nboun;
+      cpypardou(xbounini, xbounact, &isiz, &num_cpus);
+      if ((*ithermal == 1) || (*ithermal >= 3)) {
+        isiz = *nk;
+        cpypardou(t1ini, t1act, &isiz, &num_cpus);
       }
-      if(*ithermal!=2){
-	isiz=6*mi[0]*ne0;	    
-	cpypardou(stiini,sti,&isiz,&num_cpus);
-	cpypardou(emeini,eme,&isiz,&num_cpus);
-      }
-      if(*nener==1){
-	isiz=mi[0]*ne0;
-	cpypardou(enerini,ener,&isiz,&num_cpus);
-      }
-	      
+      isiz = neq[1];
+      cpypardou(fini, f, &isiz, &num_cpus);
+      if (*nmethod == 4) {
+        if (*iexpl <= 1) {
+          isiz = mt * *nk;
+          cpypardou(veini, veold, &isiz, &num_cpus);
+          cpypardou(accini, accold, &isiz, &num_cpus);
+        }
+        isiz = mt * *nk;
+        cpypardou(fnextini, fnext, &isiz, &num_cpus);
 
-      if(*mortar!=1){
-	if(*nstate_!=0){
-	  isiz=*nstate_*mi[0]*(ne0+*nslavs);
-	  cpypardou(xstateini,xstate,&isiz,&num_cpus);
-	}
+        isiz = neq[1];
+        cpypardou(fextini, fext, &isiz, &num_cpus);
+        cpypardou(cvini, cv, &isiz, &num_cpus);
+
+        if (*ithermal < 2) {
+          allwkini = allwk;
+          // MPADD start
+          if (idamping == 1)
+            dampwkini = dampwk;
+          for (k = 0; k < 4; k++) {
+            energyini[k] = energy[k];
+          }
+          // MPADD end
+        }
       }
-	
-      if(*mortar>1){
-	for (i=0;i<*ntie;i++){
-	  for(j=nslavnode[i];j<nslavnode[i+1];j++){
-	    islavactini[j]=islavact[j];
-	    bpini[j]=bp[j];
-	    for(k=0;k<mt;k++){
-	      cstressini[mt*j+k]=cstress[mt*j+k];
-	    }		      
-	  }    
-	}
-	if(iflag_fric==1){
-	  for(i=0;i<3*iwan*nslavnode[*ntie];i++){
-	    lambdaiwanini[i]=lambdaiwan[i];
-	  }
-	}
+      if (*ithermal != 2) {
+        isiz = 6 * mi[0] * ne0;
+        cpypardou(stiini, sti, &isiz, &num_cpus);
+        cpypardou(emeini, eme, &isiz, &num_cpus);
+      }
+      if (*nener == 1) {
+        isiz = mi[0] * ne0;
+        cpypardou(enerini, ener, &isiz, &num_cpus);
+      }
+
+      if (*mortar != 1) {
+        if (*nstate_ != 0) {
+          isiz = *nstate_ * mi[0] * (ne0 + *nslavs);
+          cpypardou(xstateini, xstate, &isiz, &num_cpus);
+        }
+      }
+
+      if (*mortar > 1) {
+        for (i = 0; i < *ntie; i++) {
+          for (j = nslavnode[i]; j < nslavnode[i + 1]; j++) {
+            islavactini[j] = islavact[j];
+            bpini[j]       = bp[j];
+            for (k = 0; k < mt; k++) {
+              cstressini[mt * j + k] = cstress[mt * j + k];
+            }
+          }
+        }
+        if (iflag_fric == 1) {
+          for (i = 0; i < 3 * iwan * nslavnode[*ntie]; i++) {
+            lambdaiwanini[i] = lambdaiwan[i];
+          }
+        }
       }
     }
-      
+
     /* check for max. # of increments */
-      
-    if(iinc>jmax[0]){
+
+    if (iinc > jmax[0]) {
       printf(" *ERROR: max. # of increments reached\n\n");
-      FORTRAN(stop,());
+      FORTRAN(stop, ());
     }
 
-    if(*iexpl<=1){
-      printf(" increment %" ITGFORMAT " attempt %" ITGFORMAT " \n",iinc,icutb+1);
-      printf(" increment size= %e\n",dtheta**tper);
-      printf(" sum of previous increments=%e\n",theta**tper);
-      printf(" actual step time=%e\n",(theta+dtheta)**tper);
-      printf(" actual total time=%e\n\n",*ttime+(theta+dtheta)**tper);
-      
+    if (*iexpl <= 1) {
+      printf(" increment %" ITGFORMAT " attempt %" ITGFORMAT " \n", iinc, icutb + 1);
+      printf(" increment size= %e\n", dtheta * *tper);
+      printf(" sum of previous increments=%e\n", theta * *tper);
+      printf(" actual step time=%e\n", (theta + dtheta) * *tper);
+      printf(" actual total time=%e\n\n", *ttime + (theta + dtheta) * *tper);
+
       printf(" iteration 1\n\n");
     }
-      
-    qamold[0]=qam[0];
-    qamold[1]=qam[1];
 
-    icntrl=0;
+    qamold[0] = qam[0];
+    qamold[1] = qam[1];
+
+    icntrl = 0;
 
     /* restoring the distributed loading before adding the
        friction heating */
 
-    if((*ithermal==3)&&(ncont!=0)&&(*mortar==1)&&(*ncmat_>=11)){
-      *nload=nloadref;
-      isiz=2**nload;cpyparitg(nelemload,nelemloadref,&isiz,&num_cpus);
-      if(*nam>0){
-	isiz=2**nload;cpyparitg(iamload,iamloadref,&isiz,&num_cpus);
+    if ((*ithermal == 3) && (ncont != 0) && (*mortar == 1) && (*ncmat_ >= 11)) {
+      *nload = nloadref;
+      isiz   = 2 * *nload;
+      cpyparitg(nelemload, nelemloadref, &isiz, &num_cpus);
+      if (*nam > 0) {
+        isiz = 2 * *nload;
+        cpyparitg(iamload, iamloadref, &isiz, &num_cpus);
       }
-      memcpy(&sideload[0],&sideloadref[0],sizeof(char)*20**nload);
+      memcpy(&sideload[0], &sideloadref[0], sizeof(char) * 20 * *nload);
     }
-      
+
     /* determining the actual loads at the end of the new increment*/
-      
-    reltime=theta+dtheta;
-    time=reltime**tper;
-    dtime=dtheta**tper;
-      
-    FORTRAN(tempload,(xforcold,xforc,xforcact,iamforc,nforc,xloadold,xload,
-		      xloadact,iamload,nload,ibody,xbody,nbody,xbodyold,
-		      xbodyact,t1old,t1,t1act,iamt1,nk,amta,namta,nam,ampli,
-		      &time,&reltime,ttime,&dtime,ithermal,nmethod,xbounold,
-		      xboun,xbounact,iamboun,nboun,nodeboun,ndirboun,nodeforc,
-		      ndirforc,istep,&iinc,co,vold,itg,&ntg,amname,ikboun,
-		      ilboun,nelemload,sideload,mi,ntrans,trab,inotr,veold,
-		      integerglob,doubleglob,tieset,istartset,iendset,ialset,
-		      ntie,nmpc,ipompc,ikmpc,ilmpc,nodempc,coefmpc,ipobody,
-		      iponoel,inoel,ipkon,kon,ielprop,prop,ielmat,shcon,nshcon,
-		      rhcon,nrhcon,cocon,ncocon,ntmat_,lakon,set,nset));
-      
-    for(i=0;i<3;i++){
-      cam[i]=0.;}
-    for(i=3;i<5;i++){
-      cam[i]=0.5;}
-    if(*ithermal>1){
-      radflowload(itg,ieg,&ntg,&ntr,adrad,aurad,bcr,ipivr,
-		  ac,bc,nload,sideload,nelemload,xloadact,lakon,ipiv,ntmat_,
-		  vold,
-		  shcon,nshcon,ipkon,kon,co,
-		  kontri,&ntri,nloadtr,tarea,tenv,physcon,erad,&adview,&auview,
-		  nflow,ikboun,xbounact,nboun,ithermal,&iinc,&iit,
-		  cs,mcs,inocs,&ntrit,nk,fenv,istep,&dtime,ttime,&time,ilboun,
-		  ikforc,ilforc,xforcact,nforc,cam,ielmat,&nteq,prop,ielprop,
-		  nactdog,nacteq,nodeboun,ndirboun,network,
-		  rhcon,nrhcon,ipobody,ibody,xbodyact,nbody,iviewfile,jobnamef,
-		  ctrl,xloadold,&reltime,nmethod,set,mi,istartset,iendset,
-		  ialset,nset,
-		  ineighe,nmpc,nodempc,ipompc,coefmpc,labmpc,&iemchange,nam,
-		  iamload,
-		  jqrad,irowrad,&nzsrad,icolrad,ne,iaxial,qa,cocon,ncocon,
-		  iponoel,
-		  inoel,nprop,amname,namta,amta);
-             
+
+    reltime = theta + dtheta;
+    time    = reltime * *tper;
+    dtime   = dtheta * *tper;
+
+    FORTRAN(tempload, (xforcold, xforc, xforcact, iamforc, nforc, xloadold, xload,
+                       xloadact, iamload, nload, ibody, xbody, nbody, xbodyold,
+                       xbodyact, t1old, t1, t1act, iamt1, nk, amta, namta, nam, ampli,
+                       &time, &reltime, ttime, &dtime, ithermal, nmethod, xbounold,
+                       xboun, xbounact, iamboun, nboun, nodeboun, ndirboun, nodeforc,
+                       ndirforc, istep, &iinc, co, vold, itg, &ntg, amname, ikboun,
+                       ilboun, nelemload, sideload, mi, ntrans, trab, inotr, veold,
+                       integerglob, doubleglob, tieset, istartset, iendset, ialset,
+                       ntie, nmpc, ipompc, ikmpc, ilmpc, nodempc, coefmpc, ipobody,
+                       iponoel, inoel, ipkon, kon, ielprop, prop, ielmat, shcon, nshcon,
+                       rhcon, nrhcon, cocon, ncocon, ntmat_, lakon, set, nset));
+
+    for (i = 0; i < 3; i++) {
+      cam[i] = 0.;
+    }
+    for (i = 3; i < 5; i++) {
+      cam[i] = 0.5;
+    }
+    if (*ithermal > 1) {
+      radflowload(itg, ieg, &ntg, &ntr, adrad, aurad, bcr, ipivr,
+                  ac, bc, nload, sideload, nelemload, xloadact, lakon, ipiv, ntmat_,
+                  vold,
+                  shcon, nshcon, ipkon, kon, co,
+                  kontri, &ntri, nloadtr, tarea, tenv, physcon, erad, &adview, &auview,
+                  nflow, ikboun, xbounact, nboun, ithermal, &iinc, &iit,
+                  cs, mcs, inocs, &ntrit, nk, fenv, istep, &dtime, ttime, &time, ilboun,
+                  ikforc, ilforc, xforcact, nforc, cam, ielmat, &nteq, prop, ielprop,
+                  nactdog, nacteq, nodeboun, ndirboun, network,
+                  rhcon, nrhcon, ipobody, ibody, xbodyact, nbody, iviewfile, jobnamef,
+                  ctrl, xloadold, &reltime, nmethod, set, mi, istartset, iendset,
+                  ialset, nset,
+                  ineighe, nmpc, nodempc, ipompc, coefmpc, labmpc, &iemchange, nam,
+                  iamload,
+                  jqrad, irowrad, &nzsrad, icolrad, ne, iaxial, qa, cocon, ncocon,
+                  iponoel,
+                  inoel, nprop, amname, namta, amta);
+
       /* check whether network iterations converged */
 
-      if(qa[2]>0){
-	checkdivergence(co,nk,kon,ipkon,lakon,ne,stn,nmethod, 
-			kode,filab,een,t1act,&time,epn,ielmat,matname,enern, 
-			xstaten,nstate_,istep,&iinc,iperturb,ener,mi,output,
-			ithermal,qfn,&mode,&noddiam,trab,inotr,ntrans,orab,
-			ielorien,norien,description,sti,&icutb,&iit,&dtime,qa,
-			vold,qam,ram1,ram2,ram,cam,uam,&ntg,ttime,&icntrl,
-			&theta,&dtheta,veold,vini,idrct,tper,&istab,tmax, 
-			nactdof,b,tmin,ctrl,amta,namta,itpamp,inext,&dthetaref,
-			&itp,&jprint,jout,&uncoupled,t1,&iitterm,nelemload,
-			nload,nodeboun,nboun,itg,ndirboun,&deltmx,&iflagact,
-			set,nset,istartset,iendset,ialset,emn,thicke,jobnamec,
-			mortar,nmat,ielprop,prop,&ialeatoric,&kscale,
-			energy, &allwk,&energyref,&emax,&r_abs,&enetoll,
-			energyini,
-			&allwkini,&temax,&sizemaxinc,&ne0,&neini,&dampwk,
-			&dampwkini,energystartstep);
+      if (qa[2] > 0) {
+        checkdivergence(co, nk, kon, ipkon, lakon, ne, stn, nmethod,
+                        kode, filab, een, t1act, &time, epn, ielmat, matname, enern,
+                        xstaten, nstate_, istep, &iinc, iperturb, ener, mi, output,
+                        ithermal, qfn, &mode, &noddiam, trab, inotr, ntrans, orab,
+                        ielorien, norien, description, sti, &icutb, &iit, &dtime, qa,
+                        vold, qam, ram1, ram2, ram, cam, uam, &ntg, ttime, &icntrl,
+                        &theta, &dtheta, veold, vini, idrct, tper, &istab, tmax,
+                        nactdof, b, tmin, ctrl, amta, namta, itpamp, inext, &dthetaref,
+                        &itp, &jprint, jout, &uncoupled, t1, &iitterm, nelemload,
+                        nload, nodeboun, nboun, itg, ndirboun, &deltmx, &iflagact,
+                        set, nset, istartset, iendset, ialset, emn, thicke, jobnamec,
+                        mortar, nmat, ielprop, prop, &ialeatoric, &kscale,
+                        energy, &allwk, &energyref, &emax, &r_abs, &enetoll,
+                        energyini,
+                        &allwkini, &temax, &sizemaxinc, &ne0, &neini, &dampwk,
+                        &dampwkini, energystartstep);
 
-	/* the divergence is flagged by icntrl!=0
+        /* the divergence is flagged by icntrl!=0
 	   icutb is reset to zero in order to generate
 	   regular contact elements etc.. */
 
-	icutb--;
+        icutb--;
       }
     }
-      
-    if(icfd==1){
-    }else if(icfd==2){
-         compfluidfem(&cof,&nkf,&ipkonf,&konf,&lakonf,nef,&sideface,
-            ifreestream,&nfreestream,isolidsurf,neighsolidsurf,&nsolidsurf,
-            iponoelf,inoelf,nshcon,shcon,nrhcon,rhcon,&voldf,ntmat_,nodebounf,
-            ndirbounf,&nbounf,&ipompcf,&nodempcf,&nmpcf,&ikmpcf,&ilmpcf,
-	    ithermal,
-            ikbounf,ilbounf,&iturbulent,isolver,iexpl,ttime,
-            &time,&dtime,nodeforc,ndirforc,xforc,nforc,nelemloadf,sideloadf,
-            xloadf,&nloadf,xbody,ipobodyf,nbody,&ielmatf,matname,mi,ncmat_,
-            physcon,istep,&iinc,ibody,xloadold,xbounf,&coefmpcf,
-            nmethod,xforcold,xforcact,iamforc,iamloadf,xbodyold,xbodyact,
-            t1old,t1,t1act,iamt1,amta,namta,nam,ampli,xbounold,xbounact,
-	    iambounf,itg,&ntg,amname,t0,&nelemface,&nface,cocon,ncocon,xloadact,
-	    tper,jmax,jout,set,nset,istartset,iendset,ialset,prset,prlab,
-	    nprint,trab,inotr,ntrans,filab,&labmpc,sti,norien,orab,jobnamef,
-	    tieset,ntie,mcs,ics,cs,nkon,&mpcfree,&memmpc_,&fmpc,nef,&inomat,
-	    qfx,kode,ipface,ielprop,prop,orname,tincf,&ifreesurface,&nkftot,
-	    ielorienf,nelold,nkold,nknew,nelnew);
 
-	 for(i=0;i<nkftot;i++){
-	   for(j=0;j<mt;j++){
-	     vold[mt*(nkold[i]-1)+j]=voldf[mt*i+j];
-	   }
-	 }
+    if (icfd == 1) {
+    } else if (icfd == 2) {
+      compfluidfem(&cof, &nkf, &ipkonf, &konf, &lakonf, nef, &sideface,
+                   ifreestream, &nfreestream, isolidsurf, neighsolidsurf, &nsolidsurf,
+                   iponoelf, inoelf, nshcon, shcon, nrhcon, rhcon, &voldf, ntmat_, nodebounf,
+                   ndirbounf, &nbounf, &ipompcf, &nodempcf, &nmpcf, &ikmpcf, &ilmpcf,
+                   ithermal,
+                   ikbounf, ilbounf, &iturbulent, isolver, iexpl, ttime,
+                   &time, &dtime, nodeforc, ndirforc, xforc, nforc, nelemloadf, sideloadf,
+                   xloadf, &nloadf, xbody, ipobodyf, nbody, &ielmatf, matname, mi, ncmat_,
+                   physcon, istep, &iinc, ibody, xloadold, xbounf, &coefmpcf,
+                   nmethod, xforcold, xforcact, iamforc, iamloadf, xbodyold, xbodyact,
+                   t1old, t1, t1act, iamt1, amta, namta, nam, ampli, xbounold, xbounact,
+                   iambounf, itg, &ntg, amname, t0, &nelemface, &nface, cocon, ncocon, xloadact,
+                   tper, jmax, jout, set, nset, istartset, iendset, ialset, prset, prlab,
+                   nprint, trab, inotr, ntrans, filab, &labmpc, sti, norien, orab, jobnamef,
+                   tieset, ntie, mcs, ics, cs, nkon, &mpcfree, &memmpc_, &fmpc, nef, &inomat,
+                   qfx, kode, ipface, ielprop, prop, orname, tincf, &ifreesurface, &nkftot,
+                   ielorienf, nelold, nkold, nknew, nelnew);
+
+      for (i = 0; i < nkftot; i++) {
+        for (j = 0; j < mt; j++) {
+          vold[mt * (nkold[i] - 1) + j] = voldf[mt * i + j];
+        }
+      }
     }
-      
-    if(icascade==2){
-      memmpc_=memmpcref_;mpcfree=mpcfreeref;maxlenmpc=maxlenmpcref;
-      RENEW(nodempc,ITG,3*memmpcref_);
-      isiz=3*memmpcref_;cpyparitg(nodempc,nodempcref,&isiz,&num_cpus);
-      RENEW(coefmpc,double,memmpcref_);
-      isiz=memmpcref_;cpypardou(coefmpc,coefmpcref,&isiz,&num_cpus);
+
+    if (icascade == 2) {
+      memmpc_   = memmpcref_;
+      mpcfree   = mpcfreeref;
+      maxlenmpc = maxlenmpcref;
+      RENEW(nodempc, ITG, 3 * memmpcref_);
+      isiz = 3 * memmpcref_;
+      cpyparitg(nodempc, nodempcref, &isiz, &num_cpus);
+      RENEW(coefmpc, double, memmpcref_);
+      isiz = memmpcref_;
+      cpypardou(coefmpc, coefmpcref, &isiz, &num_cpus);
     }
 
     /* generating contact elements */
-      
-    if((ncont!=0)&&(*mortar<=1)&&
 
-       /*       for purely thermal calculations: determine contact integration
+    if ((ncont != 0) && (*mortar <= 1) &&
+
+        /*       for purely thermal calculations: determine contact integration
 		points only at the start of a step */
 
-       ((*ithermal!=2)||(iit==-1))){
+        ((*ithermal != 2) || (iit == -1))) {
 
-      *ne=ne0;*nkon=nkon0;
+      *ne   = ne0;
+      *nkon = nkon0;
 
       /* at start of new increment: 
 	 - copy state variables (node-to-face)
 	 - determine slave integration points (face-to-face)
 	 - interpolate state variables (face-to-face) */
 
-      if(icutb==0){
-	if(*mortar==1){
+      if (icutb == 0) {
+        if (*mortar == 1) {
 
-	  if(*nstate_!=0){
-	    if(maxprevcontel!=0){
-	      if(iit!=-1){
-		NNEW(islavsurfold,ITG,2**ifacecount+2);
-		NNEW(pslavsurfold,double,3**nintpoint);
-		isiz=2**ifacecount+2;
-		cpyparitg(islavsurfold,islavsurf,&isiz,&num_cpus);
-		isiz=3**nintpoint;
-		cpypardou(pslavsurfold,pslavsurf,&isiz,&num_cpus);
-	      }
-	    }
-	  }
+          if (*nstate_ != 0) {
+            if (maxprevcontel != 0) {
+              if (iit != -1) {
+                NNEW(islavsurfold, ITG, 2 * *ifacecount + 2);
+                NNEW(pslavsurfold, double, 3 * *nintpoint);
+                isiz = 2 * *ifacecount + 2;
+                cpyparitg(islavsurfold, islavsurf, &isiz, &num_cpus);
+                isiz = 3 * *nintpoint;
+                cpypardou(pslavsurfold, pslavsurf, &isiz, &num_cpus);
+              }
+            }
+          }
 
-	  *nintpoint=0;
+          *nintpoint = 0;
 
-	  /* determine the location of the slave integration
+          /* determine the location of the slave integration
 	     points */
 
-	  precontact(&ncont,ntie,tieset,nset,set,istartset,
-                     iendset,ialset,itietri,lakon,ipkon,kon,koncont,ne,
-                     cg,straight,co,vold,istep,&iinc,&iit,itiefac,
-                     islavsurf,islavnode,imastnode,nslavnode,nmastnode,
-                     imastop,mi,ipe,ime,tietol,&iflagact,
-		     nintpoint,&pslavsurf,xmastnor,cs,mcs,ics,clearini,
+          precontact(&ncont, ntie, tieset, nset, set, istartset,
+                     iendset, ialset, itietri, lakon, ipkon, kon, koncont, ne,
+                     cg, straight, co, vold, istep, &iinc, &iit, itiefac,
+                     islavsurf, islavnode, imastnode, nslavnode, nmastnode,
+                     imastop, mi, ipe, ime, tietol, &iflagact,
+                     nintpoint, &pslavsurf, xmastnor, cs, mcs, ics, clearini,
                      nslavs);
-		  
-	  /* changing the dimension of element-related fields */
-		  
-	  RENEW(kon,ITG,*nkon+22**nintpoint);
-	  RENEW(springarea,double,2**nintpoint);
-	  RENEW(pmastsurf,double,6**nintpoint);
-		  
-	  if(*nener==1){
-	    RENEW(ener,double,mi[0]*(*ne+*nintpoint)*2);
 
-	    /* setting the entries for the friction contact energy to zero */
+          /* changing the dimension of element-related fields */
 
-	    DOUMEMSET(ener,mi[0]*(2**ne+*nintpoint),mi[0]*(*ne+*nintpoint)*2,
-		      0.);
+          RENEW(kon, ITG, *nkon + 22 * *nintpoint);
+          RENEW(springarea, double, 2 * *nintpoint);
+          RENEW(pmastsurf, double, 6 * *nintpoint);
 
-	  }
-	  RENEW(ipkon,ITG,*ne+*nintpoint);
-	  RENEW(lakon,char,8*(*ne+*nintpoint));
-		  
-	  if(*norien>0){
-	    RENEW(ielorien,ITG,mi[2]*(*ne+*nintpoint));
-	    ITGMEMSET(ielorien,mi[2]**ne,mi[2]*(*ne+*nintpoint),0);
-	  }
-	  RENEW(ielmat,ITG,mi[2]*(*ne+*nintpoint));
-	  isiz=mi[2]**nintpoint;
-	  ITGMEMSET(ielmat,mi[2]**ne,mi[2]*(*ne+*nintpoint),1);
+          if (*nener == 1) {
+            RENEW(ener, double, mi[0] * (*ne + *nintpoint) * 2);
 
-	  /* interpolating the state variables */
+            /* setting the entries for the friction contact energy to zero */
 
-	  if(*nstate_!=0){
-	    if(maxprevcontel!=0){
-	      RENEW(xstateini,double,
-		    *nstate_*mi[0]*(ne0+maxprevcontel));
-	      isiz=*nstate_*mi[0]*maxprevcontel;
-	      cpypardou(&xstateini[*nstate_*mi[0]*ne0],
-			&xstate[*nstate_*mi[0]*ne0],&isiz,&num_cpus);
-	    }
-		      
-	    RENEW(xstate,double,*nstate_*mi[0]*(ne0+*nintpoint));
-	    isiz=*nstate_*mi[0]**nintpoint;
-	    DOUMEMSET(xstate,*nstate_*mi[0]*ne0,
-		      *nstate_*mi[0]*(ne0+*nintpoint),0.);
-		      
-	    if((*nintpoint>0)&&(maxprevcontel>0)){
-			  
-	      /* interpolation of xstate */
-			  
-	      interpolatestatemain(ne,ipkon,kon,lakon,
-				   &ne0,mi,xstate,pslavsurf,nstate_,
-				   xstateini,islavsurf,islavsurfold,
-				   pslavsurfold,tieset,ntie,itiefac);
-			  
-	    }
+            DOUMEMSET(ener, mi[0] * (2 * *ne + *nintpoint), mi[0] * (*ne + *nintpoint) * 2,
+                      0.);
+          }
+          RENEW(ipkon, ITG, *ne + *nintpoint);
+          RENEW(lakon, char, 8 * (*ne + *nintpoint));
 
-	    if(maxprevcontel!=0){
-	      SFREE(islavsurfold);SFREE(pslavsurfold);
-	    }
+          if (*norien > 0) {
+            RENEW(ielorien, ITG, mi[2] * (*ne + *nintpoint));
+            ITGMEMSET(ielorien, mi[2] * *ne, mi[2] * (*ne + *nintpoint), 0);
+          }
+          RENEW(ielmat, ITG, mi[2] * (*ne + *nintpoint));
+          isiz = mi[2] * *nintpoint;
+          ITGMEMSET(ielmat, mi[2] * *ne, mi[2] * (*ne + *nintpoint), 1);
 
-	    maxprevcontel=*nintpoint;
+          /* interpolating the state variables */
 
-	    RENEW(xstateini,double,*nstate_*mi[0]*(ne0+*nintpoint));
-	    isiz=*nstate_*mi[0]*(ne0+*nintpoint);
-	    cpypardou(xstateini,xstate,&isiz,&num_cpus);
-	  }
+          if (*nstate_ != 0) {
+            if (maxprevcontel != 0) {
+              RENEW(xstateini, double,
+                    *nstate_ *mi[0] * (ne0 + maxprevcontel));
+              isiz = *nstate_ * mi[0] * maxprevcontel;
+              cpypardou(&xstateini[*nstate_ * mi[0] * ne0],
+                        &xstate[*nstate_ * mi[0] * ne0], &isiz, &num_cpus);
+            }
 
-	}
+            RENEW(xstate, double, *nstate_ *mi[0] * (ne0 + *nintpoint));
+            isiz = *nstate_ * mi[0] * *nintpoint;
+            DOUMEMSET(xstate, *nstate_ * mi[0] * ne0,
+                      *nstate_ * mi[0] * (ne0 + *nintpoint), 0.);
+
+            if ((*nintpoint > 0) && (maxprevcontel > 0)) {
+
+              /* interpolation of xstate */
+
+              interpolatestatemain(ne, ipkon, kon, lakon,
+                                   &ne0, mi, xstate, pslavsurf, nstate_,
+                                   xstateini, islavsurf, islavsurfold,
+                                   pslavsurfold, tieset, ntie, itiefac);
+            }
+
+            if (maxprevcontel != 0) {
+              SFREE(islavsurfold);
+              SFREE(pslavsurfold);
+            }
+
+            maxprevcontel = *nintpoint;
+
+            RENEW(xstateini, double, *nstate_ *mi[0] * (ne0 + *nintpoint));
+            isiz = *nstate_ * mi[0] * (ne0 + *nintpoint);
+            cpypardou(xstateini, xstate, &isiz, &num_cpus);
+          }
+        }
       }
 
       /* massless contact: calculate matrix Wb */
-      
-      if(*mortar==-1){
-	nzsw=5*9**nslavs; // 5 = 1 slave 4 master max and 9 times since 3x3 in 3D
-	NNEW(auw,double,nzsw);
-	NNEW(jqw,ITG,3**nslavs+1);
-	NNEW(iroww,ITG,nzsw);
+
+      if (*mortar == -1) {
+        nzsw = 5 * 9 * *nslavs; // 5 = 1 slave 4 master max and 9 times since 3x3 in 3D
+        NNEW(auw, double, nzsw);
+        NNEW(jqw, ITG, 3 * *nslavs + 1);
+        NNEW(iroww, ITG, nzsw);
       }
-      
-      contact(&ncont,ntie,tieset,nset,set,istartset,iendset,
-	      ialset,itietri,lakon,ipkon,kon,koncont,ne,cg,straight,nkon,
-	      co,vold,ielmat,cs,elcon,istep,&iinc,&iit,ncmat_,ntmat_,
-	      &ne0,vini,nmethod,
-	      iperturb,ikboun,nboun,mi,imastop,nslavnode,islavnode,
-	      islavsurf,
-	      itiefac,areaslav,iponoels,inoels,springarea,tietol,&reltime,
-	      imastnode,nmastnode,xmastnor,filab,mcs,ics,&nasym,
-	      xnoels,mortar,pslavsurf,pmastsurf,clearini,&theta,
-	      xstateini,xstate,nstate_,&icutb,&ialeatoric,jobnamef,
-	      &alea,auw,jqw,iroww,&nzsw);
-   
+
+      contact(&ncont, ntie, tieset, nset, set, istartset, iendset,
+              ialset, itietri, lakon, ipkon, kon, koncont, ne, cg, straight, nkon,
+              co, vold, ielmat, cs, elcon, istep, &iinc, &iit, ncmat_, ntmat_,
+              &ne0, vini, nmethod,
+              iperturb, ikboun, nboun, mi, imastop, nslavnode, islavnode,
+              islavsurf,
+              itiefac, areaslav, iponoels, inoels, springarea, tietol, &reltime,
+              imastnode, nmastnode, xmastnor, filab, mcs, ics, &nasym,
+              xnoels, mortar, pslavsurf, pmastsurf, clearini, &theta,
+              xstateini, xstate, nstate_, &icutb, &ialeatoric, jobnamef,
+              &alea, auw, jqw, iroww, &nzsw);
+
       /* check whether, for a dynamic calculation, contact damping 
 	 is involved */
 
-      if(*nmethod==4){
-	if(*iexpl<=1){
-	  if(idampingwithoutcontact==0){
-	    for(i=0;i<*ne;i++){
-	      if(ipkon[i]<0) continue;
-	      if(*ncmat_>=5){
-		if(strcmp1(&lakon[i*8],"ES")==0){
-		  if(strcmp1(&lakon[i*8+6],"C")==0){
-		    imat=ielmat[i*mi[2]];
-		    if(elcon[(*ncmat_+1)**ntmat_*(imat-1)+4]>0.){
-		      idamping=1;break;
-		    }
-		  }
-		}
-	      }
-	    }
-	  }
-	}
+      if (*nmethod == 4) {
+        if (*iexpl <= 1) {
+          if (idampingwithoutcontact == 0) {
+            for (i = 0; i < *ne; i++) {
+              if (ipkon[i] < 0)
+                continue;
+              if (*ncmat_ >= 5) {
+                if (strcmp1(&lakon[i * 8], "ES") == 0) {
+                  if (strcmp1(&lakon[i * 8 + 6], "C") == 0) {
+                    imat = ielmat[i * mi[2]];
+                    if (elcon[(*ncmat_ + 1) * *ntmat_ * (imat - 1) + 4] > 0.) {
+                      idamping = 1;
+                      break;
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
       }
-	  
-      if(*iexpl<=1) printf(" Number of contact spring elements=%"
-			   ITGFORMAT "\n\n",*ne-ne0);
-            
+
+      if (*iexpl <= 1)
+        printf(" Number of contact spring elements=%" ITGFORMAT "\n\n", *ne - ne0);
+
       /* carlo start */
 
       /* dynamic time step estimation for explicit dynamics under penalty 
 	 contact(CMT) start */
 
-      if((*iexpl>1)){
-	      
-	if((*ne-ne0)<ncontacts){
+      if ((*iexpl > 1)) {
 
-	  /* number of contact elements has decreased */
-	  
-	  ncontacts=*ne-ne0;
-	  inccontact=0;
-	}  
-	else if((*ne-ne0)>ncontacts)  {
+        if ((*ne - ne0) < ncontacts) {
 
-	  /* number of contact elements has increased */
-	  
-	  RENEW(smscale,double,*ne);
-		  
-	  FORTRAN(calcstabletimeinccont,(ne,lakon,kon,ipkon,mi,ielmat,elcon,
-					 mortar,adb,alpha,nactdof,springarea,
-					 &ne0,ntmat_,ncmat_,&dtcont,smscale,
-					 &dtset,&mscalmethod));
+          /* number of contact elements has decreased */
 
-	  if(dtcont>(*tmax*(*tper))){
-	    *tinc=*tmax*(*tper);}
-	  else if(dtcont<dtset){
-	    *tinc=dtset;}
-	  else {
-	    *tinc=dtcont;
-	  }
-	  dtheta=(*tinc)/(*tper);
-	  dthetaref=dtheta;
+          ncontacts  = *ne - ne0;
+          inccontact = 0;
+        } else if ((*ne - ne0) > ncontacts) {
 
-	  ncontacts=*ne-ne0; 
-	  inccontact=0;
-	}else if((inccontact==500)&&(ncontacts==0)){
+          /* number of contact elements has increased */
+
+          RENEW(smscale, double, *ne);
+
+          FORTRAN(calcstabletimeinccont, (ne, lakon, kon, ipkon, mi, ielmat, elcon,
+                                          mortar, adb, alpha, nactdof, springarea,
+                                          &ne0, ntmat_, ncmat_, &dtcont, smscale,
+                                          &dtset, &mscalmethod));
+
+          if (dtcont > (*tmax * (*tper))) {
+            *tinc = *tmax * (*tper);
+          } else if (dtcont < dtset) {
+            *tinc = dtset;
+          } else {
+            *tinc = dtcont;
+          }
+          dtheta    = (*tinc) / (*tper);
+          dthetaref = dtheta;
+
+          ncontacts  = *ne - ne0;
+          inccontact = 0;
+        } else if ((inccontact == 500) && (ncontacts == 0)) {
 
           /* no contact elements (either no contact or massless contact) */
 
-	  if(dtvol>(*tmax*(*tper))){
-	    *tinc=*tmax*(*tper);
-	  }else if(dtvol<dtset){
-	    *tinc=dtset;
-	  }else{
-	    *tinc=dtvol;
-	  }
-	  dtheta=(*tinc)/(*tper);
-	  dthetaref=dtheta;
+          if (dtvol > (*tmax * (*tper))) {
+            *tinc = *tmax * (*tper);
+          } else if (dtvol < dtset) {
+            *tinc = dtset;
+          } else {
+            *tinc = dtvol;
+          }
+          dtheta    = (*tinc) / (*tper);
+          dthetaref = dtheta;
 
-	  dtcont=1.e30;
-	} 
-	inccontact++;
+          dtcont = 1.e30;
+        }
+        inccontact++;
       }
-	  
-      /* CMT end */
 
+      /* CMT end */
     }
-      
+
     /*  updating the nonlinear mpc's (also affects the boundary
 	conditions through the nonhomogeneous part of the mpc's) */
-      
-    FORTRAN(nonlinmpc,(co,vold,ipompc,nodempc,coefmpc,labmpc,
-		       nmpc,ikboun,ilboun,nboun,xbounact,aux,iaux,
-		       &maxlenmpc,ikmpc,ilmpc,&icascade,
-		       kon,ipkon,lakon,ne,&reltime,&newstep,xboun,fmpc,
-		       &iit,&idiscon,&ncont,trab,ntrans,ithermal,mi,&kchdep));
-      
-    if(icascade==2){
-      isiz=3*memmpc_;cpyparitg(nodempcref,nodempc,&isiz,&num_cpus);
-      isiz=memmpc_;cpypardou(coefmpcref,coefmpc,&isiz,&num_cpus);
+
+    FORTRAN(nonlinmpc, (co, vold, ipompc, nodempc, coefmpc, labmpc,
+                        nmpc, ikboun, ilboun, nboun, xbounact, aux, iaux,
+                        &maxlenmpc, ikmpc, ilmpc, &icascade,
+                        kon, ipkon, lakon, ne, &reltime, &newstep, xboun, fmpc,
+                        &iit, &idiscon, &ncont, trab, ntrans, ithermal, mi, &kchdep));
+
+    if (icascade == 2) {
+      isiz = 3 * memmpc_;
+      cpyparitg(nodempcref, nodempc, &isiz, &num_cpus);
+      isiz = memmpc_;
+      cpypardou(coefmpcref, coefmpc, &isiz, &num_cpus);
     }
 
     /* recalculating the matrix structure */
-      
-    if((icascade>0)||(ncont!=0))
-      remastruct(ipompc,&coefmpc,&nodempc,nmpc,
-		 &mpcfree,nodeboun,ndirboun,nboun,ikmpc,ilmpc,ikboun,ilboun,
-		 labmpc,nk,&memmpc_,&icascade,&maxlenmpc,
-		 kon,ipkon,lakon,ne,nactdof,icol,jq,&irow,isolver,
-		 neq,nzs,nmethod,&f,&fext,&b,&aux2,&fini,&fextini,
-		 &adb,&aub,ithermal,iperturb,mass,mi,iexpl,mortar,
-		 typeboun,&cv,&cvini,&iit,network,itiefac,&ne0,&nkon0,
-		 nintpoint,islavsurf,pmastsurf,tieset,ntie,&num_cpus);
+
+    if ((icascade > 0) || (ncont != 0))
+      remastruct(ipompc, &coefmpc, &nodempc, nmpc,
+                 &mpcfree, nodeboun, ndirboun, nboun, ikmpc, ilmpc, ikboun, ilboun,
+                 labmpc, nk, &memmpc_, &icascade, &maxlenmpc,
+                 kon, ipkon, lakon, ne, nactdof, icol, jq, &irow, isolver,
+                 neq, nzs, nmethod, &f, &fext, &b, &aux2, &fini, &fextini,
+                 &adb, &aub, ithermal, iperturb, mass, mi, iexpl, mortar,
+                 typeboun, &cv, &cvini, &iit, network, itiefac, &ne0, &nkon0,
+                 nintpoint, islavsurf, pmastsurf, tieset, ntie, &num_cpus);
 
     /* invert nactdof */
-      
+
     SFREE(nactdofinv);
-    NNEW(nactdofinv,ITG,mt**nk);
-    MNEW(nodorig,ITG,*nk);
-    FORTRAN(gennactdofinv,(nactdof,nactdofinv,nk,mi,nodorig,
-			   ipkon,lakon,kon,ne));
+    NNEW(nactdofinv, ITG, mt * *nk);
+    MNEW(nodorig, ITG, *nk);
+    FORTRAN(gennactdofinv, (nactdof, nactdofinv, nk, mi, nodorig,
+                            ipkon, lakon, kon, ne));
     SFREE(nodorig);
-      
+
     /* check whether the forced displacements changed; if so, and
        if the procedure is static, the first iteration has to be
        purely linear elastic, in order to get an equilibrium
        displacement field; otherwise huge (maybe nonelastic)
        stresses may occur, jeopardizing convergence */
-      
-    ilin=0;
-      
+
+    ilin = 0;
+
     /* only for iinc=1 a linearized calculation is performed, since
        for iinc>1 a reasonable displacement field is predicted by using the
        initial velocity field at the end of the last increment */
-      
-    if((iinc==1)&&(*ithermal<2)&&(*nmethod!=4)){
-      dev=0.;
-      for(k=0;k<*nboun;++k){
-	err=fabs(xbounact[k]-xbounini[k]);
-	if(err>dev){dev=err;}
+
+    if ((iinc == 1) && (*ithermal < 2) && (*nmethod != 4)) {
+      dev = 0.;
+      for (k = 0; k < *nboun; ++k) {
+        err = fabs(xbounact[k] - xbounini[k]);
+        if (err > dev) {
+          dev = err;
+        }
       }
-      if(dev>1.e-5) ilin=1;
+      if (dev > 1.e-5)
+        ilin = 1;
     }
-      
+
     /* prediction of the kinematic vectors  */
-      
-    NNEW(v,double,mt**nk);
-    
+
+    NNEW(v, double, mt **nk);
+
     /* for massless contact there is no need for prediction,
        since scheme is on velocity level */
-      
-    if (*mortar==-1){
-      memcpy(&v[0], &vold[0], sizeof(double)*mt **nk);
-    }else{
-      prediction(uam,nmethod,&bet,&gam,&dtime,ithermal,nk,veold,accold,v,
-		 &iinc,&idiscon,vold,nactdof,mi,&num_cpus);
+
+    if (*mortar == -1) {
+      memcpy(&v[0], &vold[0], sizeof(double) * mt * *nk);
+    } else {
+      prediction(uam, nmethod, &bet, &gam, &dtime, ithermal, nk, veold, accold, v,
+                 &iinc, &idiscon, vold, nactdof, mi, &num_cpus);
     }
-      
-    MNEW(fn,double,mt**nk);
-    NNEW(stx,double,6*mi[0]**ne);
-      
+
+    MNEW(fn, double, mt **nk);
+    NNEW(stx, double, 6 * mi[0] * *ne);
+
     /* determining the internal forces at the start of the increment
 	 
        for a static calculation with increased forced displacements
@@ -2082,472 +2193,511 @@ void nonlingeo_precice(double **cop, ITG *nk, ITG **konp, ITG **ipkonp, char **l
        into account the extrapolated displacements at the end of the 
        previous increment + the forced displacements and the temperatures
        at the end of the present increment */
-      
-    iout=-1;
-    if(istrainfree==1) iout=-2;
-    iperturb_sav[0]=iperturb[0];
-    iperturb_sav[1]=iperturb[1];
-      
+
+    iout = -1;
+    if (istrainfree == 1)
+      iout = -2;
+    iperturb_sav[0] = iperturb[0];
+    iperturb_sav[1] = iperturb[1];
+
     /* first iteration in first increment: elastic tangent */
-      
-    if((*nmethod!=4)&&(ilin==1)){
-	  
-      ielas=1;
-	  
-      iperturb[0]=-1;
-      iperturb[1]=0;
-	  
-      isiz=neq[1];cpypardou(b,f,&isiz,&num_cpus);
-      if(ne1d2d==1)NNEW(inum,ITG,*nk);
-      results(co,nk,kon,ipkon,lakon,ne,v,stn,inum,stx,
-	      elcon,nelcon,rhcon,nrhcon,alcon,nalcon,alzero,ielmat,
-	      ielorien,norien,orab,ntmat_,t1ini,t1act,ithermal,
-	      prestr,iprestr,filab,eme,emn,een,iperturb,
-	      f,fn,nactdof,&iout,qa,vold,b,nodeboun,
-	      ndirboun,xbounact,nboun,ipompc,
-	      nodempc,coefmpc,labmpc,nmpc,nmethod,cam,&neq[1],veold,accold,
-	      &bet,&gam,&dtime,&time,ttime,plicon,nplicon,plkcon,nplkcon,
-	      xstateini,xstiff,xstate,npmat_,epn,matname,mi,&ielas,
-	      &icmd, ncmat_,nstate_,stiini,vini,ikboun,ilboun,ener,enern,
-	      emeini,xstaten,eei,enerini,cocon,ncocon,set,nset,istartset,
-	      iendset,ialset,nprint,prlab,prset,qfx,qfn,trab,inotr,ntrans,
-	      fmpc,nelemload,nload,ikmpc,ilmpc,istep,&iinc,springarea,
-	      &reltime,&ne0,thicke,shcon,nshcon,
-	      sideload,xloadact,xloadold,&icfd,inomat,pslavsurf,pmastsurf,
-	      mortar,islavact,cdn,islavnode,nslavnode,ntie,clearini,
-	      islavsurf,ielprop,prop,energyini,energy,&kscale,iponoel,
-	      inoel,nener,orname,network,ipobody,xbodyact,ibody,typeboun,
-	      itiefac,tieset,smscale,&mscalmethod,nbody,t0g,t1g,
-	      islavelinv,autloc,irowtloc,jqtloc,&nboun2,
-	      ndirboun2,nodeboun2,xboun2,&nmpc2,ipompc2,nodempc2,coefmpc2,
-	      labmpc2,ikboun2,ilboun2,ikmpc2,ilmpc2,&mortartrafoflag,
-	      &intscheme);
-      iperturb[0]=0;if(ne1d2d==1)SFREE(inum);
-	  
+
+    if ((*nmethod != 4) && (ilin == 1)) {
+
+      ielas = 1;
+
+      iperturb[0] = -1;
+      iperturb[1] = 0;
+
+      isiz = neq[1];
+      cpypardou(b, f, &isiz, &num_cpus);
+      if (ne1d2d == 1)
+        NNEW(inum, ITG, *nk);
+      results(co, nk, kon, ipkon, lakon, ne, v, stn, inum, stx,
+              elcon, nelcon, rhcon, nrhcon, alcon, nalcon, alzero, ielmat,
+              ielorien, norien, orab, ntmat_, t1ini, t1act, ithermal,
+              prestr, iprestr, filab, eme, emn, een, iperturb,
+              f, fn, nactdof, &iout, qa, vold, b, nodeboun,
+              ndirboun, xbounact, nboun, ipompc,
+              nodempc, coefmpc, labmpc, nmpc, nmethod, cam, &neq[1], veold, accold,
+              &bet, &gam, &dtime, &time, ttime, plicon, nplicon, plkcon, nplkcon,
+              xstateini, xstiff, xstate, npmat_, epn, matname, mi, &ielas,
+              &icmd, ncmat_, nstate_, stiini, vini, ikboun, ilboun, ener, enern,
+              emeini, xstaten, eei, enerini, cocon, ncocon, set, nset, istartset,
+              iendset, ialset, nprint, prlab, prset, qfx, qfn, trab, inotr, ntrans,
+              fmpc, nelemload, nload, ikmpc, ilmpc, istep, &iinc, springarea,
+              &reltime, &ne0, thicke, shcon, nshcon,
+              sideload, xloadact, xloadold, &icfd, inomat, pslavsurf, pmastsurf,
+              mortar, islavact, cdn, islavnode, nslavnode, ntie, clearini,
+              islavsurf, ielprop, prop, energyini, energy, &kscale, iponoel,
+              inoel, nener, orname, network, ipobody, xbodyact, ibody, typeboun,
+              itiefac, tieset, smscale, &mscalmethod, nbody, t0g, t1g,
+              islavelinv, autloc, irowtloc, jqtloc, &nboun2,
+              ndirboun2, nodeboun2, xboun2, &nmpc2, ipompc2, nodempc2, coefmpc2,
+              labmpc2, ikboun2, ilboun2, ikmpc2, ilmpc2, &mortartrafoflag,
+              &intscheme);
+      iperturb[0] = 0;
+      if (ne1d2d == 1)
+        SFREE(inum);
+
       /* check whether any displacements or temperatures are changed
 	 in the new increment */
-	  
-      for(k=0;k<neq[1];++k){
-	f[k]=f[k]+b[k];}
-	  
-    }
-    else{
-	  
-      if(ne1d2d==1)NNEW(inum,ITG,*nk);
-      results(co,nk,kon,ipkon,lakon,ne,v,stn,inum,stx,
-	      elcon,nelcon,rhcon,nrhcon,alcon,nalcon,alzero,ielmat,
-	      ielorien,norien,orab,ntmat_,t0,t1act,ithermal,
-	      prestr,iprestr,filab,eme,emn,een,iperturb,
-	      f,fn,nactdof,&iout,qa,vold,b,nodeboun,
-	      ndirboun,xbounact,nboun,ipompc,
-	      nodempc,coefmpc,labmpc,nmpc,nmethod,cam,&neq[1],veold,accold,
-	      &bet,&gam,&dtime,&time,ttime,plicon,nplicon,plkcon,nplkcon,
-	      xstateini,xstiff,xstate,npmat_,epn,matname,mi,&ielas,
-	      &icmd,ncmat_,nstate_,stiini,vini,ikboun,ilboun,ener,enern,
-	      emeini,xstaten,eei,enerini,cocon,ncocon,set,nset,istartset,
-	      iendset,ialset,nprint,prlab,prset,qfx,qfn,trab,inotr,ntrans,
-	      fmpc,nelemload,nload,ikmpc,ilmpc,istep,&iinc,springarea,
-	      &reltime,&ne0,thicke,shcon,nshcon,
-	      sideload,xloadact,xloadold,&icfd,inomat,pslavsurf,pmastsurf,
-	      mortar,islavact,cdn,islavnode,nslavnode,ntie,clearini,
-	      islavsurf,ielprop,prop,energyini,energy,&kscale,iponoel,
-	      inoel,nener,orname,network,ipobody,xbodyact,ibody,typeboun,
-	      itiefac,tieset,smscale,&mscalmethod,nbody,t0g,t1g,
-	      islavelinv,autloc,irowtloc,jqtloc,&nboun2,
-	      ndirboun2,nodeboun2,xboun2,&nmpc2,ipompc2,nodempc2,coefmpc2,
-	      labmpc2,ikboun2,ilboun2,ikmpc2,ilmpc2,&mortartrafoflag,
-	      &intscheme);
-      if(ne1d2d==1)SFREE(inum);
-	  
-      isiz=mt**nk;cpypardou(vold,v,&isiz,&num_cpus);
-	  
-      if(*ithermal!=2){
-	isiz=6*mi[0]*ne0;	    
-	cpypardou(sti,stx,&isiz,&num_cpus);
+
+      for (k = 0; k < neq[1]; ++k) {
+        f[k] = f[k] + b[k];
       }
-	  
+
+    } else {
+
+      if (ne1d2d == 1)
+        NNEW(inum, ITG, *nk);
+      results(co, nk, kon, ipkon, lakon, ne, v, stn, inum, stx,
+              elcon, nelcon, rhcon, nrhcon, alcon, nalcon, alzero, ielmat,
+              ielorien, norien, orab, ntmat_, t0, t1act, ithermal,
+              prestr, iprestr, filab, eme, emn, een, iperturb,
+              f, fn, nactdof, &iout, qa, vold, b, nodeboun,
+              ndirboun, xbounact, nboun, ipompc,
+              nodempc, coefmpc, labmpc, nmpc, nmethod, cam, &neq[1], veold, accold,
+              &bet, &gam, &dtime, &time, ttime, plicon, nplicon, plkcon, nplkcon,
+              xstateini, xstiff, xstate, npmat_, epn, matname, mi, &ielas,
+              &icmd, ncmat_, nstate_, stiini, vini, ikboun, ilboun, ener, enern,
+              emeini, xstaten, eei, enerini, cocon, ncocon, set, nset, istartset,
+              iendset, ialset, nprint, prlab, prset, qfx, qfn, trab, inotr, ntrans,
+              fmpc, nelemload, nload, ikmpc, ilmpc, istep, &iinc, springarea,
+              &reltime, &ne0, thicke, shcon, nshcon,
+              sideload, xloadact, xloadold, &icfd, inomat, pslavsurf, pmastsurf,
+              mortar, islavact, cdn, islavnode, nslavnode, ntie, clearini,
+              islavsurf, ielprop, prop, energyini, energy, &kscale, iponoel,
+              inoel, nener, orname, network, ipobody, xbodyact, ibody, typeboun,
+              itiefac, tieset, smscale, &mscalmethod, nbody, t0g, t1g,
+              islavelinv, autloc, irowtloc, jqtloc, &nboun2,
+              ndirboun2, nodeboun2, xboun2, &nmpc2, ipompc2, nodempc2, coefmpc2,
+              labmpc2, ikboun2, ilboun2, ikmpc2, ilmpc2, &mortartrafoflag,
+              &intscheme);
+      if (ne1d2d == 1)
+        SFREE(inum);
+
+      isiz = mt * *nk;
+      cpypardou(vold, v, &isiz, &num_cpus);
+
+      if (*ithermal != 2) {
+        isiz = 6 * mi[0] * ne0;
+        cpypardou(sti, stx, &isiz, &num_cpus);
+      }
     }
-      
-    ielas=0;
-    iout=0;
-      
-    SFREE(fn);SFREE(v);
-    if((*ithermal!=3)||(ncont==0)||(*mortar!=1)||(*ncmat_<11)) SFREE(stx);
-      
+
+    ielas = 0;
+    iout  = 0;
+
+    SFREE(fn);
+    SFREE(v);
+    if ((*ithermal != 3) || (ncont == 0) || (*mortar != 1) || (*ncmat_ < 11))
+      SFREE(stx);
+
     /***************************************************************/
     /* iteration counter and start of the loop over the iterations */
     /***************************************************************/
 
-    if(*mortar>1){	  
-      NNEW(bhat,double,neq[1]);
-      NNEW(islavactdof,ITG,neq[1]);
-      iflagact_old=1;
-    } 
-      
-    iit=1;
+    if (*mortar > 1) {
+      NNEW(bhat, double, neq[1]);
+      NNEW(islavactdof, ITG, neq[1]);
+      iflagact_old = 1;
+    }
+
+    iit = 1;
 
     /* change due to previous checkdivergence routine */
 
-    if(icntrl!=0) icutb++;
+    if (icntrl != 0)
+      icutb++;
 
-    ctrl[0]=i0ref;ctrl[1]=irref;ctrl[3]=icref;
-    if(*nmethod!=4)NNEW(resold,double,neq[1]);
-    if(uncoupled){
-      *ithermal=2;
-      NNEW(iruc,ITG,nzs[1]-nzs[0]);
-      for(k=0;k<nzs[1]-nzs[0];k++){
-	iruc[k]=irow[k+nzs[0]]-neq[0];}
+    ctrl[0] = i0ref;
+    ctrl[1] = irref;
+    ctrl[3] = icref;
+    if (*nmethod != 4)
+      NNEW(resold, double, neq[1]);
+    if (uncoupled) {
+      *ithermal = 2;
+      NNEW(iruc, ITG, nzs[1] - nzs[0]);
+      for (k = 0; k < nzs[1] - nzs[0]; k++) {
+        iruc[k] = irow[k + nzs[0]] - neq[0];
+      }
     }
 
-    while(icntrl==0){
+    while (icntrl == 0) {
 
 #ifdef COMPANY
-      FORTRAN(uiter,(&iit));
-#endif	  
+      FORTRAN(uiter, (&iit));
+#endif
 
       /*  updating the nonlinear mpc's (also affects the boundary
 	  conditions through the nonhomogeneous part of the mpc's) */
 
-      if((iit!=1)||((uncoupled)&&(*ithermal==1))){
+      if ((iit != 1) || ((uncoupled) && (*ithermal == 1))) {
 
-	printf(" iteration %" ITGFORMAT "\n\n",iit);
+        printf(" iteration %" ITGFORMAT "\n\n", iit);
 
-	/* restoring the distributed loading before adding the
+        /* restoring the distributed loading before adding the
 	   friction heating */
-	  
-	if((*ithermal==3)&&(ncont!=0)&&(*mortar==1)&&(*ncmat_>=11)){
-	  *nload=nloadref;
-	  isiz=2**nload;cpyparitg(nelemload,nelemloadref,&isiz,&num_cpus);
-	  if(*nam>0){
-	    isiz=2**nload;cpyparitg(iamload,iamloadref,&isiz,&num_cpus);
-	  }
-	  memcpy(&sideload[0],&sideloadref[0],sizeof(char)*20**nload);
-	}
-	  
-	FORTRAN(tempload,(xforcold,xforc,xforcact,iamforc,nforc,xloadold,xload,
-			  xloadact,iamload,nload,ibody,xbody,nbody,xbodyold,
-			  xbodyact,t1old,t1,t1act,iamt1,nk,amta,namta,nam,
-			  ampli,&time,&reltime,ttime,&dtime,ithermal,nmethod,
-			  xbounold,xboun,xbounact,iamboun,nboun,nodeboun,
-			  ndirboun,nodeforc,ndirforc,istep,&iinc,co,vold,itg,
-			  &ntg,amname,ikboun,ilboun,nelemload,sideload,mi,
-			  ntrans,trab,inotr,veold,integerglob,doubleglob,
-			  tieset,istartset,iendset,ialset,ntie,nmpc,ipompc,
-			  ikmpc,ilmpc,nodempc,coefmpc,ipobody,iponoel,inoel,
-			  ipkon,kon,ielprop,prop,ielmat,shcon,nshcon,rhcon,
-			  nrhcon,cocon,ncocon,ntmat_,lakon,set,nset));
 
-	for(i=0;i<3;i++){
-	  cam[i]=0.;}
-	for(i=3;i<5;i++){
-	  cam[i]=0.5;}
-	if(*ithermal>1){
-	  radflowload(itg,ieg,&ntg,&ntr,adrad,aurad,bcr,ipivr,ac,bc,nload,
-		      sideload,nelemload,xloadact,lakon,ipiv,ntmat_,vold,shcon,
-		      nshcon,ipkon,kon,co,kontri,&ntri,nloadtr,tarea,tenv,
-		      physcon,erad,&adview,&auview,nflow,ikboun,xbounact,nboun,
-		      ithermal,&iinc,&iit,cs,mcs,inocs,&ntrit,nk,fenv,istep,
-		      &dtime,ttime,&time,ilboun,ikforc,ilforc,xforcact,nforc,
-		      cam,ielmat,&nteq,prop,ielprop,nactdog,nacteq,nodeboun,
-		      ndirboun,network,rhcon,nrhcon,ipobody,ibody,xbodyact,
-		      nbody,iviewfile,jobnamef,ctrl,xloadold,&reltime,nmethod,
-		      set,mi,istartset,iendset,ialset,nset,ineighe,nmpc,
-		      nodempc,ipompc,coefmpc,labmpc,&iemchange,nam,iamload,
-		      jqrad,irowrad,&nzsrad,icolrad,ne,iaxial,qa,cocon,ncocon,
-		      iponoel,inoel,nprop,amname,namta,amta);
-             
-	  /* check whether network iterations converged */
+        if ((*ithermal == 3) && (ncont != 0) && (*mortar == 1) && (*ncmat_ >= 11)) {
+          *nload = nloadref;
+          isiz   = 2 * *nload;
+          cpyparitg(nelemload, nelemloadref, &isiz, &num_cpus);
+          if (*nam > 0) {
+            isiz = 2 * *nload;
+            cpyparitg(iamload, iamloadref, &isiz, &num_cpus);
+          }
+          memcpy(&sideload[0], &sideloadref[0], sizeof(char) * 20 * *nload);
+        }
 
-	  if(qa[2]>0){
-	    checkdivergence(co,nk,kon,ipkon,lakon,ne,stn,nmethod,kode,filab,
-			    een,t1act,&time,epn,ielmat,matname,enern,xstaten,
-			    nstate_,istep,&iinc,iperturb,ener,mi,output,
-			    ithermal,qfn,&mode,&noddiam,trab,inotr,ntrans,orab,
-			    ielorien,norien,description,sti,&icutb,&iit,&dtime,
-			    qa,vold,qam,ram1,ram2,ram,cam,uam,&ntg,ttime,
-			    &icntrl,&theta,&dtheta,veold,vini,idrct,tper,
-			    &istab,tmax,nactdof,b,tmin,ctrl,amta,namta,itpamp,
-			    inext,&dthetaref,&itp,&jprint,jout,&uncoupled,t1,
-			    &iitterm,nelemload,nload,nodeboun,nboun,itg,
-			    ndirboun,&deltmx,&iflagact,set,nset,istartset,
-			    iendset,ialset,emn,thicke,jobnamec,mortar,nmat,
-			    ielprop,prop,&ialeatoric,&kscale,energy,&allwk,
-			    &energyref,&emax,&r_abs,&enetoll,energyini,
-			    &allwkini,&temax,&sizemaxinc,&ne0,&neini,&dampwk,
-			    &dampwkini,energystartstep);
-	    continue;
-	  }
-	}
+        FORTRAN(tempload, (xforcold, xforc, xforcact, iamforc, nforc, xloadold, xload,
+                           xloadact, iamload, nload, ibody, xbody, nbody, xbodyold,
+                           xbodyact, t1old, t1, t1act, iamt1, nk, amta, namta, nam,
+                           ampli, &time, &reltime, ttime, &dtime, ithermal, nmethod,
+                           xbounold, xboun, xbounact, iamboun, nboun, nodeboun,
+                           ndirboun, nodeforc, ndirforc, istep, &iinc, co, vold, itg,
+                           &ntg, amname, ikboun, ilboun, nelemload, sideload, mi,
+                           ntrans, trab, inotr, veold, integerglob, doubleglob,
+                           tieset, istartset, iendset, ialset, ntie, nmpc, ipompc,
+                           ikmpc, ilmpc, nodempc, coefmpc, ipobody, iponoel, inoel,
+                           ipkon, kon, ielprop, prop, ielmat, shcon, nshcon, rhcon,
+                           nrhcon, cocon, ncocon, ntmat_, lakon, set, nset));
 
-	if(icascade==2){
-	  memmpc_=memmpcref_;mpcfree=mpcfreeref;maxlenmpc=maxlenmpcref;
-	  RENEW(nodempc,ITG,3*memmpcref_);
-	  isiz=3*memmpcref_;cpyparitg(nodempc,nodempcref,&isiz,&num_cpus);
-	  RENEW(coefmpc,double,memmpcref_);
-	  isiz=memmpcref_;cpypardou(coefmpc,coefmpcref,&isiz,&num_cpus);
-	}
+        for (i = 0; i < 3; i++) {
+          cam[i] = 0.;
+        }
+        for (i = 3; i < 5; i++) {
+          cam[i] = 0.5;
+        }
+        if (*ithermal > 1) {
+          radflowload(itg, ieg, &ntg, &ntr, adrad, aurad, bcr, ipivr, ac, bc, nload,
+                      sideload, nelemload, xloadact, lakon, ipiv, ntmat_, vold, shcon,
+                      nshcon, ipkon, kon, co, kontri, &ntri, nloadtr, tarea, tenv,
+                      physcon, erad, &adview, &auview, nflow, ikboun, xbounact, nboun,
+                      ithermal, &iinc, &iit, cs, mcs, inocs, &ntrit, nk, fenv, istep,
+                      &dtime, ttime, &time, ilboun, ikforc, ilforc, xforcact, nforc,
+                      cam, ielmat, &nteq, prop, ielprop, nactdog, nacteq, nodeboun,
+                      ndirboun, network, rhcon, nrhcon, ipobody, ibody, xbodyact,
+                      nbody, iviewfile, jobnamef, ctrl, xloadold, &reltime, nmethod,
+                      set, mi, istartset, iendset, ialset, nset, ineighe, nmpc,
+                      nodempc, ipompc, coefmpc, labmpc, &iemchange, nam, iamload,
+                      jqrad, irowrad, &nzsrad, icolrad, ne, iaxial, qa, cocon, ncocon,
+                      iponoel, inoel, nprop, amname, namta, amta);
 
-	if((ncont!=0)&&(*mortar<=1)&&(ismallsliding==0)&&
-	   /*           for node-to-face contact: freeze contact elements for
+          /* check whether network iterations converged */
+
+          if (qa[2] > 0) {
+            checkdivergence(co, nk, kon, ipkon, lakon, ne, stn, nmethod, kode, filab,
+                            een, t1act, &time, epn, ielmat, matname, enern, xstaten,
+                            nstate_, istep, &iinc, iperturb, ener, mi, output,
+                            ithermal, qfn, &mode, &noddiam, trab, inotr, ntrans, orab,
+                            ielorien, norien, description, sti, &icutb, &iit, &dtime,
+                            qa, vold, qam, ram1, ram2, ram, cam, uam, &ntg, ttime,
+                            &icntrl, &theta, &dtheta, veold, vini, idrct, tper,
+                            &istab, tmax, nactdof, b, tmin, ctrl, amta, namta, itpamp,
+                            inext, &dthetaref, &itp, &jprint, jout, &uncoupled, t1,
+                            &iitterm, nelemload, nload, nodeboun, nboun, itg,
+                            ndirboun, &deltmx, &iflagact, set, nset, istartset,
+                            iendset, ialset, emn, thicke, jobnamec, mortar, nmat,
+                            ielprop, prop, &ialeatoric, &kscale, energy, &allwk,
+                            &energyref, &emax, &r_abs, &enetoll, energyini,
+                            &allwkini, &temax, &sizemaxinc, &ne0, &neini, &dampwk,
+                            &dampwkini, energystartstep);
+            continue;
+          }
+        }
+
+        if (icascade == 2) {
+          memmpc_   = memmpcref_;
+          mpcfree   = mpcfreeref;
+          maxlenmpc = maxlenmpcref;
+          RENEW(nodempc, ITG, 3 * memmpcref_);
+          isiz = 3 * memmpcref_;
+          cpyparitg(nodempc, nodempcref, &isiz, &num_cpus);
+          RENEW(coefmpc, double, memmpcref_);
+          isiz = memmpcref_;
+          cpypardou(coefmpc, coefmpcref, &isiz, &num_cpus);
+        }
+
+        if ((ncont != 0) && (*mortar <= 1) && (ismallsliding == 0) &&
+            /*           for node-to-face contact: freeze contact elements for
 			iterations 8 and higher */
-	   ((iit<=8)||(*mortar==1))&&
-	   /*           for purely thermal calculations: freeze contact elements
+            ((iit <= 8) || (*mortar == 1)) &&
+            /*           for purely thermal calculations: freeze contact elements
 			during complete step */
-	   ((*ithermal!=2)||(iit==-1))){
+            ((*ithermal != 2) || (iit == -1))) {
 
-	  neold=*ne;
-	  *ne=ne0;*nkon=nkon0;
-	  contact(&ncont,ntie,tieset,nset,set,istartset,iendset,
-		  ialset,itietri,lakon,ipkon,kon,koncont,ne,cg,
-		  straight,nkon,co,vold,ielmat,cs,elcon,istep,
-		  &iinc,&iit,ncmat_,ntmat_,&ne0,
-		  vini,nmethod,iperturb,
-		  ikboun,nboun,mi,imastop,nslavnode,islavnode,islavsurf,
-		  itiefac,areaslav,iponoels,inoels,springarea,tietol,
-		  &reltime,imastnode,nmastnode,xmastnor,
-		  filab,mcs,ics,&nasym,xnoels,mortar,pslavsurf,pmastsurf,
-		  clearini,&theta,xstateini,xstate,nstate_,&icutb,
-		  &ialeatoric,jobnamef,&alea,auw,jqw,iroww,&nzsw);
+          neold = *ne;
+          *ne   = ne0;
+          *nkon = nkon0;
+          contact(&ncont, ntie, tieset, nset, set, istartset, iendset,
+                  ialset, itietri, lakon, ipkon, kon, koncont, ne, cg,
+                  straight, nkon, co, vold, ielmat, cs, elcon, istep,
+                  &iinc, &iit, ncmat_, ntmat_, &ne0,
+                  vini, nmethod, iperturb,
+                  ikboun, nboun, mi, imastop, nslavnode, islavnode, islavsurf,
+                  itiefac, areaslav, iponoels, inoels, springarea, tietol,
+                  &reltime, imastnode, nmastnode, xmastnor,
+                  filab, mcs, ics, &nasym, xnoels, mortar, pslavsurf, pmastsurf,
+                  clearini, &theta, xstateini, xstate, nstate_, &icutb,
+                  &ialeatoric, jobnamef, &alea, auw, jqw, iroww, &nzsw);
 
-	  /* check whether, for a dynamic calculation, contact damping is 
+          /* check whether, for a dynamic calculation, contact damping is 
 	     involved */
-	      
-	  if(*nmethod==4){
-	    if(*iexpl<=1){
-	      if(idampingwithoutcontact==0){
-		for(i=0;i<*ne;i++){
-		  if(ipkon[i]<0) continue;
-		  if(*ncmat_>=5){
-		    if(strcmp1(&lakon[i*8],"ES")==0){
-		      if(strcmp1(&lakon[i*8+6],"C")==0){
-			imat=ielmat[i*mi[2]];
-			if(elcon[(*ncmat_+1)**ntmat_*(imat-1)+4]>0.){
-			  idamping=1;break;
-			}
-		      }
-		    }
-		  }
-		}
-	      }
-	    }
-	  }
-	      
-	  if(*mortar==0){
-	    if(*ne!=neold){iflagact=1;}
-	  }else if(*mortar==1){
-	    if(((*ne-ne0)<(neold-ne0)*(1.-delcon))||
-	       ((*ne-ne0)>(neold-ne0)*(1.+delcon))){iflagact=1;}
-	  }
 
-	  printf(" Number of contact spring elements=%" ITGFORMAT "\n\n",
-		 *ne-ne0);
+          if (*nmethod == 4) {
+            if (*iexpl <= 1) {
+              if (idampingwithoutcontact == 0) {
+                for (i = 0; i < *ne; i++) {
+                  if (ipkon[i] < 0)
+                    continue;
+                  if (*ncmat_ >= 5) {
+                    if (strcmp1(&lakon[i * 8], "ES") == 0) {
+                      if (strcmp1(&lakon[i * 8 + 6], "C") == 0) {
+                        imat = ielmat[i * mi[2]];
+                        if (elcon[(*ncmat_ + 1) * *ntmat_ * (imat - 1) + 4] > 0.) {
+                          idamping = 1;
+                          break;
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
 
-	}
-	  
-	if(*ithermal==3){
-	  for(k=0;k<*nk;++k){
-	    t1act[k]=vold[mt*k];}
-	}
+          if (*mortar == 0) {
+            if (*ne != neold) {
+              iflagact = 1;
+            }
+          } else if (*mortar == 1) {
+            if (((*ne - ne0) < (neold - ne0) * (1. - delcon)) ||
+                ((*ne - ne0) > (neold - ne0) * (1. + delcon))) {
+              iflagact = 1;
+            }
+          }
 
-	FORTRAN(nonlinmpc,(co,vold,ipompc,nodempc,coefmpc,labmpc,
-			   nmpc,ikboun,ilboun,nboun,xbounact,aux,iaux,
-			   &maxlenmpc,ikmpc,ilmpc,&icascade,
-			   kon,ipkon,lakon,ne,&reltime,&newstep,xboun,fmpc,&iit,
-			   &idiscon,&ncont,trab,ntrans,ithermal,mi,&kchdep));
+          printf(" Number of contact spring elements=%" ITGFORMAT "\n\n",
+                 *ne - ne0);
+        }
 
-	if(icascade==2){
-	  isiz=3*memmpc_;cpyparitg(nodempcref,nodempc,&isiz,&num_cpus);
-	  isiz=memmpc_;cpypardou(coefmpcref,coefmpc,&isiz,&num_cpus);
-	}
+        if (*ithermal == 3) {
+          for (k = 0; k < *nk; ++k) {
+            t1act[k] = vold[mt * k];
+          }
+        }
 
-	/* recalculating the matrix structure */
+        FORTRAN(nonlinmpc, (co, vold, ipompc, nodempc, coefmpc, labmpc,
+                            nmpc, ikboun, ilboun, nboun, xbounact, aux, iaux,
+                            &maxlenmpc, ikmpc, ilmpc, &icascade,
+                            kon, ipkon, lakon, ne, &reltime, &newstep, xboun, fmpc, &iit,
+                            &idiscon, &ncont, trab, ntrans, ithermal, mi, &kchdep));
 
-	/* for face-to-face contact (mortar=1) this is only done if
+        if (icascade == 2) {
+          isiz = 3 * memmpc_;
+          cpyparitg(nodempcref, nodempc, &isiz, &num_cpus);
+          isiz = memmpc_;
+          cpypardou(coefmpcref, coefmpc, &isiz, &num_cpus);
+        }
+
+        /* recalculating the matrix structure */
+
+        /* for face-to-face contact (mortar=1) this is only done if
 	   the dependent term in nonlinear MPC's changed */
-	
-	if((icascade>0)||(ncont!=0)){
-	  if((*mortar!=1)||(kchdep==1)){
-	    remastruct(ipompc,&coefmpc,&nodempc,nmpc,
-		       &mpcfree,nodeboun,ndirboun,nboun,ikmpc,ilmpc,ikboun,
-		       ilboun,labmpc,nk,&memmpc_,&icascade,&maxlenmpc,
-		       kon,ipkon,lakon,ne,nactdof,icol,jq,&irow,isolver,
-		       neq,nzs,nmethod,&f,&fext,&b,&aux2,&fini,&fextini,
-		       &adb,&aub,ithermal,iperturb,mass,mi,iexpl,mortar,
-		       typeboun,&cv,&cvini,&iit,network,itiefac,&ne0,&nkon0,
-		       nintpoint,islavsurf,pmastsurf,tieset,ntie,&num_cpus);
-	  }
 
-	  /* invert nactdof */
-	      
-	  SFREE(nactdofinv);
-	  NNEW(nactdofinv,ITG,mt**nk);
-	  MNEW(nodorig,ITG,*nk);
-	  FORTRAN(gennactdofinv,(nactdof,nactdofinv,nk,mi,nodorig,
-				 ipkon,lakon,kon,ne));
-	  SFREE(nodorig);
-	      
-	  MNEW(v,double,mt**nk);
-	  NNEW(stx,double,6*mi[0]**ne);
-	  MNEW(fn,double,mt**nk);
-      
-	  isiz=mt**nk;cpypardou(v,vold,&isiz,&num_cpus);
-	  iout=-1;
-	      
-	  if(ne1d2d==1)NNEW(inum,ITG,*nk);
-	  results(co,nk,kon,ipkon,lakon,ne,v,stn,inum,stx,
-		  elcon,nelcon,rhcon,nrhcon,alcon,nalcon,alzero,ielmat,
-		  ielorien,norien,orab,ntmat_,t0,t1act,ithermal,
-		  prestr,iprestr,filab,eme,emn,een,iperturb,
-		  f,fn,nactdof,&iout,qa,vold,b,nodeboun,
-		  ndirboun,xbounact,nboun,ipompc,
-		  nodempc,coefmpc,labmpc,nmpc,nmethod,cam,&neq[1],veold,accold,
-		  &bet,&gam,&dtime,&time,ttime,plicon,nplicon,plkcon,nplkcon,
-		  xstateini,xstiff,xstate,npmat_,epn,matname,mi,&ielas,&icmd,
-		  ncmat_,nstate_,stiini,vini,ikboun,ilboun,ener,enern,emeini,
-		  xstaten,eei,enerini,cocon,ncocon,set,nset,istartset,iendset,
-		  ialset,nprint,prlab,prset,qfx,qfn,trab,inotr,ntrans,fmpc,
-		  nelemload,nload,ikmpc,ilmpc,istep,&iinc,springarea,
-		  &reltime,&ne0,thicke,shcon,nshcon,
-		  sideload,xloadact,xloadold,&icfd,inomat,pslavsurf,pmastsurf,
-		  mortar,islavact,cdn,islavnode,nslavnode,ntie,clearini,
-		  islavsurf,ielprop,prop,energyini,energy,&kscale,iponoel,
-		  inoel,nener,orname,network,ipobody,xbodyact,ibody,typeboun,
-		  itiefac,tieset,smscale,&mscalmethod,nbody,t0g,t1g,
-		  islavelinv,autloc,irowtloc,jqtloc,&nboun2,
-		  ndirboun2,nodeboun2,xboun2,&nmpc2,ipompc2,nodempc2,coefmpc2,
-		  labmpc2,ikboun2,ilboun2,ikmpc2,ilmpc2,&mortartrafoflag,
-		  &intscheme);
-	  
-	  isiz=mt**nk;cpypardou(vold,v,&isiz,&num_cpus);
-	      
-	  if(*ithermal!=2){
-	    isiz=6*mi[0]*ne0;	    
-	    cpypardou(sti,stx,&isiz,&num_cpus);
-	  }
-	      
-	  SFREE(v);SFREE(fn);if(ne1d2d==1)SFREE(inum);
-	  if((*ithermal!=3)||(ncont==0)||(*mortar!=1)||(*ncmat_<11)) SFREE(stx);
-	  iout=0;
-	}    
+        if ((icascade > 0) || (ncont != 0)) {
+          if ((*mortar != 1) || (kchdep == 1)) {
+            remastruct(ipompc, &coefmpc, &nodempc, nmpc,
+                       &mpcfree, nodeboun, ndirboun, nboun, ikmpc, ilmpc, ikboun,
+                       ilboun, labmpc, nk, &memmpc_, &icascade, &maxlenmpc,
+                       kon, ipkon, lakon, ne, nactdof, icol, jq, &irow, isolver,
+                       neq, nzs, nmethod, &f, &fext, &b, &aux2, &fini, &fextini,
+                       &adb, &aub, ithermal, iperturb, mass, mi, iexpl, mortar,
+                       typeboun, &cv, &cvini, &iit, network, itiefac, &ne0, &nkon0,
+                       nintpoint, islavsurf, pmastsurf, tieset, ntie, &num_cpus);
+          }
+
+          /* invert nactdof */
+
+          SFREE(nactdofinv);
+          NNEW(nactdofinv, ITG, mt * *nk);
+          MNEW(nodorig, ITG, *nk);
+          FORTRAN(gennactdofinv, (nactdof, nactdofinv, nk, mi, nodorig,
+                                  ipkon, lakon, kon, ne));
+          SFREE(nodorig);
+
+          MNEW(v, double, mt **nk);
+          NNEW(stx, double, 6 * mi[0] * *ne);
+          MNEW(fn, double, mt **nk);
+
+          isiz = mt * *nk;
+          cpypardou(v, vold, &isiz, &num_cpus);
+          iout = -1;
+
+          if (ne1d2d == 1)
+            NNEW(inum, ITG, *nk);
+          results(co, nk, kon, ipkon, lakon, ne, v, stn, inum, stx,
+                  elcon, nelcon, rhcon, nrhcon, alcon, nalcon, alzero, ielmat,
+                  ielorien, norien, orab, ntmat_, t0, t1act, ithermal,
+                  prestr, iprestr, filab, eme, emn, een, iperturb,
+                  f, fn, nactdof, &iout, qa, vold, b, nodeboun,
+                  ndirboun, xbounact, nboun, ipompc,
+                  nodempc, coefmpc, labmpc, nmpc, nmethod, cam, &neq[1], veold, accold,
+                  &bet, &gam, &dtime, &time, ttime, plicon, nplicon, plkcon, nplkcon,
+                  xstateini, xstiff, xstate, npmat_, epn, matname, mi, &ielas, &icmd,
+                  ncmat_, nstate_, stiini, vini, ikboun, ilboun, ener, enern, emeini,
+                  xstaten, eei, enerini, cocon, ncocon, set, nset, istartset, iendset,
+                  ialset, nprint, prlab, prset, qfx, qfn, trab, inotr, ntrans, fmpc,
+                  nelemload, nload, ikmpc, ilmpc, istep, &iinc, springarea,
+                  &reltime, &ne0, thicke, shcon, nshcon,
+                  sideload, xloadact, xloadold, &icfd, inomat, pslavsurf, pmastsurf,
+                  mortar, islavact, cdn, islavnode, nslavnode, ntie, clearini,
+                  islavsurf, ielprop, prop, energyini, energy, &kscale, iponoel,
+                  inoel, nener, orname, network, ipobody, xbodyact, ibody, typeboun,
+                  itiefac, tieset, smscale, &mscalmethod, nbody, t0g, t1g,
+                  islavelinv, autloc, irowtloc, jqtloc, &nboun2,
+                  ndirboun2, nodeboun2, xboun2, &nmpc2, ipompc2, nodempc2, coefmpc2,
+                  labmpc2, ikboun2, ilboun2, ikmpc2, ilmpc2, &mortartrafoflag,
+                  &intscheme);
+
+          isiz = mt * *nk;
+          cpypardou(vold, v, &isiz, &num_cpus);
+
+          if (*ithermal != 2) {
+            isiz = 6 * mi[0] * ne0;
+            cpypardou(sti, stx, &isiz, &num_cpus);
+          }
+
+          SFREE(v);
+          SFREE(fn);
+          if (ne1d2d == 1)
+            SFREE(inum);
+          if ((*ithermal != 3) || (ncont == 0) || (*mortar != 1) || (*ncmat_ < 11))
+            SFREE(stx);
+          iout = 0;
+        }
       }
-	  
+
       /* add friction heating  */
-      
-      if((*ithermal==3)&&(ncont!=0)&&(*mortar==1)&&(*ncmat_>=11)){
-	nload_=*nload+2*(*ne-ne0);
 
-	RENEW(nelemload,ITG,2*nload_);
-	ITGMEMSET(nelemload,2**nload,2*nload_,0);
-	if(*nam>0){
-	  RENEW(iamload,ITG,2*nload_);
-	  ITGMEMSET(iamload,2**nload,2*nload_,0);
-	}
-	RENEW(xloadact,double,2*nload_);
-	DOUMEMSET(xloadact,2**nload,2*nload_,0.);
-	RENEW(sideload,char,20*nload_);
-	DMEMSET(sideload,20**nload,20*nload_,'\0');
+      if ((*ithermal == 3) && (ncont != 0) && (*mortar == 1) && (*ncmat_ >= 11)) {
+        nload_ = *nload + 2 * (*ne - ne0);
 
-	MNEW(idefload,ITG,nload_);
-	ITGMEMSET(idefload,0,nload_,1);
-	FORTRAN(frictionheating,(&ne0,ne,ipkon,lakon,ielmat,mi,elcon,ncmat_,
-				 ntmat_,kon,islavsurf,pmastsurf,springarea,co,
-				 vold,veold,pslavsurf,xloadact,nload,&nload_,
-				 nelemload,iamload,idefload,sideload,stx,nam,
-				 &time,ttime,matname,istep,&iinc));
-	SFREE(idefload);SFREE(stx);
+        RENEW(nelemload, ITG, 2 * nload_);
+        ITGMEMSET(nelemload, 2 * *nload, 2 * nload_, 0);
+        if (*nam > 0) {
+          RENEW(iamload, ITG, 2 * nload_);
+          ITGMEMSET(iamload, 2 * *nload, 2 * nload_, 0);
+        }
+        RENEW(xloadact, double, 2 * nload_);
+        DOUMEMSET(xloadact, 2 * *nload, 2 * nload_, 0.);
+        RENEW(sideload, char, 20 * nload_);
+        DMEMSET(sideload, 20 * *nload, 20 * nload_, '\0');
+
+        MNEW(idefload, ITG, nload_);
+        ITGMEMSET(idefload, 0, nload_, 1);
+        FORTRAN(frictionheating, (&ne0, ne, ipkon, lakon, ielmat, mi, elcon, ncmat_,
+                                  ntmat_, kon, islavsurf, pmastsurf, springarea, co,
+                                  vold, veold, pslavsurf, xloadact, nload, &nload_,
+                                  nelemload, iamload, idefload, sideload, stx, nam,
+                                  &time, ttime, matname, istep, &iinc));
+        SFREE(idefload);
+        SFREE(stx);
       }
-      
-      if((*iexpl<=1)||(*mortar==-1)){
 
-	/* calculating the local stiffness matrix and external loading */
+      if ((*iexpl <= 1) || (*mortar == -1)) {
 
-	NNEW(ad,double,neq[1]);
-	NNEW(au,double,nzs[1]);
+        /* calculating the local stiffness matrix and external loading */
 
-	if(*nmethod==4){
-	  DOUMEMSET(fnext,0,mt**nk,0.);
-	}
+        NNEW(ad, double, neq[1]);
+        NNEW(au, double, nzs[1]);
 
-	mafillsmmain(co,nk,kon,ipkon,lakon,ne,nodeboun,ndirboun,xbounact,nboun,
-		     ipompc,nodempc,coefmpc,nmpc,nodeforc,ndirforc,xforcact,
-		     nforc,nelemload,sideload,xloadact,nload,xbodyact,ipobody,
-		     nbody,cgr,ad,au,fext,nactdof,icol,jq,irow,neq,nzl,
-		     nmethod,ikmpc,ilmpc,ikboun,ilboun,
-		     elcon,nelcon,rhcon,nrhcon,alcon,nalcon,alzero,
-		     ielmat,ielorien,norien,orab,ntmat_,
-		     t0,t1act,ithermal,prestr,iprestr,vold,iperturb,sti,
-		     nzs,stx,adb,aub,iexpl,plicon,nplicon,plkcon,nplkcon,
-		     xstiff,npmat_,&dtime,matname,mi,
-		     ncmat_,mass,&stiffness,&buckling,&rhsi,&intscheme,
-		     physcon,shcon,nshcon,cocon,ncocon,ttime,&time,istep,&iinc,
-		     &coriolis,ibody,xloadold,&reltime,veold,springarea,nstate_,
-		     xstateini,xstate,thicke,integerglob,doubleglob,
-		     tieset,istartset,iendset,ialset,ntie,&nasym,pslavsurf,
-		     pmastsurf,mortar,clearini,ielprop,prop,&ne0,fnext,&kscale,
-		     iponoel,inoel,network,ntrans,inotr,trab,smscale,
-		     &mscalmethod,set,nset,islavelinv,autloc,irowtloc,jqtloc,
-		     &mortartrafoflag);
+        if (*nmethod == 4) {
+          DOUMEMSET(fnext, 0, mt * *nk, 0.);
+        }
 
-	if(nasym==1){
-	  RENEW(au,double,2*nzs[1]);
-	  if(*nmethod==4){
-	    RENEW(aub,double,2*nzs[1]);}
-	  symmetryflag=2;
-	  inputformat=1;
+        mafillsmmain(co, nk, kon, ipkon, lakon, ne, nodeboun, ndirboun, xbounact, nboun,
+                     ipompc, nodempc, coefmpc, nmpc, nodeforc, ndirforc, xforcact,
+                     nforc, nelemload, sideload, xloadact, nload, xbodyact, ipobody,
+                     nbody, cgr, ad, au, fext, nactdof, icol, jq, irow, neq, nzl,
+                     nmethod, ikmpc, ilmpc, ikboun, ilboun,
+                     elcon, nelcon, rhcon, nrhcon, alcon, nalcon, alzero,
+                     ielmat, ielorien, norien, orab, ntmat_,
+                     t0, t1act, ithermal, prestr, iprestr, vold, iperturb, sti,
+                     nzs, stx, adb, aub, iexpl, plicon, nplicon, plkcon, nplkcon,
+                     xstiff, npmat_, &dtime, matname, mi,
+                     ncmat_, mass, &stiffness, &buckling, &rhsi, &intscheme,
+                     physcon, shcon, nshcon, cocon, ncocon, ttime, &time, istep, &iinc,
+                     &coriolis, ibody, xloadold, &reltime, veold, springarea, nstate_,
+                     xstateini, xstate, thicke, integerglob, doubleglob,
+                     tieset, istartset, iendset, ialset, ntie, &nasym, pslavsurf,
+                     pmastsurf, mortar, clearini, ielprop, prop, &ne0, fnext, &kscale,
+                     iponoel, inoel, network, ntrans, inotr, trab, smscale,
+                     &mscalmethod, set, nset, islavelinv, autloc, irowtloc, jqtloc,
+                     &mortartrafoflag);
 
-	  mafillsmasmain(co,nk,kon,ipkon,lakon,ne,nodeboun,
-			 ndirboun,xbounact,nboun,
-			 ipompc,nodempc,coefmpc,nmpc,nodeforc,ndirforc,xforcact,
-			 nforc,nelemload,sideload,xloadact,nload,xbodyact,
-			 ipobody,
-			 nbody,cgr,ad,au,fext,nactdof,icol,jq,irow,neq,nzl,
-			 nmethod,ikmpc,ilmpc,ikboun,ilboun,
-			 elcon,nelcon,rhcon,nrhcon,alcon,nalcon,alzero,
-			 ielmat,ielorien,norien,orab,ntmat_,
-			 t0,t1act,ithermal,prestr,iprestr,vold,iperturb,sti,
-			 nzs,stx,adb,aub,iexpl,plicon,nplicon,plkcon,nplkcon,
-			 xstiff,npmat_,&dtime,matname,mi,
-			 ncmat_,mass,&stiffness,&buckling,&rhsi,&intscheme,
-			 physcon,shcon,nshcon,cocon,ncocon,ttime,&time,istep,
-			 &iinc,
-			 &coriolis,ibody,xloadold,&reltime,veold,springarea,
-			 nstate_,
-			 xstateini,xstate,thicke,
-			 integerglob,doubleglob,tieset,istartset,iendset,
-			 ialset,ntie,&nasym,pslavsurf,pmastsurf,mortar,clearini,
-			 ielprop,prop,&ne0,&kscale,iponoel,inoel,network,set,
-			 nset);
-	}
+        if (nasym == 1) {
+          RENEW(au, double, 2 * nzs[1]);
+          if (*nmethod == 4) {
+            RENEW(aub, double, 2 * nzs[1]);
+          }
+          symmetryflag = 2;
+          inputformat  = 1;
 
-	iperturb[0]=iperturb_sav[0];
-	iperturb[1]=iperturb_sav[1];
+          mafillsmasmain(co, nk, kon, ipkon, lakon, ne, nodeboun,
+                         ndirboun, xbounact, nboun,
+                         ipompc, nodempc, coefmpc, nmpc, nodeforc, ndirforc, xforcact,
+                         nforc, nelemload, sideload, xloadact, nload, xbodyact,
+                         ipobody,
+                         nbody, cgr, ad, au, fext, nactdof, icol, jq, irow, neq, nzl,
+                         nmethod, ikmpc, ilmpc, ikboun, ilboun,
+                         elcon, nelcon, rhcon, nrhcon, alcon, nalcon, alzero,
+                         ielmat, ielorien, norien, orab, ntmat_,
+                         t0, t1act, ithermal, prestr, iprestr, vold, iperturb, sti,
+                         nzs, stx, adb, aub, iexpl, plicon, nplicon, plkcon, nplkcon,
+                         xstiff, npmat_, &dtime, matname, mi,
+                         ncmat_, mass, &stiffness, &buckling, &rhsi, &intscheme,
+                         physcon, shcon, nshcon, cocon, ncocon, ttime, &time, istep,
+                         &iinc,
+                         &coriolis, ibody, xloadold, &reltime, veold, springarea,
+                         nstate_,
+                         xstateini, xstate, thicke,
+                         integerglob, doubleglob, tieset, istartset, iendset,
+                         ialset, ntie, &nasym, pslavsurf, pmastsurf, mortar, clearini,
+                         ielprop, prop, &ne0, &kscale, iponoel, inoel, network, set,
+                         nset);
+        }
 
-      }else{
+        iperturb[0] = iperturb_sav[0];
+        iperturb[1] = iperturb_sav[1];
 
-	/* calculating the external loading 
+      } else {
+
+        /* calculating the external loading 
 
 	   This is only done once per increment. In reality, the
            external loading is a function of vold (specifically,
            the body forces and surface loading). This effect is
            neglected, since the increment size in dynamic explicit
            calculations is usually small */
-	   
-	rhsmain(co,nk,kon,ipkon,lakon,ne,
-	  	ipompc,nodempc,coefmpc,nmpc,nodeforc,ndirforc,xforcact,
-	  	nforc,nelemload,sideload,xloadact,nload,xbodyact,ipobody,
-	  	nbody,cgr,fext,nactdof,&neq[1],
-	  	nmethod,ikmpc,ilmpc,
-	  	elcon,nelcon,rhcon,nrhcon,alcon,nalcon,alzero,
-	  	ielmat,ielorien,norien,orab,ntmat_,
-	  	t0,t1act,ithermal,iprestr,vold,iperturb,
-	  	iexpl,plicon,nplicon,plkcon,nplkcon,
-	  	npmat_,ttime,&time,istep,&iinc,&dtime,physcon,ibody,
-	  	xbodyold,&reltime,veold,matname,mi,ikactmech,
-	  	&nactmech,ielprop,prop,sti,xstateini,xstate,nstate_,
-	        ntrans,inotr,trab);
 
+        rhsmain(co, nk, kon, ipkon, lakon, ne,
+                ipompc, nodempc, coefmpc, nmpc, nodeforc, ndirforc, xforcact,
+                nforc, nelemload, sideload, xloadact, nload, xbodyact, ipobody,
+                nbody, cgr, fext, nactdof, &neq[1],
+                nmethod, ikmpc, ilmpc,
+                elcon, nelcon, rhcon, nrhcon, alcon, nalcon, alzero,
+                ielmat, ielorien, norien, orab, ntmat_,
+                t0, t1act, ithermal, iprestr, vold, iperturb,
+                iexpl, plicon, nplicon, plkcon, nplkcon,
+                npmat_, ttime, &time, istep, &iinc, &dtime, physcon, ibody,
+                xbodyold, &reltime, veold, matname, mi, ikactmech,
+                &nactmech, ielprop, prop, sti, xstateini, xstate, nstate_,
+                ntrans, inotr, trab);
       }
-      
+
       /*      for(k=0;k<neq[1];++k){printf("f=%" ITGFORMAT ",%f\n",k,f[k]);}
 	      for(k=0;k<neq[1];++k){printf("fext=%" ITGFORMAT ",%f\n",k,fext[k]);}
 	      for(k=0;k<neq[1];++k){printf("ad=%" ITGFORMAT ",%f\n",k,ad[k]);}
@@ -2556,143 +2706,149 @@ void nonlingeo_precice(double **cop, ITG *nk, ITG **konp, ITG **ipkonp, char **l
       /* calculating the damping matrix for implicit dynamic
          calculations */
 
-      if((idamping==1)&&(*iexpl<=1)){
+      if ((idamping == 1) && (*iexpl <= 1)) {
 
-	/* Rayleigh damping */
+        /* Rayleigh damping */
 
-	MNEW(adc,double,neq[1]);DOUMEMSET(adc,neq[0],neq[1],0.);
-	for(k=0;k<neq[0];k++){
-	  adc[k]=alpham*adb[k]+betam*ad[k];}
-	if(nasym==0){
-	  MNEW(auc,double,nzs[1]);DOUMEMSET(auc,nzs[0],nzs[1],0.);
-	  for(k=0;k<nzs[0];k++){
-	    auc[k]=alpham*aub[k]+betam*au[k];}
-	}else{
-	  NNEW(auc,double,2*nzs[1]);DOUMEMSET(auc,2*nzs[0],2*nzs[1],0.);
-	  for(k=0;k<2*nzs[0];k++){
-	    auc[k]=alpham*aub[k]+betam*au[k];}
-	}
- 
-	/* dashpots and contact damping */
+        MNEW(adc, double, neq[1]);
+        DOUMEMSET(adc, neq[0], neq[1], 0.);
+        for (k = 0; k < neq[0]; k++) {
+          adc[k] = alpham * adb[k] + betam * ad[k];
+        }
+        if (nasym == 0) {
+          MNEW(auc, double, nzs[1]);
+          DOUMEMSET(auc, nzs[0], nzs[1], 0.);
+          for (k = 0; k < nzs[0]; k++) {
+            auc[k] = alpham * aub[k] + betam * au[k];
+          }
+        } else {
+          NNEW(auc, double, 2 * nzs[1]);
+          DOUMEMSET(auc, 2 * nzs[0], 2 * nzs[1], 0.);
+          for (k = 0; k < 2 * nzs[0]; k++) {
+            auc[k] = alpham * aub[k] + betam * au[k];
+          }
+        }
 
-	FORTRAN(mafilldm,(co,nk,kon,ipkon,lakon,ne,nodeboun,
-			  ndirboun,xbounact,nboun,
-			  ipompc,nodempc,coefmpc,nmpc,nodeforc,ndirforc,
-			  xforcact,
-			  nforc,nelemload,sideload,xloadact,nload,xbodyact,
-			  ipobody,nbody,cgr,
-			  adc,auc,nactdof,icol,jq,irow,neq,nzl,nmethod,
-			  ikmpc,ilmpc,ikboun,ilboun,
-			  elcon,nelcon,rhcon,nrhcon,alcon,nalcon,alzero,ielmat,
-			  ielorien,norien,orab,ntmat_,
-			  t0,t1act,ithermal,prestr,iprestr,vold,iperturb,sti,
-			  nzs,stx,adb,aub,iexpl,plicon,nplicon,plkcon,nplkcon,
-			  xstiff,npmat_,&dtime,matname,mi,ncmat_,
-			  ttime,&time,istep,&iinc,ibody,clearini,mortar,
-			  springarea,
-			  pslavsurf,pmastsurf,&reltime,&nasym));
+        /* dashpots and contact damping */
+
+        FORTRAN(mafilldm, (co, nk, kon, ipkon, lakon, ne, nodeboun,
+                           ndirboun, xbounact, nboun,
+                           ipompc, nodempc, coefmpc, nmpc, nodeforc, ndirforc,
+                           xforcact,
+                           nforc, nelemload, sideload, xloadact, nload, xbodyact,
+                           ipobody, nbody, cgr,
+                           adc, auc, nactdof, icol, jq, irow, neq, nzl, nmethod,
+                           ikmpc, ilmpc, ikboun, ilboun,
+                           elcon, nelcon, rhcon, nrhcon, alcon, nalcon, alzero, ielmat,
+                           ielorien, norien, orab, ntmat_,
+                           t0, t1act, ithermal, prestr, iprestr, vold, iperturb, sti,
+                           nzs, stx, adb, aub, iexpl, plicon, nplicon, plkcon, nplkcon,
+                           xstiff, npmat_, &dtime, matname, mi, ncmat_,
+                           ttime, &time, istep, &iinc, ibody, clearini, mortar,
+                           springarea,
+                           pslavsurf, pmastsurf, &reltime, &nasym));
       }
 
       /* calculating the residual (RHS of equation system) */
 
-      if(*mortar!=-1){
-	calcresidual(nmethod,neq,b,fext,f,iexpl,nactdof,aux2,vold,
-		     vini,&dtime,accold,nk,adb,aub,jq,irow,nzl,alpha,fextini,
-		     fini,islavnode,nslavnode,mortar,ntie,f_cm,f_cs,mi,
-		     nzs,&nasym,&idamping,veold,adc,auc,cvini,cv,&alpham,
-		     &num_cpus);
-      }else{
-	NNEW(volddof,double,neq[0]);
-	NNEW(qb,double,neqtot);
-        massless(kslav,lslav,ktot,ltot,au,ad,auc,adc,
-		 jq,irow,neq,nzs,auw,jqw,iroww,&nzsw,
-		 islavnode,nslavnode,nslavs,imastnode,nmastnode,ntie,nactdof,
-		 mi,vold,volddof,veold,nk,fext,isolver,iperturb,co,springarea,
-		 &neqslav,&neqtot,qb,b);
-        SFREE(ad);SFREE(au); 
+      if (*mortar != -1) {
+        calcresidual(nmethod, neq, b, fext, f, iexpl, nactdof, aux2, vold,
+                     vini, &dtime, accold, nk, adb, aub, jq, irow, nzl, alpha, fextini,
+                     fini, islavnode, nslavnode, mortar, ntie, f_cm, f_cs, mi,
+                     nzs, &nasym, &idamping, veold, adc, auc, cvini, cv, &alpham,
+                     &num_cpus);
+      } else {
+        NNEW(volddof, double, neq[0]);
+        NNEW(qb, double, neqtot);
+        massless(kslav, lslav, ktot, ltot, au, ad, auc, adc,
+                 jq, irow, neq, nzs, auw, jqw, iroww, &nzsw,
+                 islavnode, nslavnode, nslavs, imastnode, nmastnode, ntie, nactdof,
+                 mi, vold, volddof, veold, nk, fext, isolver, iperturb, co, springarea,
+                 &neqslav, &neqtot, qb, b);
+        SFREE(ad);
+        SFREE(au);
       }
-	
 
       /* mortar contact */
 
-      if(*mortar>1){
-	
-	/* trafo u -> util */
-	
-	premortar(&iflagact,&ismallsliding,nzs,&nzsc2,&auc2,&adc2,
-		  &irowc2,&icolc2,&jqc2,&aubd,&irowbd,&jqbd,&aubdtil,
-		  &irowbdtil,&jqbdtil,&aubdtil2,&irowbdtil2,&jqbdtil2,
-		  &audd,&irowdd,&jqdd,&auddtil,&irowddtil,&jqddtil,
-		  &auddtil2,&irowddtil2,&jqddtil2,&auddinv,&irowddinv,
-		  &jqddinv,&jqtemp,&irowtemp,&icoltemp,nzstemp,&iit,
-		  slavnor,slavtan,icol,irow,jq,ikboun,ilboun,ikmpc,ilmpc,
-		  &nboun2,&ndirboun2,&nodeboun2,&xboun2,&nmpc2,&ipompc2,
-		  &nodempc2,&coefmpc2,&labmpc2,&ikboun2,&ilboun2,&ikmpc2,
-		  &ilmpc2,&nslavspc,&islavspc,&nslavmpc,&islavmpc,
-		  &nslavspc2,&islavspc2,&nslavmpc2,&islavmpc2,&nmastspc,
-		  &imastspc,&nmastmpc,&imastmpc,&nmastmpc2,&imastmpc2,
-		  &nmmpc2,&nsspc,&nsspc2,&nsmpc,&nsmpc2,imastnode,
-		  nmastnode,&nmspc,&nmmpc,co,nk,kon,ipkon,lakon,ne,stn,
-		  elcon,nelcon,rhcon,nrhcon,alcon,nalcon,alzero,ielmat,
-		  ielorien,norien,orab,ntmat_,t0,t1,ithermal,prestr,
-		  iprestr,filab,eme,emn,een,iperturb,f,nactdof,&iout,qa,
-		  vold,b,nodeboun,ndirboun,xbounact,xboun,nboun,ipompc,
-		  nodempc,coefmpc,labmpc,nmpc,nmethod,neq,veold,accold,
-		  &dtime,&time,ttime,plicon,nplicon,plkcon,nplkcon,
-		  xstateini,xstiff,xstate,npmat_,matname,mi,&ielas,&icmd,
-		  ncmat_,nstate_,stiini,vini,ener,enern,emeini,xstaten,
-		  eei,enerini,cocon,ncocon,set,nset,istartset,iendset,
-		  ialset,nprint,prlab,prset,qfx,qfn,trab,inotr,ntrans,
-		  nelemload,nload,istep,&iinc,springarea,&reltime,&ne0,
-		  xforc,nforc,thicke,shcon,nshcon,sideload,xload,xloadold,
-		  &icfd,inomat,islavelinv,islavsurf,iponoels,inoels,
-		  mortar,nslavnode,
-		  islavnode,nslavs,ntie,autloc,irowtloc,jqtloc,autlocinv,
-		  irowtlocinv,jqtlocinv,&nk2,&iflagdualquad,tieset,
-		  itiefac,&rhsi,au,ad,&f_cm,&f_cs,t1act,cam,&bet,&gam,epn,
-		  xloadact,nodeforc,ndirforc,xforcact,xbodyact,ipobody,
-		  nbody,cgr,nzl,sti,iexpl,mass,&buckling,&stiffness,
-		  &intscheme,physcon,&coriolis,ibody,integerglob,
-		  doubleglob,&nasym,&alpham,&betam,auxtil2,pslavsurf,
-		  pmastsurf,clearini,ielprop,prop,islavact,cdn,&memmpc_,
-		  cvtilini,cvtil,&idamping,&ilin,iperturb_sav,
-		  adb,aub,&nodeforc2,&ndirforc2,&xforc2,&nforc2,
-		  itietri,cg,straight,koncont,energyini,energy,&kscale,
-		  iponoel,inoel,nener,orname,network,typeboun,&num_cpus,
-		  t0g,t1g,smscale,&mscalmethod);
-	
-	/* calculating coupling matrices and embedding weak 
-	   contact conditions */ 
-      
-	contactmortar(&ncont,ntie,tieset,nset,set,istartset,iendset,ialset,
-		      itietri,lakon,ipkon,kon,koncont,ne,cg,straight,co,vold,
-		      ielmat,elcon,istep,&iinc,&iit,ncmat_,ntmat_,&ne0,vini,
-		      nmethod,neq,nzs,nactdof,itiefac,islavsurf,islavnode,
-		      imastnode,nslavnode,nmastnode,ad,&au,b,&irow,icol,jq,
-		      imastop,iponoels,inoels,&nzsc2,&auc2,adc2,&irowc2,jqc2,
-		      islavact,gap,slavnor,slavtan,bhat,&irowbd,jqbd,&aubd,
-		      &irowbdtil,jqbdtil,&aubdtil,&irowbdtil2,jqbdtil2,
-		      &aubdtil2,&irowdd,jqdd,&audd,&irowddtil,jqddtil,&auddtil,
-		      &irowddtil2,jqddtil2,&auddtil2,&irowddinv,jqddinv,
-		      &auddinv,irowtloc,jqtloc,autloc,irowtlocinv,jqtlocinv,
-		      autlocinv,mi,ipe,ime,tietol,&iflagact,cstress,cstressini,
-		      bp,&iflag_fric,nk,nboun,ndirboun,nodeboun,xbounact,nmpc,
-		      ipompc,nodempc,coefmpc,ikboun,ilboun,ikmpc,ilmpc,&nboun2,
-		      ndirboun2,nodeboun2,xboun2,&nmpc2,ipompc2,nodempc2,
-		      coefmpc2,ikboun2,ilboun2,ikmpc2,ilmpc2,nslavspc,islavspc,
-		      &nsspc,nslavmpc,islavmpc,&nsmpc,nslavspc2,islavspc2,
-		      &nsspc2,nslavmpc2,islavmpc2,&nsmpc2,nmastspc,imastspc,
-		      &nmspc,nmastmpc,imastmpc,&nmmpc,nmastmpc2,imastmpc2,
-		      &nmmpc2,pslavdual,pslavdualpg,islavactdof,islavactdoftie,
-		      plicon,nplicon,npmat_,nelcon,&dtime,islavnodeinv,&Bd,
-		      &irowb,jqb,&Bdhelp,&irowbhelp,jqbhelp,&Dd,&irowd,jqd,
-		      &Ddtil,&irowdtil,jqdtil,&Bdtil,&irowbtil,jqbtil,&Bpgd,
-		      &irowbpg,jqbpg,&Dpgd,&irowdpg,jqdpg,&Dpgdtil,&irowdpgtil,
-		      jqdpgtil,&Bpgdtil,&irowbpgtil,jqbpgtil,lambdaiwan,
-		      lambdaiwanini,&bet,&iflagdualquad,labmpc2,cfsini,
-		      &reltime,ithermal,plkcon,nplkcon);
-	
-	/*	for(k=0;k<neq[1];++k){printf("nactdofinv=%" ITGFORMAT ",%" ITGFORMAT ",%" ITGFORMAT "\n",k,(ITG)((double)nactdofinv[k]/mt)+1,nactdofinv[k]-mt*((ITG)((double)nactdofinv[k]/mt)));}
+      if (*mortar > 1) {
+
+        /* trafo u -> util */
+
+        premortar(&iflagact, &ismallsliding, nzs, &nzsc2, &auc2, &adc2,
+                  &irowc2, &icolc2, &jqc2, &aubd, &irowbd, &jqbd, &aubdtil,
+                  &irowbdtil, &jqbdtil, &aubdtil2, &irowbdtil2, &jqbdtil2,
+                  &audd, &irowdd, &jqdd, &auddtil, &irowddtil, &jqddtil,
+                  &auddtil2, &irowddtil2, &jqddtil2, &auddinv, &irowddinv,
+                  &jqddinv, &jqtemp, &irowtemp, &icoltemp, nzstemp, &iit,
+                  slavnor, slavtan, icol, irow, jq, ikboun, ilboun, ikmpc, ilmpc,
+                  &nboun2, &ndirboun2, &nodeboun2, &xboun2, &nmpc2, &ipompc2,
+                  &nodempc2, &coefmpc2, &labmpc2, &ikboun2, &ilboun2, &ikmpc2,
+                  &ilmpc2, &nslavspc, &islavspc, &nslavmpc, &islavmpc,
+                  &nslavspc2, &islavspc2, &nslavmpc2, &islavmpc2, &nmastspc,
+                  &imastspc, &nmastmpc, &imastmpc, &nmastmpc2, &imastmpc2,
+                  &nmmpc2, &nsspc, &nsspc2, &nsmpc, &nsmpc2, imastnode,
+                  nmastnode, &nmspc, &nmmpc, co, nk, kon, ipkon, lakon, ne, stn,
+                  elcon, nelcon, rhcon, nrhcon, alcon, nalcon, alzero, ielmat,
+                  ielorien, norien, orab, ntmat_, t0, t1, ithermal, prestr,
+                  iprestr, filab, eme, emn, een, iperturb, f, nactdof, &iout, qa,
+                  vold, b, nodeboun, ndirboun, xbounact, xboun, nboun, ipompc,
+                  nodempc, coefmpc, labmpc, nmpc, nmethod, neq, veold, accold,
+                  &dtime, &time, ttime, plicon, nplicon, plkcon, nplkcon,
+                  xstateini, xstiff, xstate, npmat_, matname, mi, &ielas, &icmd,
+                  ncmat_, nstate_, stiini, vini, ener, enern, emeini, xstaten,
+                  eei, enerini, cocon, ncocon, set, nset, istartset, iendset,
+                  ialset, nprint, prlab, prset, qfx, qfn, trab, inotr, ntrans,
+                  nelemload, nload, istep, &iinc, springarea, &reltime, &ne0,
+                  xforc, nforc, thicke, shcon, nshcon, sideload, xload, xloadold,
+                  &icfd, inomat, islavelinv, islavsurf, iponoels, inoels,
+                  mortar, nslavnode,
+                  islavnode, nslavs, ntie, autloc, irowtloc, jqtloc, autlocinv,
+                  irowtlocinv, jqtlocinv, &nk2, &iflagdualquad, tieset,
+                  itiefac, &rhsi, au, ad, &f_cm, &f_cs, t1act, cam, &bet, &gam, epn,
+                  xloadact, nodeforc, ndirforc, xforcact, xbodyact, ipobody,
+                  nbody, cgr, nzl, sti, iexpl, mass, &buckling, &stiffness,
+                  &intscheme, physcon, &coriolis, ibody, integerglob,
+                  doubleglob, &nasym, &alpham, &betam, auxtil2, pslavsurf,
+                  pmastsurf, clearini, ielprop, prop, islavact, cdn, &memmpc_,
+                  cvtilini, cvtil, &idamping, &ilin, iperturb_sav,
+                  adb, aub, &nodeforc2, &ndirforc2, &xforc2, &nforc2,
+                  itietri, cg, straight, koncont, energyini, energy, &kscale,
+                  iponoel, inoel, nener, orname, network, typeboun, &num_cpus,
+                  t0g, t1g, smscale, &mscalmethod);
+
+        /* calculating coupling matrices and embedding weak 
+	   contact conditions */
+
+        contactmortar(&ncont, ntie, tieset, nset, set, istartset, iendset, ialset,
+                      itietri, lakon, ipkon, kon, koncont, ne, cg, straight, co, vold,
+                      ielmat, elcon, istep, &iinc, &iit, ncmat_, ntmat_, &ne0, vini,
+                      nmethod, neq, nzs, nactdof, itiefac, islavsurf, islavnode,
+                      imastnode, nslavnode, nmastnode, ad, &au, b, &irow, icol, jq,
+                      imastop, iponoels, inoels, &nzsc2, &auc2, adc2, &irowc2, jqc2,
+                      islavact, gap, slavnor, slavtan, bhat, &irowbd, jqbd, &aubd,
+                      &irowbdtil, jqbdtil, &aubdtil, &irowbdtil2, jqbdtil2,
+                      &aubdtil2, &irowdd, jqdd, &audd, &irowddtil, jqddtil, &auddtil,
+                      &irowddtil2, jqddtil2, &auddtil2, &irowddinv, jqddinv,
+                      &auddinv, irowtloc, jqtloc, autloc, irowtlocinv, jqtlocinv,
+                      autlocinv, mi, ipe, ime, tietol, &iflagact, cstress, cstressini,
+                      bp, &iflag_fric, nk, nboun, ndirboun, nodeboun, xbounact, nmpc,
+                      ipompc, nodempc, coefmpc, ikboun, ilboun, ikmpc, ilmpc, &nboun2,
+                      ndirboun2, nodeboun2, xboun2, &nmpc2, ipompc2, nodempc2,
+                      coefmpc2, ikboun2, ilboun2, ikmpc2, ilmpc2, nslavspc, islavspc,
+                      &nsspc, nslavmpc, islavmpc, &nsmpc, nslavspc2, islavspc2,
+                      &nsspc2, nslavmpc2, islavmpc2, &nsmpc2, nmastspc, imastspc,
+                      &nmspc, nmastmpc, imastmpc, &nmmpc, nmastmpc2, imastmpc2,
+                      &nmmpc2, pslavdual, pslavdualpg, islavactdof, islavactdoftie,
+                      plicon, nplicon, npmat_, nelcon, &dtime, islavnodeinv, &Bd,
+                      &irowb, jqb, &Bdhelp, &irowbhelp, jqbhelp, &Dd, &irowd, jqd,
+                      &Ddtil, &irowdtil, jqdtil, &Bdtil, &irowbtil, jqbtil, &Bpgd,
+                      &irowbpg, jqbpg, &Dpgd, &irowdpg, jqdpg, &Dpgdtil, &irowdpgtil,
+                      jqdpgtil, &Bpgdtil, &irowbpgtil, jqbpgtil, lambdaiwan,
+                      lambdaiwanini, &bet, &iflagdualquad, labmpc2, cfsini,
+                      &reltime, ithermal, plkcon, nplkcon);
+
+        /*	for(k=0;k<neq[1];++k){printf("nactdofinv=%" ITGFORMAT ",%" ITGFORMAT ",%" ITGFORMAT "\n",k,(ITG)((double)nactdofinv[k]/mt)+1,nactdofinv[k]-mt*((ITG)((double)nactdofinv[k]/mt)));}
 
 	printf("neq[1]=%d,nzs[1]=%d\n",neq[1],nzs[1]);
 	for(k=0;k<neq[1];++k){printf("f=%" ITGFORMAT ",%f\n",k,f[k]);}
@@ -2701,118 +2857,122 @@ void nonlingeo_precice(double **cop, ITG *nk, ITG **konp, ITG **ipkonp, char **l
 	for(k=0;k<neq[1]+1;++k){printf("jq=%" ITGFORMAT ",%d\n",k,jq[k]);}
 	for(k=0;k<nzs[1];++k){printf("irow=%" ITGFORMAT ",%d\n",k,irow[k]);}
 	for(k=0;k<nzs[1];++k){printf("au=%" ITGFORMAT ",%f\n",k,au[k]);}*/
-	  
-	nzs[0]=nzs[1];
-	nzs[2]=nzs[1];
-	symmetryflag=2;
-	inputformat=3; 
+
+        nzs[0]       = nzs[1];
+        nzs[2]       = nzs[1];
+        symmetryflag = 2;
+        inputformat  = 3;
       }
 
       /* storing the residuum in resold (for line search) */
 
-      if((*mortar==1)&&(iit!=1)&&(*ne-ne0>0)&&(*nmethod!=4)){
-	isiz=neq[1];cpypardou(resold,b,&isiz,&num_cpus);
+      if ((*mortar == 1) && (iit != 1) && (*ne - ne0 > 0) && (*nmethod != 4)) {
+        isiz = neq[1];
+        cpypardou(resold, b, &isiz, &num_cpus);
       }
-	  
-      newstep=0;
-      
-      if(*nmethod==0){
-	  
-	/* error occurred in mafill: storing the geometry in frd format */
-	  
-	*nmethod=0;
-	++*kode;
-	NNEW(inum,ITG,*nk);ITGMEMSET(inum,0,*nk,1);
-	if(strcmp1(&filab[1044],"ZZS")==0){
-	  NNEW(neigh,ITG,40**ne);
-	  MNEW(ipneigh,ITG,*nk);
-	}
-	  
-	ptime=*ttime+time;
-	frd(co,nk,kon,ipkon,lakon,&ne0,v,stn,inum,nmethod,
-	    kode,filab,een,t1,fn,&ptime,epn,ielmat,matname,enern,xstaten,
-	    nstate_,istep,&iinc,ithermal,qfn,&mode,&noddiam,trab,inotr,
-	    ntrans,orab,ielorien,norien,description,ipneigh,neigh,
-	    mi,sti,vr,vi,stnr,stni,vmax,stnmax,&ngraph,veold,ener,ne,
-	    cs,set,nset,istartset,iendset,ialset,eenmax,fnr,fni,emn,
-	    thicke,jobnamec,output,qfx,cdn,mortar,cdnr,cdni,nmat,
-	    ielprop,prop,sti);
 
-	if(strcmp1(&filab[1044],"ZZS")==0){SFREE(ipneigh);SFREE(neigh);} 
+      newstep = 0;
+
+      if (*nmethod == 0) {
+
+        /* error occurred in mafill: storing the geometry in frd format */
+
+        *nmethod = 0;
+        ++*kode;
+        NNEW(inum, ITG, *nk);
+        ITGMEMSET(inum, 0, *nk, 1);
+        if (strcmp1(&filab[1044], "ZZS") == 0) {
+          NNEW(neigh, ITG, 40 * *ne);
+          MNEW(ipneigh, ITG, *nk);
+        }
+
+        ptime = *ttime + time;
+        frd(co, nk, kon, ipkon, lakon, &ne0, v, stn, inum, nmethod,
+            kode, filab, een, t1, fn, &ptime, epn, ielmat, matname, enern, xstaten,
+            nstate_, istep, &iinc, ithermal, qfn, &mode, &noddiam, trab, inotr,
+            ntrans, orab, ielorien, norien, description, ipneigh, neigh,
+            mi, sti, vr, vi, stnr, stni, vmax, stnmax, &ngraph, veold, ener, ne,
+            cs, set, nset, istartset, iendset, ialset, eenmax, fnr, fni, emn,
+            thicke, jobnamec, output, qfx, cdn, mortar, cdnr, cdni, nmat,
+            ielprop, prop, sti);
+
+        if (strcmp1(&filab[1044], "ZZS") == 0) {
+          SFREE(ipneigh);
+          SFREE(neigh);
+        }
 #ifdef COMPANY
-	FORTRAN(uout,(v,mi,ithermal,filab,kode,output,jobnamec));
+        FORTRAN(uout, (v, mi, ithermal, filab, kode, output, jobnamec));
 #endif
-	SFREE(inum);FORTRAN(stop,());
-	  
+        SFREE(inum);
+        FORTRAN(stop, ());
       }
-      
+
       /* implicit step (static or dynamic) */
-      
-      if(*iexpl<=1){
-	if((*nmethod==4)&&(*mortar<2)){
-	      
-	  /* mechanical part */
-	      
-	  if(*ithermal!=2){
-	    scal1=bet*dtime*dtime*(1.+alpha[0]);
-	    for(k=0;k<neq[0];++k){
-	      ad[k]=adb[k]+scal1*ad[k];
-	    }
-	    for(k=0;k<nzs[0];++k){
-	      au[k]=aub[k]+scal1*au[k];
-	    }
-		  
-	    /* upper triangle of asymmetric matrix */
-		  
-	    if(nasym>0){
-	      for(k=nzs[2];k<nzs[2]+nzs[0];++k){
-		au[k]=aub[k]+scal1*au[k];
-	      }
-	    }
 
-	    /* damping */
-		  
-	    if(idamping==1){
-	      scal1=gam*dtime*(1.+alpha[0]);
-	      for(k=0;k<neq[0];++k){
-		ad[k]+=scal1*adc[k];
-	      }
-	      for(k=0;k<nzs[0];++k){
-		au[k]+=scal1*auc[k];
-	      }
-		      
-	      /* upper triangle of asymmetric matrix */
-		      
-	      if(nasym>0){
-		for(k=nzs[2];k<nzs[2]+nzs[0];++k){
-		  au[k]+=scal1*auc[k];
-		}
-	      }
-	    }
+      if (*iexpl <= 1) {
+        if ((*nmethod == 4) && (*mortar < 2)) {
 
-	  }
-	      
-	  /* thermal part */
-	      
-	  if(*ithermal>1){
-	    for(k=neq[0];k<neq[1];++k){
-	      ad[k]=adb[k]/dtime+ad[k];
-	    }
-	    for(k=nzs[0];k<nzs[1];++k){
-	      au[k]=aub[k]/dtime+au[k];
-	    }
-		  
-	    /* upper triangle of asymmetric matrix */
-		  
-	    if(nasym>0){
-	      for(k=nzs[2]+nzs[0];k<nzs[2]+nzs[1];++k){
-		au[k]=aub[k]/dtime+au[k];
-	      }
-	    }
-	  }
-	}
-      
-	/*	for(k=0;k<neq[1];++k){printf("fext=%" ITGFORMAT ",%f\n",k,fext[k]);}
+          /* mechanical part */
+
+          if (*ithermal != 2) {
+            scal1 = bet * dtime * dtime * (1. + alpha[0]);
+            for (k = 0; k < neq[0]; ++k) {
+              ad[k] = adb[k] + scal1 * ad[k];
+            }
+            for (k = 0; k < nzs[0]; ++k) {
+              au[k] = aub[k] + scal1 * au[k];
+            }
+
+            /* upper triangle of asymmetric matrix */
+
+            if (nasym > 0) {
+              for (k = nzs[2]; k < nzs[2] + nzs[0]; ++k) {
+                au[k] = aub[k] + scal1 * au[k];
+              }
+            }
+
+            /* damping */
+
+            if (idamping == 1) {
+              scal1 = gam * dtime * (1. + alpha[0]);
+              for (k = 0; k < neq[0]; ++k) {
+                ad[k] += scal1 * adc[k];
+              }
+              for (k = 0; k < nzs[0]; ++k) {
+                au[k] += scal1 * auc[k];
+              }
+
+              /* upper triangle of asymmetric matrix */
+
+              if (nasym > 0) {
+                for (k = nzs[2]; k < nzs[2] + nzs[0]; ++k) {
+                  au[k] += scal1 * auc[k];
+                }
+              }
+            }
+          }
+
+          /* thermal part */
+
+          if (*ithermal > 1) {
+            for (k = neq[0]; k < neq[1]; ++k) {
+              ad[k] = adb[k] / dtime + ad[k];
+            }
+            for (k = nzs[0]; k < nzs[1]; ++k) {
+              au[k] = aub[k] / dtime + au[k];
+            }
+
+            /* upper triangle of asymmetric matrix */
+
+            if (nasym > 0) {
+              for (k = nzs[2] + nzs[0]; k < nzs[2] + nzs[1]; ++k) {
+                au[k] = aub[k] / dtime + au[k];
+              }
+            }
+          }
+        }
+
+        /*	for(k=0;k<neq[1];++k){printf("fext=%" ITGFORMAT ",%f\n",k,fext[k]);}
 	for(k=0;k<neq[1];++k){printf("f=%" ITGFORMAT ",%f\n",k,f[k]);}
 	for(k=0;k<neq[1];++k){printf("b=%" ITGFORMAT ",%f\n",k,b[k]);}
 	for(k=0;k<neq[1];++k){printf("ad=%" ITGFORMAT ",%f\n",k,ad[k]);}
@@ -2820,615 +2980,680 @@ void nonlingeo_precice(double **cop, ITG *nk, ITG **konp, ITG **ipkonp, char **l
 	for(k=0;k<nzs[1];++k){printf("irow=%" ITGFORMAT ",%d\n",k,irow[k]);}
 	for(k=0;k<neq[1]+1;++k){printf("jq=%" ITGFORMAT ",%d\n",k,jq[k]);}
 	for(k=0;k<neq[1];++k){printf("icol=%" ITGFORMAT ",%d %d\n",k,icol[k],jq[k+1]-jq[k]);}*/
-      
-	if(*isolver==0){
+
+        if (*isolver == 0) {
 #ifdef SPOOLES
-	  if(*ithermal<2){
-	    spooles(ad,au,adb,aub,&sigma,b,icol,irow,&neq[0],&nzs[0],
-		    &symmetryflag,&inputformat,&nzs[2]);
-	    /*FORTRAN(writetrilinos,(jq,irow,ad,au,b,&neq[0],&nzs[0],&symmetryflag,
+          if (*ithermal < 2) {
+            spooles(ad, au, adb, aub, &sigma, b, icol, irow, &neq[0], &nzs[0],
+                    &symmetryflag, &inputformat, &nzs[2]);
+            /*FORTRAN(writetrilinos,(jq,irow,ad,au,b,&neq[0],&nzs[0],&symmetryflag,
 	      &inputformat,co,nk,nactdof,jobnamef,mi));*/
-	    
-	  }else if((*ithermal==2)&&(uncoupled)){
-	    n1=neq[1]-neq[0];
-	    n2=nzs[1]-nzs[0];
-	    spooles(&ad[neq[0]],&au[nzs[0]],&adb[neq[0]],&aub[nzs[0]],
-		    &sigma,&b[neq[0]],&icol[neq[0]],iruc,
-		    &n1,&n2,&symmetryflag,&inputformat,&nzs[2]);
-	  }else{
-	    spooles(ad,au,adb,aub,&sigma,b,icol,irow,&neq[1],&nzs[1],
-		    &symmetryflag,&inputformat,&nzs[2]);
-	  }
+
+          } else if ((*ithermal == 2) && (uncoupled)) {
+            n1 = neq[1] - neq[0];
+            n2 = nzs[1] - nzs[0];
+            spooles(&ad[neq[0]], &au[nzs[0]], &adb[neq[0]], &aub[nzs[0]],
+                    &sigma, &b[neq[0]], &icol[neq[0]], iruc,
+                    &n1, &n2, &symmetryflag, &inputformat, &nzs[2]);
+          } else {
+            spooles(ad, au, adb, aub, &sigma, b, icol, irow, &neq[1], &nzs[1],
+                    &symmetryflag, &inputformat, &nzs[2]);
+          }
 #else
-	  printf(" *ERROR in nonlingeo: the SPOOLES library is not linked\n\n");
-	  FORTRAN(stop,());
+          printf(" *ERROR in nonlingeo: the SPOOLES library is not linked\n\n");
+          FORTRAN(stop, ());
 #endif
-	}
-	else if((*isolver==2)||(*isolver==3)){
-	  if(symmetryflag==2){
-	    if(*isolver==3){
-	      printf(" *WARNING in nonlingeo: the iterative Cholesky solver");
-	      printf(" cannot be used for asymmetric matrices.\nThe");
-	      printf(" iterative scaling solver will be used instead\n\n");
-	    }
-	    NNEW(rwork,double,neq[1]);
-	    NNEW(sol,double,neq[1]);
-	    RENEW(au,double,2*nzs[1]+neq[1]);
-	    isiz=neq[1];cpypardou(&au[2*nzs[1]],ad,&isiz,&num_cpus);
-	    nelt=2*nzs[1]+neq[1];
-	    lrgw=131+16*neq[1];
-	    isym=0;
-	    NNEW(rgwk,double,lrgw);
-	    NNEW(igwk,ITG,20);
-	    for(i=0;i<neq[1];i++){
-	      rwork[i]=1./ad[i];}
-	    FORTRAN(predgmres_struct,(&neq[1],b,sol,&nelt,irow,jq,au,
-				      &isym,&itol,&tol,&itmax,&iter,
-				      &err,&ierr,&iunit,sb,sx,rgwk,&lrgw,igwk,
-				      &ligw,rwork,iwork));
-	    isiz=neq[1];cpypardou(b,sol,&isiz,&num_cpus);
-	    SFREE(rgwk);SFREE(igwk);SFREE(rwork);SFREE(sol);
-	  }else{
-	    preiter(ad,&au,b,&icol,&irow,&neq[1],&nzs[1],isolver,iperturb);
-	  }
-	}
-	else if(*isolver==4){
+        } else if ((*isolver == 2) || (*isolver == 3)) {
+          if (symmetryflag == 2) {
+            if (*isolver == 3) {
+              printf(" *WARNING in nonlingeo: the iterative Cholesky solver");
+              printf(" cannot be used for asymmetric matrices.\nThe");
+              printf(" iterative scaling solver will be used instead\n\n");
+            }
+            NNEW(rwork, double, neq[1]);
+            NNEW(sol, double, neq[1]);
+            RENEW(au, double, 2 * nzs[1] + neq[1]);
+            isiz = neq[1];
+            cpypardou(&au[2 * nzs[1]], ad, &isiz, &num_cpus);
+            nelt = 2 * nzs[1] + neq[1];
+            lrgw = 131 + 16 * neq[1];
+            isym = 0;
+            NNEW(rgwk, double, lrgw);
+            NNEW(igwk, ITG, 20);
+            for (i = 0; i < neq[1]; i++) {
+              rwork[i] = 1. / ad[i];
+            }
+            FORTRAN(predgmres_struct, (&neq[1], b, sol, &nelt, irow, jq, au,
+                                       &isym, &itol, &tol, &itmax, &iter,
+                                       &err, &ierr, &iunit, sb, sx, rgwk, &lrgw, igwk,
+                                       &ligw, rwork, iwork));
+            isiz = neq[1];
+            cpypardou(b, sol, &isiz, &num_cpus);
+            SFREE(rgwk);
+            SFREE(igwk);
+            SFREE(rwork);
+            SFREE(sol);
+          } else {
+            preiter(ad, &au, b, &icol, &irow, &neq[1], &nzs[1], isolver, iperturb);
+          }
+        } else if (*isolver == 4) {
 #ifdef SGI
-	  if(symmetryflag==2){
-	    printf(" *ERROR in nonlingeo: the SGI solver cannot be used for asymmetric matrices\n\n");
-	    FORTRAN(stop,());
-	  }
-	  token=1;
-	  if(*ithermal<2){
-	    sgi_main(ad,au,adb,aub,&sigma,b,icol,irow,&neq[0],&nzs[0],token);
-	  }else if((*ithermal==2)&&(uncoupled)){
-	    n1=neq[1]-neq[0];
-	    n2=nzs[1]-nzs[0];
-	    sgi_main(&ad[neq[0]],&au[nzs[0]],&adb[neq[0]],&aub[nzs[0]],
-		     &sigma,&b[neq[0]],&icol[neq[0]],iruc,
-		     &n1,&n2,token);
-	  }else{
-	    sgi_main(ad,au,adb,aub,&sigma,b,icol,irow,&neq[1],&nzs[1],token);
-	  }
+          if (symmetryflag == 2) {
+            printf(" *ERROR in nonlingeo: the SGI solver cannot be used for asymmetric matrices\n\n");
+            FORTRAN(stop, ());
+          }
+          token = 1;
+          if (*ithermal < 2) {
+            sgi_main(ad, au, adb, aub, &sigma, b, icol, irow, &neq[0], &nzs[0], token);
+          } else if ((*ithermal == 2) && (uncoupled)) {
+            n1 = neq[1] - neq[0];
+            n2 = nzs[1] - nzs[0];
+            sgi_main(&ad[neq[0]], &au[nzs[0]], &adb[neq[0]], &aub[nzs[0]],
+                     &sigma, &b[neq[0]], &icol[neq[0]], iruc,
+                     &n1, &n2, token);
+          } else {
+            sgi_main(ad, au, adb, aub, &sigma, b, icol, irow, &neq[1], &nzs[1], token);
+          }
 #else
-	  printf(" *ERROR in nonlingeo: the SGI library is not linked\n\n");
-	  FORTRAN(stop,());
+          printf(" *ERROR in nonlingeo: the SGI library is not linked\n\n");
+          FORTRAN(stop, ());
 #endif
-	}
-	else if(*isolver==5){
+        } else if (*isolver == 5) {
 #ifdef TAUCS
-	  if(symmetryflag==2){
-	    printf(" *ERROR in nonlingeo: the TAUCS solver cannot be used for asymmetric matrices\n\n");
-	    FORTRAN(stop,());
-	  }
-	  tau(ad,&au,adb,aub,&sigma,b,icol,&irow,&neq[1],&nzs[1]);
+          if (symmetryflag == 2) {
+            printf(" *ERROR in nonlingeo: the TAUCS solver cannot be used for asymmetric matrices\n\n");
+            FORTRAN(stop, ());
+          }
+          tau(ad, &au, adb, aub, &sigma, b, icol, &irow, &neq[1], &nzs[1]);
 #else
-	  printf(" *ERROR in nonlingeo: the TAUCS library is not linked\n\n");
-	  FORTRAN(stop,());
+          printf(" *ERROR in nonlingeo: the TAUCS library is not linked\n\n");
+          FORTRAN(stop, ());
 #endif
-	}
-	else if(*isolver==6){
+        } else if (*isolver == 6) {
 #ifdef MATRIXSTORAGE
-	  matrixstorage(ad,&au,adb,aub,&sigma,icol,&irow,&neq[1],&nzs[1],
-			ntrans,inotr,trab,co,nk,nactdof,jobnamec,mi,ipkon,
-			lakon,kon,ne,mei,nboun,nmpc,cs,mcs,ithermal,nmethod);
-	  strcpy(fneig,jobnamec);
-	  strcat(fneig,".frd");
-	  if((f1=fopen(fneig,"ab"))==NULL){
-	    printf("*ERROR in frd: cannot open frd file for writing...");
-	    exit(0);
-	  }
-	  fprintf(f1," 9999\n");
-	  fclose(f1);
-	  FORTRAN(stopwithout201,());
+          matrixstorage(ad, &au, adb, aub, &sigma, icol, &irow, &neq[1], &nzs[1],
+                        ntrans, inotr, trab, co, nk, nactdof, jobnamec, mi, ipkon,
+                        lakon, kon, ne, mei, nboun, nmpc, cs, mcs, ithermal, nmethod);
+          strcpy(fneig, jobnamec);
+          strcat(fneig, ".frd");
+          if ((f1 = fopen(fneig, "ab")) == NULL) {
+            printf("*ERROR in frd: cannot open frd file for writing...");
+            exit(0);
+          }
+          fprintf(f1, " 9999\n");
+          fclose(f1);
+          FORTRAN(stopwithout201, ());
 #else
-	  printf("*ERROR in arpack: the MATRIXSTORAGE library is not linked\n\n");
-	  FORTRAN(stop,());
+          printf("*ERROR in arpack: the MATRIXSTORAGE library is not linked\n\n");
+          FORTRAN(stop, ());
 #endif
-	}
-	else if(*isolver==7){
+        } else if (*isolver == 7) {
 #ifdef PARDISO
-	  if(*ithermal<2){
-	    pardiso_main(ad,au,adb,aub,&sigma,b,icol,irow,&neq[0],&nzs[0],
-			 &symmetryflag,&inputformat,jq,&nzs[2],&nrhs);
-	  }else if((*ithermal==2)&&(uncoupled)){
-	    n1=neq[1]-neq[0];
-	    n2=nzs[1]-nzs[0];
-	    pardiso_main(&ad[neq[0]],&au[nzs[0]],&adb[neq[0]],&aub[nzs[0]],
-			 &sigma,&b[neq[0]],&icol[neq[0]],iruc,
-			 &n1,&n2,&symmetryflag,&inputformat,jq,&nzs[2],&nrhs);
-	  }else{
-	    pardiso_main(ad,au,adb,aub,&sigma,b,icol,irow,&neq[1],&nzs[1],
-			 &symmetryflag,&inputformat,jq,&nzs[2],&nrhs);
-	  }
+          if (*ithermal < 2) {
+            pardiso_main(ad, au, adb, aub, &sigma, b, icol, irow, &neq[0], &nzs[0],
+                         &symmetryflag, &inputformat, jq, &nzs[2], &nrhs);
+          } else if ((*ithermal == 2) && (uncoupled)) {
+            n1 = neq[1] - neq[0];
+            n2 = nzs[1] - nzs[0];
+            pardiso_main(&ad[neq[0]], &au[nzs[0]], &adb[neq[0]], &aub[nzs[0]],
+                         &sigma, &b[neq[0]], &icol[neq[0]], iruc,
+                         &n1, &n2, &symmetryflag, &inputformat, jq, &nzs[2], &nrhs);
+          } else {
+            pardiso_main(ad, au, adb, aub, &sigma, b, icol, irow, &neq[1], &nzs[1],
+                         &symmetryflag, &inputformat, jq, &nzs[2], &nrhs);
+          }
 #else
-	  printf(" *ERROR in nonlingeo: the PARDISO library is not linked\n\n");
-	  FORTRAN(stop,());
+          printf(" *ERROR in nonlingeo: the PARDISO library is not linked\n\n");
+          FORTRAN(stop, ());
 #endif
-	}
-	else if(*isolver==8){
+        } else if (*isolver == 8) {
 #ifdef PASTIX
-	  if(*ithermal<2){
-	    pastix_main(ad,au,adb,aub,&sigma,b,icol,irow,&neq[0],&nzs[0],
-			&symmetryflag,&inputformat,jq,&nzs[2],&nrhs);
-	  }else if((*ithermal==2)&&(uncoupled)){
-	    n1=neq[1]-neq[0];
-	    n2=nzs[1]-nzs[0];
-	    NNEW(jqtherm,ITG,n1+1);
-	    for(i=0;i<n1+1;i++){
-	      jqtherm[i]=jq[neq[0]+i]-nzs[0];}
-	    /*	    printf("jq[0]=%d\n",jqtherm[0]);
+          if (*ithermal < 2) {
+            pastix_main(ad, au, adb, aub, &sigma, b, icol, irow, &neq[0], &nzs[0],
+                        &symmetryflag, &inputformat, jq, &nzs[2], &nrhs);
+          } else if ((*ithermal == 2) && (uncoupled)) {
+            n1 = neq[1] - neq[0];
+            n2 = nzs[1] - nzs[0];
+            NNEW(jqtherm, ITG, n1 + 1);
+            for (i = 0; i < n1 + 1; i++) {
+              jqtherm[i] = jq[neq[0] + i] - nzs[0];
+            }
+            /*	    printf("jq[0]=%d\n",jqtherm[0]);
 	    for(i=0;i<n1;i++){
 	      printf("i=%d,jqdiff=%d\n",i,jqtherm[i+1]-(jqtherm[i]+icol[neq[0]+i]));
 	      }*/
-	    pastix_main(&ad[neq[0]],&au[nzs[0]],&adb[neq[0]],&aub[nzs[0]],
-			&sigma,&b[neq[0]],&icol[neq[0]],iruc,
-			&n1,&n2,&symmetryflag,&inputformat,jqtherm,&nzs[2],&nrhs);
-	    SFREE(jqtherm);
-	  }else{
-	    pastix_main(ad,au,adb,aub,&sigma,b,icol,irow,&neq[1],&nzs[1],
-			&symmetryflag,&inputformat,jq,&nzs[2],&nrhs);
-	  }
+            pastix_main(&ad[neq[0]], &au[nzs[0]], &adb[neq[0]], &aub[nzs[0]],
+                        &sigma, &b[neq[0]], &icol[neq[0]], iruc,
+                        &n1, &n2, &symmetryflag, &inputformat, jqtherm, &nzs[2], &nrhs);
+            SFREE(jqtherm);
+          } else {
+            pastix_main(ad, au, adb, aub, &sigma, b, icol, irow, &neq[1], &nzs[1],
+                        &symmetryflag, &inputformat, jq, &nzs[2], &nrhs);
+          }
 #else
-	  printf(" *ERROR in nonlingeo: the PASTIX library is not linked\n\n");
-	  FORTRAN(stop,());
+          printf(" *ERROR in nonlingeo: the PASTIX library is not linked\n\n");
+          FORTRAN(stop, ());
 #endif
-	}
-	//	for(k=0;k<neq[1];++k){printf("sol=%" ITGFORMAT ",%f\n",k,b[k]);}
-	  
-	if(*mortar<=1){
-	  if(isensitivity){
-	    SFREE(adcpy);MNEW(adcpy,double,neq[1]);
-	    SFREE(aucpy);MNEW(aucpy,double,(nasym+1)*nzs[1]);
-	    isiz=neq[1];cpypardou(adcpy,ad,&isiz,&num_cpus);
-	    isiz=(nasym+1)*nzs[1];cpypardou(aucpy,au,&isiz,&num_cpus);
-	  }
-	  SFREE(ad);SFREE(au);
-	} 
-      }
-      
-      /* explicit dynamic step */
-      
-      else{
-	if(((mscalmethod==0)||(mscalmethod==2))&&(*mortar!=-1)){
-	  if(*ithermal!=2){
-	    isiz=neq[0];divparll(b,adb,&isiz,&num_cpus);
-	  }
-	  if(*ithermal>1){
-	    for(k=neq[0];k<neq[1];++k){
-	      b[k]=b[k]*dtime/adb[k];
-	    }
-	  }
-	}
-	else{
-	  if(*ithermal!=2){
-	    if(*isolver==0){
-#ifdef SPOOLES
-	      spooles_solve(b,&neq[0]);
-#endif
-	    }
-	    else if(*isolver==4){
-#ifdef SGI
-	      sgi_solve(b,token);
-#endif
-	    }
-	    else if(*isolver==5){
-#ifdef TAUCS
-	      tau_solve(b,&neq[0]);
-#endif
-	    }
-	    else if(*isolver==7){
-#ifdef PARDISO
-	      pardiso_solve(b,&neq[0],&symmetryflag,&inputformat,&nrhs);
-#endif
-	    }
-	    else if(*isolver==8){
-#ifdef PASTIX
-	      pastix_solve(b,&neq[0],&symmetryflag,&nrhs);
-#endif
-	    }
-	    if(*mortar==-1){
+        }
+        //	for(k=0;k<neq[1];++k){printf("sol=%" ITGFORMAT ",%f\n",k,b[k]);}
 
-	      /* determine the velocity in the contact nodes */
-	      
-	      for(i=0;i<neqtot;++i){
-		b[ktot[i]-1]=(qb[i]-volddof[ktot[i]-1])/(*tinc);
-	      }
-	      SFREE(qb);SFREE(volddof);
-	    }
-	  }
-	  if(*ithermal>1){
-	    for(k=neq[0];k<neq[1];++k){
-	      b[k]=b[k]*dtime/adb[k];
-	    }
-	  }
-	}
+        if (*mortar <= 1) {
+          if (isensitivity) {
+            SFREE(adcpy);
+            MNEW(adcpy, double, neq[1]);
+            SFREE(aucpy);
+            MNEW(aucpy, double, (nasym + 1) * nzs[1]);
+            isiz = neq[1];
+            cpypardou(adcpy, ad, &isiz, &num_cpus);
+            isiz = (nasym + 1) * nzs[1];
+            cpypardou(aucpy, au, &isiz, &num_cpus);
+          }
+          SFREE(ad);
+          SFREE(au);
+        }
+      }
+
+      /* explicit dynamic step */
+
+      else {
+        if (((mscalmethod == 0) || (mscalmethod == 2)) && (*mortar != -1)) {
+          if (*ithermal != 2) {
+            isiz = neq[0];
+            divparll(b, adb, &isiz, &num_cpus);
+          }
+          if (*ithermal > 1) {
+            for (k = neq[0]; k < neq[1]; ++k) {
+              b[k] = b[k] * dtime / adb[k];
+            }
+          }
+        } else {
+          if (*ithermal != 2) {
+            if (*isolver == 0) {
+#ifdef SPOOLES
+              spooles_solve(b, &neq[0]);
+#endif
+            } else if (*isolver == 4) {
+#ifdef SGI
+              sgi_solve(b, token);
+#endif
+            } else if (*isolver == 5) {
+#ifdef TAUCS
+              tau_solve(b, &neq[0]);
+#endif
+            } else if (*isolver == 7) {
+#ifdef PARDISO
+              pardiso_solve(b, &neq[0], &symmetryflag, &inputformat, &nrhs);
+#endif
+            } else if (*isolver == 8) {
+#ifdef PASTIX
+              pastix_solve(b, &neq[0], &symmetryflag, &nrhs);
+#endif
+            }
+            if (*mortar == -1) {
+
+              /* determine the velocity in the contact nodes */
+
+              for (i = 0; i < neqtot; ++i) {
+                b[ktot[i] - 1] = (qb[i] - volddof[ktot[i] - 1]) / (*tinc);
+              }
+              SFREE(qb);
+              SFREE(volddof);
+            }
+          }
+          if (*ithermal > 1) {
+            for (k = neq[0]; k < neq[1]; ++k) {
+              b[k] = b[k] * dtime / adb[k];
+            }
+          }
+        }
       }
       //     for(k=0;k<neq[1];++k){printf("b=%" ITGFORMAT ",%f\n",k,b[k]);}
-      
+
       /* mortar */
 
-      if(*mortar>1){	    
-  
-	/* restoring the structure of the original stiffness
+      if (*mortar > 1) {
+
+        /* restoring the structure of the original stiffness
 	   matrix */
 
-	for(i=0;i<3;i++){
-	  nzs[i]=nzstemp[i];}
-	for (i=0;i<neq[1];i++){jq[i]=jqtemp[i];icol[i]=icoltemp[i];}
-	jq[neq[1]]=jqtemp[neq[1]];
-	for (i=0;i<nzs[1];i++){irow[i]=irowtemp[i];}
-	SFREE(jqtemp);SFREE(irowtemp);SFREE(icoltemp);
-	iflagact=iflagact_old;
+        for (i = 0; i < 3; i++) {
+          nzs[i] = nzstemp[i];
+        }
+        for (i = 0; i < neq[1]; i++) {
+          jq[i]   = jqtemp[i];
+          icol[i] = icoltemp[i];
+        }
+        jq[neq[1]] = jqtemp[neq[1]];
+        for (i = 0; i < nzs[1]; i++) {
+          irow[i] = irowtemp[i];
+        }
+        SFREE(jqtemp);
+        SFREE(irowtemp);
+        SFREE(icoltemp);
+        iflagact = iflagact_old;
 
-	/* trafo util->u , calculate cstress and update active set  */
+        /* trafo util->u , calculate cstress and update active set  */
 
-	stressmortar(bhat,adc2,auc2,jqc2,irowc2,neq,gap,b,islavact,irowddinv,
-		     jqddinv,auddinv,irowtloc,jqtloc,autloc,irowtlocinv,
-		     jqtlocinv,autlocinv,ntie,nslavnode,islavnode,nmastnode,
-		     imastnode,slavnor,slavtan,nactdof,&iflagact,cstress,
-		     cstressini,mi,cdisp,f_cs,f_cm,&iit,&iinc,vold,vini,bp,
-		     nk,&nboun2,ndirboun2,nodeboun2,xboun2,&nmpc2,ipompc2,
-		     nodempc2,coefmpc2,ikboun2,ilboun2,ikmpc2,ilmpc2,nmpc,
-		     ipompc,nodempc,coefmpc,ikboun,ilboun,ikmpc,ilmpc,
-		     nslavspc2,islavspc2,&nsspc2,nslavmpc2,islavmpc2,&nsmpc2,
-		     nmastspc,imastspc,&nmspc,nmastmpc,imastmpc,&nmmpc,
-		     tieset,elcon,tietol,ncmat_,ntmat_,plicon,nplicon,npmat_,
-		     nelcon,&dtime,cfs,cfm,islavnodeinv,Bd,irowb,jqb,Dd,
-		     irowd,jqd,Ddtil,irowdtil,jqdtil,Bdtil,irowbtil,jqbtil,
-		     Bpgd,irowbpg,jqbpg,Dpgd,irowdpg,jqdpg,lambdaiwan,
-		     lambdaiwanini,nmethod,&bet,&iflagdualquad,ithermal,
-		     iperturb,labmpc,labmpc2,cam,veold,accold,&gam,&nk2,
-		     cfsini,cfstil,plkcon,nplkcon,filab,f,fn,qa,nprint,prlab,
-		     xforc,nforc);
-	iflagact_old=iflagact;
-	  
-	SFREE(auc2);SFREE(adc2);SFREE(irowc2);SFREE(icolc2);SFREE(jqc2);
-	SFREE(au);SFREE(ad);	  
-	if(ismallsliding==0){
-	  SFREE(aubd);SFREE(jqbd);SFREE(irowbd);
-	  SFREE(aubdtil);SFREE(jqbdtil);SFREE(irowbdtil);
-	  SFREE(aubdtil2);SFREE(jqbdtil2);SFREE(irowbdtil2);
-	  SFREE(audd);SFREE(jqdd);SFREE(irowdd);
-	  SFREE(auddinv);SFREE(jqddinv);SFREE(irowddinv);
-	  SFREE(auddtil);SFREE(jqddtil);SFREE(irowddtil);
-	  SFREE(auddtil2);SFREE(jqddtil2);SFREE(irowddtil2);
-	}
+        stressmortar(bhat, adc2, auc2, jqc2, irowc2, neq, gap, b, islavact, irowddinv,
+                     jqddinv, auddinv, irowtloc, jqtloc, autloc, irowtlocinv,
+                     jqtlocinv, autlocinv, ntie, nslavnode, islavnode, nmastnode,
+                     imastnode, slavnor, slavtan, nactdof, &iflagact, cstress,
+                     cstressini, mi, cdisp, f_cs, f_cm, &iit, &iinc, vold, vini, bp,
+                     nk, &nboun2, ndirboun2, nodeboun2, xboun2, &nmpc2, ipompc2,
+                     nodempc2, coefmpc2, ikboun2, ilboun2, ikmpc2, ilmpc2, nmpc,
+                     ipompc, nodempc, coefmpc, ikboun, ilboun, ikmpc, ilmpc,
+                     nslavspc2, islavspc2, &nsspc2, nslavmpc2, islavmpc2, &nsmpc2,
+                     nmastspc, imastspc, &nmspc, nmastmpc, imastmpc, &nmmpc,
+                     tieset, elcon, tietol, ncmat_, ntmat_, plicon, nplicon, npmat_,
+                     nelcon, &dtime, cfs, cfm, islavnodeinv, Bd, irowb, jqb, Dd,
+                     irowd, jqd, Ddtil, irowdtil, jqdtil, Bdtil, irowbtil, jqbtil,
+                     Bpgd, irowbpg, jqbpg, Dpgd, irowdpg, jqdpg, lambdaiwan,
+                     lambdaiwanini, nmethod, &bet, &iflagdualquad, ithermal,
+                     iperturb, labmpc, labmpc2, cam, veold, accold, &gam, &nk2,
+                     cfsini, cfstil, plkcon, nplkcon, filab, f, fn, qa, nprint, prlab,
+                     xforc, nforc);
+        iflagact_old = iflagact;
+
+        SFREE(auc2);
+        SFREE(adc2);
+        SFREE(irowc2);
+        SFREE(icolc2);
+        SFREE(jqc2);
+        SFREE(au);
+        SFREE(ad);
+        if (ismallsliding == 0) {
+          SFREE(aubd);
+          SFREE(jqbd);
+          SFREE(irowbd);
+          SFREE(aubdtil);
+          SFREE(jqbdtil);
+          SFREE(irowbdtil);
+          SFREE(aubdtil2);
+          SFREE(jqbdtil2);
+          SFREE(irowbdtil2);
+          SFREE(audd);
+          SFREE(jqdd);
+          SFREE(irowdd);
+          SFREE(auddinv);
+          SFREE(jqddinv);
+          SFREE(irowddinv);
+          SFREE(auddtil);
+          SFREE(jqddtil);
+          SFREE(irowddtil);
+          SFREE(auddtil2);
+          SFREE(jqddtil2);
+          SFREE(irowddtil2);
+        }
       }
 
       /* calculating the displacements, stresses and forces */
-      
-      MNEW(v,double,mt**nk);
-      isiz=mt**nk;cpypardou(v,vold,&isiz,&num_cpus);
-      
-      NNEW(stx,double,6*mi[0]**ne);
-      MNEW(fn,double,mt**nk);
-      
-      if(ne1d2d==1)NNEW(inum,ITG,*nk);
-      results(co,nk,kon,ipkon,lakon,ne,v,stn,inum,stx,
-	      elcon,nelcon,rhcon,nrhcon,alcon,nalcon,alzero,ielmat,
-	      ielorien,norien,orab,ntmat_,t0,t1act,ithermal,
-	      prestr,iprestr,filab,eme,emn,een,iperturb,
-	      f,fn,nactdof,&iout,qa,vold,b,nodeboun,
-	      ndirboun,xbounact,nboun,ipompc,
-	      nodempc,coefmpc,labmpc,nmpc,nmethod,cam,&neq[1],veold,accold,
-	      &bet,&gam,&dtime,&time,ttime,plicon,nplicon,plkcon,nplkcon,
-	      xstateini,xstiff,xstate,npmat_,epn,matname,mi,&ielas,
-	      &icmd,ncmat_,nstate_,stiini,vini,ikboun,ilboun,ener,enern,
-	      emeini,xstaten,eei,enerini,cocon,ncocon,set,nset,istartset,
-	      iendset,ialset,nprint,prlab,prset,qfx,qfn,trab,inotr,ntrans,
-	      fmpc,nelemload,nload,ikmpc,ilmpc,istep,&iinc,springarea,
-	      &reltime,&ne0,thicke,shcon,nshcon,
-	      sideload,xloadact,xloadold,&icfd,inomat,pslavsurf,pmastsurf,
-	      mortar,islavact,cdn,islavnode,nslavnode,ntie,clearini,
-              islavsurf,ielprop,prop,energyini,energy,&kscale,iponoel,
-              inoel,nener,orname,network,ipobody,xbodyact,ibody,typeboun,
-	      itiefac,tieset,smscale,&mscalmethod,nbody,t0g,t1g,
-	      islavelinv,autloc,irowtloc,jqtloc,&nboun2,
-	      ndirboun2,nodeboun2,xboun2,&nmpc2,ipompc2,nodempc2,coefmpc2,
-	      labmpc2,ikboun2,ilboun2,ikmpc2,ilmpc2,&mortartrafoflag,
-	      &intscheme);
-      if(ne1d2d==1)SFREE(inum);
+
+      MNEW(v, double, mt **nk);
+      isiz = mt * *nk;
+      cpypardou(v, vold, &isiz, &num_cpus);
+
+      NNEW(stx, double, 6 * mi[0] * *ne);
+      MNEW(fn, double, mt **nk);
+
+      if (ne1d2d == 1)
+        NNEW(inum, ITG, *nk);
+      results(co, nk, kon, ipkon, lakon, ne, v, stn, inum, stx,
+              elcon, nelcon, rhcon, nrhcon, alcon, nalcon, alzero, ielmat,
+              ielorien, norien, orab, ntmat_, t0, t1act, ithermal,
+              prestr, iprestr, filab, eme, emn, een, iperturb,
+              f, fn, nactdof, &iout, qa, vold, b, nodeboun,
+              ndirboun, xbounact, nboun, ipompc,
+              nodempc, coefmpc, labmpc, nmpc, nmethod, cam, &neq[1], veold, accold,
+              &bet, &gam, &dtime, &time, ttime, plicon, nplicon, plkcon, nplkcon,
+              xstateini, xstiff, xstate, npmat_, epn, matname, mi, &ielas,
+              &icmd, ncmat_, nstate_, stiini, vini, ikboun, ilboun, ener, enern,
+              emeini, xstaten, eei, enerini, cocon, ncocon, set, nset, istartset,
+              iendset, ialset, nprint, prlab, prset, qfx, qfn, trab, inotr, ntrans,
+              fmpc, nelemload, nload, ikmpc, ilmpc, istep, &iinc, springarea,
+              &reltime, &ne0, thicke, shcon, nshcon,
+              sideload, xloadact, xloadold, &icfd, inomat, pslavsurf, pmastsurf,
+              mortar, islavact, cdn, islavnode, nslavnode, ntie, clearini,
+              islavsurf, ielprop, prop, energyini, energy, &kscale, iponoel,
+              inoel, nener, orname, network, ipobody, xbodyact, ibody, typeboun,
+              itiefac, tieset, smscale, &mscalmethod, nbody, t0g, t1g,
+              islavelinv, autloc, irowtloc, jqtloc, &nboun2,
+              ndirboun2, nodeboun2, xboun2, &nmpc2, ipompc2, nodempc2, coefmpc2,
+              labmpc2, ikboun2, ilboun2, ikmpc2, ilmpc2, &mortartrafoflag,
+              &intscheme);
+      if (ne1d2d == 1)
+        SFREE(inum);
 
       /* implicit dynamics (Matteo Pacher) */
 
-      if((*ne!=ne0)&&(*nmethod==4)&&(*ithermal<2)&&(*iexpl<=1)){
-	FORTRAN(storecontactprop,(ne,&ne0,lakon,kon,ipkon,mi,ielmat,elcon,
-				  mortar,adblump,nactdof,springarea,ncmat_,
-				  ntmat_,stx,&temax));
+      if ((*ne != ne0) && (*nmethod == 4) && (*ithermal < 2) && (*iexpl <= 1)) {
+        FORTRAN(storecontactprop, (ne, &ne0, lakon, kon, ipkon, mi, ielmat, elcon,
+                                   mortar, adblump, nactdof, springarea, ncmat_,
+                                   ntmat_, stx, &temax));
       }
 
       /* updating the external work (only for dynamic calculations) */
 
-      if((*nmethod==4)&&(*ithermal<2)){
-	allwk=allwkini;
-	worparll(&allwk,fnext,&mt,fnextini,v,vini,nk,&num_cpus);
+      if ((*nmethod == 4) && (*ithermal < 2)) {
+        allwk = allwkini;
+        worparll(&allwk, fnext, &mt, fnextini, v, vini, nk, &num_cpus);
 
         /* Work due to damping forces (cv and cvini) --> MPADD */
 
-	if(idamping==1){
-	  dampwk=dampwkini;
-	  dam1parll(&mt,nactdof,aux2,v,vini,nk,&num_cpus);
-	  dam2parll(&dampwk,cv,cvini,aux2,&neq[0],&num_cpus);
-	}
+        if (idamping == 1) {
+          dampwk = dampwkini;
+          dam1parll(&mt, nactdof, aux2, v, vini, nk, &num_cpus);
+          dam2parll(&dampwk, cv, cvini, aux2, &neq[0], &num_cpus);
+        }
         /* Damping forces --> MPADD */
       }
 
       /* line search (only for static surface-to-surface penalty contact)
          and not in the first iteration */
 
-      if((*mortar==1)&&(iit!=1)&&(*ne-ne0>0)&&(*nmethod!=4)){
+      if ((*mortar == 1) && (iit != 1) && (*ne - ne0 > 0) && (*nmethod != 4)) {
 
-	SFREE(v);SFREE(stx);SFREE(fn);
-      
-	/* calculating the residual */
-      
-	NNEW(res,double,neq[1]);
-	calcresidual(nmethod,neq,res,fext,f,iexpl,nactdof,aux2,vold,vini,
-		     &dtime,accold,nk,adb,aub,jq,irow,nzl,alpha,fextini,fini,
-		     islavnode,nslavnode,mortar,ntie,f_cm,f_cs,mi,nzs,&nasym,
-		     &idamping,veold,adc,auc,cvini,cv,&alpham,&num_cpus);
+        SFREE(v);
+        SFREE(stx);
+        SFREE(fn);
 
-	/* calculating the line search factor */
+        /* calculating the residual */
 
-	sum1=0.;sum2=0.;
-	for(i=0;i<neq[1];i++){
-	  sum1+=b[i]*resold[i];
-	  sum2+=b[i]*res[i];
-	}
-	SFREE(res);
+        NNEW(res, double, neq[1]);
+        calcresidual(nmethod, neq, res, fext, f, iexpl, nactdof, aux2, vold, vini,
+                     &dtime, accold, nk, adb, aub, jq, irow, nzl, alpha, fextini, fini,
+                     islavnode, nslavnode, mortar, ntie, f_cm, f_cs, mi, nzs, &nasym,
+                     &idamping, veold, adc, auc, cvini, cv, &alpham, &num_cpus);
 
-	if(fabs(sum1-sum2)<1.e-30){
-	  flinesearch=1.;
-	}else{
-	  flinesearch=sum1/(sum1-sum2);
-	  if(flinesearch>smaxls){
-	    flinesearch=smaxls;
-	  }else if(flinesearch<sminls){
-	    flinesearch=sminls;
-	  }
-	}
-	printf("line search factor=%f\n\n",flinesearch);
+        /* calculating the line search factor */
 
-	/* update the solution */
+        sum1 = 0.;
+        sum2 = 0.;
+        for (i = 0; i < neq[1]; i++) {
+          sum1 += b[i] * resold[i];
+          sum2 += b[i] * res[i];
+        }
+        SFREE(res);
 
-	for(i=0;i<neq[1];i++){
-	  b[i]*=flinesearch;}
-      
-	MNEW(v,double,mt**nk);
-	isiz=mt**nk;cpypardou(v,vold,&isiz,&num_cpus);
-	  
-	NNEW(stx,double,6*mi[0]**ne);
-	MNEW(fn,double,mt**nk);
-	  
-	if(ne1d2d==1)NNEW(inum,ITG,*nk);
-	results(co,nk,kon,ipkon,lakon,ne,v,stn,inum,stx,
-		elcon,nelcon,rhcon,nrhcon,alcon,nalcon,alzero,ielmat,
-		ielorien,norien,orab,ntmat_,t0,t1act,ithermal,
-		prestr,iprestr,filab,eme,emn,een,iperturb,
-		f,fn,nactdof,&iout,qa,vold,b,nodeboun,
-		ndirboun,xbounact,nboun,ipompc,
-		nodempc,coefmpc,labmpc,nmpc,nmethod,cam,&neq[1],veold,accold,
-		&bet,&gam,&dtime,&time,ttime,plicon,nplicon,plkcon,nplkcon,
-		xstateini,xstiff,xstate,npmat_,epn,matname,mi,&ielas,
-		&icmd,ncmat_,nstate_,stiini,vini,ikboun,ilboun,ener,enern,
-		emeini,xstaten,eei,enerini,cocon,ncocon,set,nset,istartset,
-		iendset,ialset,nprint,prlab,prset,qfx,qfn,trab,inotr,ntrans,
-		fmpc,nelemload,nload,ikmpc,ilmpc,istep,&iinc,springarea,
-		&reltime,&ne0,thicke,shcon,nshcon,
-		sideload,xloadact,xloadold,&icfd,inomat,pslavsurf,pmastsurf,
-		mortar,islavact,cdn,islavnode,nslavnode,ntie,clearini,
-		islavsurf,ielprop,prop,energyini,energy,&kscale,iponoel,
-		inoel,nener,orname,network,ipobody,xbodyact,ibody,typeboun,
-		itiefac,tieset,smscale,&mscalmethod,nbody,t0g,t1g,
-		islavelinv,autloc,irowtloc,jqtloc,&nboun2,
-		ndirboun2,nodeboun2,xboun2,&nmpc2,ipompc2,nodempc2,coefmpc2,
-		labmpc2,ikboun2,ilboun2,ikmpc2,ilmpc2,&mortartrafoflag,
-		&intscheme);
-	if(ne1d2d==1)SFREE(inum);
+        if (fabs(sum1 - sum2) < 1.e-30) {
+          flinesearch = 1.;
+        } else {
+          flinesearch = sum1 / (sum1 - sum2);
+          if (flinesearch > smaxls) {
+            flinesearch = smaxls;
+          } else if (flinesearch < sminls) {
+            flinesearch = sminls;
+          }
+        }
+        printf("line search factor=%f\n\n", flinesearch);
+
+        /* update the solution */
+
+        for (i = 0; i < neq[1]; i++) {
+          b[i] *= flinesearch;
+        }
+
+        MNEW(v, double, mt **nk);
+        isiz = mt * *nk;
+        cpypardou(v, vold, &isiz, &num_cpus);
+
+        NNEW(stx, double, 6 * mi[0] * *ne);
+        MNEW(fn, double, mt **nk);
+
+        if (ne1d2d == 1)
+          NNEW(inum, ITG, *nk);
+        results(co, nk, kon, ipkon, lakon, ne, v, stn, inum, stx,
+                elcon, nelcon, rhcon, nrhcon, alcon, nalcon, alzero, ielmat,
+                ielorien, norien, orab, ntmat_, t0, t1act, ithermal,
+                prestr, iprestr, filab, eme, emn, een, iperturb,
+                f, fn, nactdof, &iout, qa, vold, b, nodeboun,
+                ndirboun, xbounact, nboun, ipompc,
+                nodempc, coefmpc, labmpc, nmpc, nmethod, cam, &neq[1], veold, accold,
+                &bet, &gam, &dtime, &time, ttime, plicon, nplicon, plkcon, nplkcon,
+                xstateini, xstiff, xstate, npmat_, epn, matname, mi, &ielas,
+                &icmd, ncmat_, nstate_, stiini, vini, ikboun, ilboun, ener, enern,
+                emeini, xstaten, eei, enerini, cocon, ncocon, set, nset, istartset,
+                iendset, ialset, nprint, prlab, prset, qfx, qfn, trab, inotr, ntrans,
+                fmpc, nelemload, nload, ikmpc, ilmpc, istep, &iinc, springarea,
+                &reltime, &ne0, thicke, shcon, nshcon,
+                sideload, xloadact, xloadold, &icfd, inomat, pslavsurf, pmastsurf,
+                mortar, islavact, cdn, islavnode, nslavnode, ntie, clearini,
+                islavsurf, ielprop, prop, energyini, energy, &kscale, iponoel,
+                inoel, nener, orname, network, ipobody, xbodyact, ibody, typeboun,
+                itiefac, tieset, smscale, &mscalmethod, nbody, t0g, t1g,
+                islavelinv, autloc, irowtloc, jqtloc, &nboun2,
+                ndirboun2, nodeboun2, xboun2, &nmpc2, ipompc2, nodempc2, coefmpc2,
+                labmpc2, ikboun2, ilboun2, ikmpc2, ilmpc2, &mortartrafoflag,
+                &intscheme);
+        if (ne1d2d == 1)
+          SFREE(inum);
       }
-      
+
       /* calculating the residual */
-      
-      calcresidual(nmethod,neq,b,fext,f,iexpl,nactdof,aux2,vold,
-		   vini,&dtime,accold,nk,adb,aub,jq,irow,nzl,alpha,fextini,fini,
-		   islavnode,nslavnode,mortar,ntie,f_cm,f_cs,mi,
-		   nzs,&nasym,&idamping,veold,adc,auc,cvini,cv,&alpham,
-		   &num_cpus);
+
+      calcresidual(nmethod, neq, b, fext, f, iexpl, nactdof, aux2, vold,
+                   vini, &dtime, accold, nk, adb, aub, jq, irow, nzl, alpha, fextini, fini,
+                   islavnode, nslavnode, mortar, ntie, f_cm, f_cs, mi,
+                   nzs, &nasym, &idamping, veold, adc, auc, cvini, cv, &alpham,
+                   &num_cpus);
 
       /* fix residuals for mortar contact, add contact forces */
-      
-      if(*mortar>1){
-	for(k=0;k<neq[1];k++){
-	  b[k]=b[k]-f_cs[k]-f_cm[k];}
-      }	 
 
-      isiz=mt**nk;cpypardou(vold,v,&isiz,&num_cpus);
-      if(*ithermal!=2){
-	for(k=0;k<6*mi[0]*ne0;++k){
-	  sti[k]=stx[k];
-	}
+      if (*mortar > 1) {
+        for (k = 0; k < neq[1]; k++) {
+          b[k] = b[k] - f_cs[k] - f_cm[k];
+        }
       }
-      
+
+      isiz = mt * *nk;
+      cpypardou(vold, v, &isiz, &num_cpus);
+      if (*ithermal != 2) {
+        for (k = 0; k < 6 * mi[0] * ne0; ++k) {
+          sti[k] = stx[k];
+        }
+      }
+
       /* calculating the ratio of the smallest to largest pressure
          for face-to-face contact
          only done at the end of a step */
 
-      if((*mortar==1)&&(1.-theta-dtheta<=1.e-6)){
-	FORTRAN(negativepressure,(&ne0,ne,mi,stx,&pressureratio));
-      }else{pressureratio=0.;}
-
-      SFREE(v);SFREE(stx);SFREE(fn);
-
-      if((idamping==1)&&(*iexpl<=1)){SFREE(adc);SFREE(auc);}
-
-      if(*iexpl<=1){
-	  
-	/* store the residual forces for the next iteration */
-
-	if(*ithermal!=2){
-	  if(cam[0]>uam[0]){
-	    uam[0]=cam[0];}      
-	  if(qau<1.e-10){
-	    if(qa[0]>ea*qam[0]){
-	      qam[0]=(qamold[0]*jnz+qa[0])/(jnz+1);}
-	    else {
-	      qam[0]=qamold[0];}
-	  }
-	}
-	if(*ithermal>1){
-	  if(cam[1]>uam[1]){
-	    uam[1]=cam[1];}      
-	  if(qau<1.e-10){
-	    if(qa[1]>ea*qam[1]){
-	      qam[1]=(qamold[1]*jnz+qa[1])/(jnz+1);}
-	    else {
-	      qam[1]=qamold[1];}
-	  }
-	}
-      
-	/* calculating the maximum residual */
-
-	for(k=0;k<2;++k){
-	  ram2[k]=ram1[k];
-	  ram1[k]=ram[k];
-	  ram[k]=0.;
-	}
-	if(*ithermal!=2){
-	  for(k=0;k<neq[0];++k){
-	    err=fabs(b[k]);
-	    if(err>ram[0]){
-	      ram[0]=err;
-	      ram[2]=k+0.5;}
-	  }
-	}
-	if(*ithermal>1){
-	  for(k=neq[0];k<neq[1];++k){
-	    err=fabs(b[k]);
-	    if(err>ram[1]){
-	      ram[1]=err;
-	      ram[3]=k+0.5;}
-	  }
-	}
-	  
-	/*   Divergence criteria for face-to-face penalty is different */
-	  
-	if(*mortar==1){
-	  for(k=4;k<6;++k){
-	    ram2[k]=ram1[k];
-	    ram1[k]=ram[k];
-	  } 
-	  ram[4]=ram[0]+ram1[0];
-	  ram[5]=(*ne-ne0)-(neold-ne0)+0.5;
-	}
-	  
-	/* next line is inserted to cope with stress-less
-	   temperature calculations */
-	  
-	if(*ithermal!=2){
-	  if(ram[0]<1.e-6){
-	    ram[0]=0.;} 
-	  printf(" average force= %f\n",qa[0]);
-	  printf(" time avg. forc= %f\n",qam[0]);
-	  if((ITG)((double)nactdofinv[(ITG)ram[2]]/mt)+1==0){
-	    printf(" largest residual force= %f\n",
-		   ram[0]);
-	  }else{
-	    inode=(ITG)((double)nactdofinv[(ITG)ram[2]]/mt)+1;
-	    idir=nactdofinv[(ITG)ram[2]]-mt*(inode-1);
-	    printf(" largest residual force= %f in node %" ITGFORMAT
-		   " and dof %" ITGFORMAT "\n",
-		   ram[0],inode,idir);
-	  }
-	  printf(" largest increment of disp= %e\n",uam[0]);
-	  if((ITG)cam[3]==0){
-	    printf(" largest correction to disp= %e\n\n",
-		   cam[0]);
-	  }else{
-	    inode=(ITG)((double)nactdofinv[(ITG)cam[3]]/mt)+1;
-	    idir=nactdofinv[(ITG)cam[3]]-mt*(inode-1);
-	    printf(" largest correction to disp= %e in node %" ITGFORMAT
-		   " and dof %" ITGFORMAT "\n\n",cam[0],inode,idir);
-	  }
-	}
-	if(*ithermal>1){
-	  if(ram[1]<1.e-6){
-	    ram[1]=0.;}      
-	  printf(" average flux= %f\n",qa[1]);
-	  printf(" time avg. flux= %f\n",qam[1]);
-	  if((ITG)((double)nactdofinv[(ITG)ram[3]]/mt)+1==0){
-	    printf(" largest residual flux= %f\n",
-		   ram[1]);
-	  }else{
-	    inode=(ITG)((double)nactdofinv[(ITG)ram[3]]/mt)+1;
-	    idir=nactdofinv[(ITG)ram[3]]-mt*(inode-1);
-	    printf(" largest residual flux= %f in node %" ITGFORMAT
-		   " and dof %" ITGFORMAT "\n",ram[1],inode,idir);
-	  }
-	  printf(" largest increment of temp= %e\n",uam[1]);
-	  if((ITG)cam[4]==0){
-	    printf(" largest correction to temp= %e\n\n",
-		   cam[1]);
-	  }else{
-	    inode=(ITG)((double)nactdofinv[(ITG)cam[4]]/mt)+1;
-	    idir=nactdofinv[(ITG)cam[4]]-mt*(inode-1);
-	    printf(" largest correction to temp= %e in node %" ITGFORMAT
-		   " and dof %" ITGFORMAT "\n\n",cam[1],inode,idir);
-	  }
-	}
-	fflush(stdout);
-	  
-	FORTRAN(writecvg,(istep,&iinc,&icutb,&iit,ne,&ne0,ram,qam,cam,uam,
-			  ithermal));
-
-	//      printf(" in nonlingeo.c a stop was inserted \n");
-	//      FORTRAN(stop,());
-
-	checkconvergence(co,nk,kon,ipkon,lakon,ne,stn,nmethod, 
-			 kode,filab,een,t1act,&time,epn,ielmat,matname,enern, 
-			 xstaten,nstate_,istep,&iinc,iperturb,ener,mi,output,
-			 ithermal,qfn,&mode,&noddiam,trab,inotr,ntrans,orab,
-			 ielorien,norien,description,sti,&icutb,&iit,&dtime,qa,
-			 vold,qam,ram1,ram2,ram,cam,uam,&ntg,ttime,&icntrl,
-			 &theta,&dtheta,veold,vini,idrct,tper,&istab,tmax, 
-			 nactdof,b,tmin,ctrl,amta,namta,itpamp,inext,&dthetaref,
-			 &itp,&jprint,jout,&uncoupled,t1,&iitterm,nelemload,
-			 nload,nodeboun,nboun,itg,ndirboun,&deltmx,&iflagact,
-			 set,nset,istartset,iendset,ialset,emn,thicke,jobnamec,
-			 mortar,nmat,ielprop,prop,&ialeatoric,&kscale,
-			 energy,&allwk,&energyref,&emax,&r_abs,&enetoll,
-			 energyini,
-			 &allwkini,&temax,&sizemaxinc,&ne0,&neini,&dampwk,
-			 &dampwkini,energystartstep);
-
-	if(*mortar>1){
-	  SFREE(f_cs);SFREE(f_cm);
-	} 
-	  
-      }else{
-
-	/* explicit dynamics */
-
-	icntrl=1;
-	icutb=0;   
-
-	theta=theta+dtheta;  
-	if(dtheta>=1.-theta){
-	  if(dtheta>1.-theta){
-	    printf(" the increment size exceeds the remainder of the step and is decreased to %e\n\n",
-		   dtheta**tper);
-	  }
-	  dtheta=1.-theta;
-	  dthetaref=dtheta;
-	}
-	iflagact=0;
+      if ((*mortar == 1) && (1. - theta - dtheta <= 1.e-6)) {
+        FORTRAN(negativepressure, (&ne0, ne, mi, stx, &pressureratio));
+      } else {
+        pressureratio = 0.;
       }
 
-      if(*mortar==-1){SFREE(auw);SFREE(jqw);SFREE(iroww);}
-      
+      SFREE(v);
+      SFREE(stx);
+      SFREE(fn);
+
+      if ((idamping == 1) && (*iexpl <= 1)) {
+        SFREE(adc);
+        SFREE(auc);
+      }
+
+      if (*iexpl <= 1) {
+
+        /* store the residual forces for the next iteration */
+
+        if (*ithermal != 2) {
+          if (cam[0] > uam[0]) {
+            uam[0] = cam[0];
+          }
+          if (qau < 1.e-10) {
+            if (qa[0] > ea * qam[0]) {
+              qam[0] = (qamold[0] * jnz + qa[0]) / (jnz + 1);
+            } else {
+              qam[0] = qamold[0];
+            }
+          }
+        }
+        if (*ithermal > 1) {
+          if (cam[1] > uam[1]) {
+            uam[1] = cam[1];
+          }
+          if (qau < 1.e-10) {
+            if (qa[1] > ea * qam[1]) {
+              qam[1] = (qamold[1] * jnz + qa[1]) / (jnz + 1);
+            } else {
+              qam[1] = qamold[1];
+            }
+          }
+        }
+
+        /* calculating the maximum residual */
+
+        for (k = 0; k < 2; ++k) {
+          ram2[k] = ram1[k];
+          ram1[k] = ram[k];
+          ram[k]  = 0.;
+        }
+        if (*ithermal != 2) {
+          for (k = 0; k < neq[0]; ++k) {
+            err = fabs(b[k]);
+            if (err > ram[0]) {
+              ram[0] = err;
+              ram[2] = k + 0.5;
+            }
+          }
+        }
+        if (*ithermal > 1) {
+          for (k = neq[0]; k < neq[1]; ++k) {
+            err = fabs(b[k]);
+            if (err > ram[1]) {
+              ram[1] = err;
+              ram[3] = k + 0.5;
+            }
+          }
+        }
+
+        /*   Divergence criteria for face-to-face penalty is different */
+
+        if (*mortar == 1) {
+          for (k = 4; k < 6; ++k) {
+            ram2[k] = ram1[k];
+            ram1[k] = ram[k];
+          }
+          ram[4] = ram[0] + ram1[0];
+          ram[5] = (*ne - ne0) - (neold - ne0) + 0.5;
+        }
+
+        /* next line is inserted to cope with stress-less
+	   temperature calculations */
+
+        if (*ithermal != 2) {
+          if (ram[0] < 1.e-6) {
+            ram[0] = 0.;
+          }
+          printf(" average force= %f\n", qa[0]);
+          printf(" time avg. forc= %f\n", qam[0]);
+          if ((ITG)((double) nactdofinv[(ITG) ram[2]] / mt) + 1 == 0) {
+            printf(" largest residual force= %f\n",
+                   ram[0]);
+          } else {
+            inode = (ITG)((double) nactdofinv[(ITG) ram[2]] / mt) + 1;
+            idir  = nactdofinv[(ITG) ram[2]] - mt * (inode - 1);
+            printf(" largest residual force= %f in node %" ITGFORMAT
+                   " and dof %" ITGFORMAT "\n",
+                   ram[0], inode, idir);
+          }
+          printf(" largest increment of disp= %e\n", uam[0]);
+          if ((ITG) cam[3] == 0) {
+            printf(" largest correction to disp= %e\n\n",
+                   cam[0]);
+          } else {
+            inode = (ITG)((double) nactdofinv[(ITG) cam[3]] / mt) + 1;
+            idir  = nactdofinv[(ITG) cam[3]] - mt * (inode - 1);
+            printf(" largest correction to disp= %e in node %" ITGFORMAT
+                   " and dof %" ITGFORMAT "\n\n",
+                   cam[0], inode, idir);
+          }
+        }
+        if (*ithermal > 1) {
+          if (ram[1] < 1.e-6) {
+            ram[1] = 0.;
+          }
+          printf(" average flux= %f\n", qa[1]);
+          printf(" time avg. flux= %f\n", qam[1]);
+          if ((ITG)((double) nactdofinv[(ITG) ram[3]] / mt) + 1 == 0) {
+            printf(" largest residual flux= %f\n",
+                   ram[1]);
+          } else {
+            inode = (ITG)((double) nactdofinv[(ITG) ram[3]] / mt) + 1;
+            idir  = nactdofinv[(ITG) ram[3]] - mt * (inode - 1);
+            printf(" largest residual flux= %f in node %" ITGFORMAT
+                   " and dof %" ITGFORMAT "\n",
+                   ram[1], inode, idir);
+          }
+          printf(" largest increment of temp= %e\n", uam[1]);
+          if ((ITG) cam[4] == 0) {
+            printf(" largest correction to temp= %e\n\n",
+                   cam[1]);
+          } else {
+            inode = (ITG)((double) nactdofinv[(ITG) cam[4]] / mt) + 1;
+            idir  = nactdofinv[(ITG) cam[4]] - mt * (inode - 1);
+            printf(" largest correction to temp= %e in node %" ITGFORMAT
+                   " and dof %" ITGFORMAT "\n\n",
+                   cam[1], inode, idir);
+          }
+        }
+        fflush(stdout);
+
+        FORTRAN(writecvg, (istep, &iinc, &icutb, &iit, ne, &ne0, ram, qam, cam, uam,
+                           ithermal));
+
+        //      printf(" in nonlingeo.c a stop was inserted \n");
+        //      FORTRAN(stop,());
+
+        checkconvergence(co, nk, kon, ipkon, lakon, ne, stn, nmethod,
+                         kode, filab, een, t1act, &time, epn, ielmat, matname, enern,
+                         xstaten, nstate_, istep, &iinc, iperturb, ener, mi, output,
+                         ithermal, qfn, &mode, &noddiam, trab, inotr, ntrans, orab,
+                         ielorien, norien, description, sti, &icutb, &iit, &dtime, qa,
+                         vold, qam, ram1, ram2, ram, cam, uam, &ntg, ttime, &icntrl,
+                         &theta, &dtheta, veold, vini, idrct, tper, &istab, tmax,
+                         nactdof, b, tmin, ctrl, amta, namta, itpamp, inext, &dthetaref,
+                         &itp, &jprint, jout, &uncoupled, t1, &iitterm, nelemload,
+                         nload, nodeboun, nboun, itg, ndirboun, &deltmx, &iflagact,
+                         set, nset, istartset, iendset, ialset, emn, thicke, jobnamec,
+                         mortar, nmat, ielprop, prop, &ialeatoric, &kscale,
+                         energy, &allwk, &energyref, &emax, &r_abs, &enetoll,
+                         energyini,
+                         &allwkini, &temax, &sizemaxinc, &ne0, &neini, &dampwk,
+                         &dampwkini, energystartstep);
+
+        if (*mortar > 1) {
+          SFREE(f_cs);
+          SFREE(f_cm);
+        }
+
+      } else {
+
+        /* explicit dynamics */
+
+        icntrl = 1;
+        icutb  = 0;
+
+        theta = theta + dtheta;
+        if (dtheta >= 1. - theta) {
+          if (dtheta > 1. - theta) {
+            printf(" the increment size exceeds the remainder of the step and is decreased to %e\n\n",
+                   dtheta * *tper);
+          }
+          dtheta    = 1. - theta;
+          dthetaref = dtheta;
+        }
+        iflagact = 0;
+      }
+
+      if (*mortar == -1) {
+        SFREE(auw);
+        SFREE(jqw);
+        SFREE(iroww);
+      }
     }
 
-    if(*nmethod!=4)SFREE(resold);
+    if (*nmethod != 4)
+      SFREE(resold);
 
     /*********************************************************/
     /*   end of the iteration loop                          */
@@ -3438,469 +3663,545 @@ void nonlingeo_precice(double **cop, ITG *nk, ITG **konp, ITG **ipkonp, char **l
        icutb!=0 indicates that the increment has to be reiterated with
        another increment size (dtheta) */
 
-    if(*mortar>1){
-      if(ismallsliding==1){      
-	SFREE(aubd);SFREE(jqbd);SFREE(irowbd);
-	SFREE(aubdtil);SFREE(jqbdtil);SFREE(irowbdtil);
-	SFREE(aubdtil2);SFREE(jqbdtil2);SFREE(irowbdtil2);
-	SFREE(audd);SFREE(jqdd);SFREE(irowdd);
-	SFREE(auddinv);SFREE(jqddinv);SFREE(irowddinv);
-	SFREE(auddtil);SFREE(jqddtil);SFREE(irowddtil);
-	SFREE(auddtil2);SFREE(jqddtil2);SFREE(irowddtil2);
+    if (*mortar > 1) {
+      if (ismallsliding == 1) {
+        SFREE(aubd);
+        SFREE(jqbd);
+        SFREE(irowbd);
+        SFREE(aubdtil);
+        SFREE(jqbdtil);
+        SFREE(irowbdtil);
+        SFREE(aubdtil2);
+        SFREE(jqbdtil2);
+        SFREE(irowbdtil2);
+        SFREE(audd);
+        SFREE(jqdd);
+        SFREE(irowdd);
+        SFREE(auddinv);
+        SFREE(jqddinv);
+        SFREE(irowddinv);
+        SFREE(auddtil);
+        SFREE(jqddtil);
+        SFREE(irowddtil);
+        SFREE(auddtil2);
+        SFREE(jqddtil2);
+        SFREE(irowddtil2);
       }
-      SFREE(bhat);	  
+      SFREE(bhat);
       SFREE(islavactdof);
-    }   
-	
-	/* Adapter: Copy necessary data for coupling */
-	simulationData.fn = fn;
-    memcpy(&vold[0],&v[0],sizeof(double)*mt**nk);
+    }
 
-	Precice_WriteCouplingData( &simulationData );
+    /* Adapter: Copy necessary data for coupling */
+    simulationData.fn = fn;
+    memcpy(&vold[0], &v[0], sizeof(double) * mt * *nk);
+
+    Precice_WriteCouplingData(&simulationData);
     /* Adapter: Advance the coupling */
-    Precice_Advance( &simulationData );
+    Precice_Advance(&simulationData);
     /* Adapter: If the coupling does not converge, read the checkpoint */
-    if( Precice_IsReadCheckpointRequired() )
-    {
-        if( *nmethod == 4 )
-        {
-            Precice_ReadIterationCheckpoint( &simulationData, vold );
-            icutb++;
-        }
-        Precice_FulfilledReadCheckpoint();
+    if (Precice_IsReadCheckpointRequired()) {
+      if (*nmethod == 4) {
+        Precice_ReadIterationCheckpoint(&simulationData, vold);
+        icutb++;
+      }
+      Precice_FulfilledReadCheckpoint();
     }
     /* printing the energies (only for dynamic calculations) */
 
-    if((icutb==0)&&(*nmethod==4)&&(*ithermal<2)&&(jout[0]==jprint)){
+    if ((icutb == 0) && (*nmethod == 4) && (*ithermal < 2) && (jout[0] == jprint)) {
 
-      if(*iexpl>1){
-	printf(" actual total time=%e\n\n",*ttime+theta**tper);
+      if (*iexpl > 1) {
+        printf(" actual total time=%e\n\n", *ttime + theta * *tper);
       }
-	
-      printf(" initial energy (at start of step) = %e\n\n",energyref);
+
+      printf(" initial energy (at start of step) = %e\n\n", energyref);
 
       printf(" since start of the step: \n");
-      printf(" external work = %e\n",allwk);
-      printf(" work performed by the damping forces = %e\n",dampwk);
-      printf(" netto work = %e\n\n",allwk+dampwk);
+      printf(" external work = %e\n", allwk);
+      printf(" work performed by the damping forces = %e\n", dampwk);
+      printf(" netto work = %e\n\n", allwk + dampwk);
 
       printf(" actual energy: \n");
-      printf(" internal energy = %e\n",energy[0]);
-      printf(" kinetic energy = %e\n",energy[1]);
-      printf(" elastic contact energy = %e\n",energy[2]);
-      printf(" energy lost due to friction = %e\n",energy[3]);
-      printf(" total energy  = %e\n\n",energy[0]+energy[1]+energy[2]+energy[3]);
+      printf(" internal energy = %e\n", energy[0]);
+      printf(" kinetic energy = %e\n", energy[1]);
+      printf(" elastic contact energy = %e\n", energy[2]);
+      printf(" energy lost due to friction = %e\n", energy[3]);
+      printf(" total energy  = %e\n\n", energy[0] + energy[1] + energy[2] + energy[3]);
 
-      printf(" energy increase = %e\n\n",energy[0]+energy[1]+energy[2]
-	     +energy[3]-energyref);
+      printf(" energy increase = %e\n\n", energy[0] + energy[1] + energy[2] + energy[3] - energyref);
 
-      printf(" energy balance (absolute) = %e \n",energy[0]+energy[1]
-	     +energy[2]+energy[3]-energyref-allwk-dampwk);
+      printf(" energy balance (absolute) = %e \n", energy[0] + energy[1] + energy[2] + energy[3] - energyref - allwk - dampwk);
 
       /* Belytschko criterion */
 
-      denergymax=energy[0];
-      if(denergymax<energy[1]){
-	denergymax=energy[1];}
-      if(denergymax<fabs(allwk)) denergymax=fabs(allwk);
-
-      if(denergymax>ea*energym){
-	energym=(energymold*jnz+denergymax)/(jnz+1);}
-      else {
-	energym=energymold;}
-      energymold=energym;   
-
-      if(energym>1.e-30){
-	printf(" energy balance (relative) = %f %% \n\n",
-	       fabs((energy[0]+energy[1]+energy[2]+energy[3]-energyref-allwk
-		     -dampwk)/energym*100.));
-      }else{
-	printf(" energy balance (relative) =0 %% \n\n");
+      denergymax = energy[0];
+      if (denergymax < energy[1]) {
+        denergymax = energy[1];
       }
-	
+      if (denergymax < fabs(allwk))
+        denergymax = fabs(allwk);
+
+      if (denergymax > ea * energym) {
+        energym = (energymold * jnz + denergymax) / (jnz + 1);
+      } else {
+        energym = energymold;
+      }
+      energymold = energym;
+
+      if (energym > 1.e-30) {
+        printf(" energy balance (relative) = %f %% \n\n",
+               fabs((energy[0] + energy[1] + energy[2] + energy[3] - energyref - allwk - dampwk) / energym * 100.));
+      } else {
+        printf(" energy balance (relative) =0 %% \n\n");
+      }
+
       /*Energy balance to evaluate mass scaling*/
-      
-      if((mscalmethod==1)||(mscalmethod==3)){
-	printf(" artificial energy due to selective mass scaling = %e\n",
-	       energy[4]);
-	    
-	printf(" energy balance with mass scaling(relative) = %f %% \n\n",
-	       fabs((energy[0]+energy[1]+energy[2]+energy[3]+energy[4]
-		     -energyref-allwk-dampwk)/energym*100.));
-	    
+
+      if ((mscalmethod == 1) || (mscalmethod == 3)) {
+        printf(" artificial energy due to selective mass scaling = %e\n",
+               energy[4]);
+
+        printf(" energy balance with mass scaling(relative) = %f %% \n\n",
+               fabs((energy[0] + energy[1] + energy[2] + energy[3] + energy[4] - energyref - allwk - dampwk) / energym * 100.));
       }
-	
-      // # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # 
+
+      // # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
       //    MPADD start
       //	printf(" work done by the damping forces = %e\n", dampwk);
-      //	neini=*ne; 
+      //	neini=*ne;
       //	printf(" contact elements end of increment = %"ITGFORMAT"\n\n", *ne - ne0);
       //    MPADD end
       // # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
-
     }
 
-    if(uncoupled){
+    if (uncoupled) {
       SFREE(iruc);
     }
 
-    if(((qa[0]>ea*qam[0])||(qa[1]>ea*qam[1]))&&(icutb==0)){jnz++;}
-    iit=0;
+    if (((qa[0] > ea * qam[0]) || (qa[1] > ea * qam[1])) && (icutb == 0)) {
+      jnz++;
+    }
+    iit = 0;
 
-    if(icutb!=0){
-      isiz=mt**nk;cpypardou(vold,vini,&isiz,&num_cpus);
+    if (icutb != 0) {
+      isiz = mt * *nk;
+      cpypardou(vold, vini, &isiz, &num_cpus);
 
-      isiz=*nboun;cpypardou(xbounact,xbounini,&isiz,&num_cpus);
-      if((*ithermal==1)||(*ithermal>=3)){
-	isiz=*nk;cpypardou(t1act,t1ini,&isiz,&num_cpus);
+      isiz = *nboun;
+      cpypardou(xbounact, xbounini, &isiz, &num_cpus);
+      if ((*ithermal == 1) || (*ithermal >= 3)) {
+        isiz = *nk;
+        cpypardou(t1act, t1ini, &isiz, &num_cpus);
       }
-      isiz=neq[1];cpypardou(f,fini,&isiz,&num_cpus);
-      if(*nmethod==4){
-	isiz=mt**nk;
-	cpypardou(veold,veini,&isiz,&num_cpus);
-	cpypardou(accold,accini,&isiz,&num_cpus);
-	isiz=neq[1];
-	cpypardou(fext,fextini,&isiz,&num_cpus);
-	cpypardou(cv,cvini,&isiz,&num_cpus);
-	if(*ithermal<2){
-	  allwk=allwkini;
-	  if(idamping==1)dampwk=dampwkini;
-	  for(k=0;k<4;k++){
-	    energy[k]=energyini[k];
-	  }
-	}
+      isiz = neq[1];
+      cpypardou(f, fini, &isiz, &num_cpus);
+      if (*nmethod == 4) {
+        isiz = mt * *nk;
+        cpypardou(veold, veini, &isiz, &num_cpus);
+        cpypardou(accold, accini, &isiz, &num_cpus);
+        isiz = neq[1];
+        cpypardou(fext, fextini, &isiz, &num_cpus);
+        cpypardou(cv, cvini, &isiz, &num_cpus);
+        if (*ithermal < 2) {
+          allwk = allwkini;
+          if (idamping == 1)
+            dampwk = dampwkini;
+          for (k = 0; k < 4; k++) {
+            energy[k] = energyini[k];
+          }
+        }
       }
-      if(*ithermal!=2){
-	isiz=6*mi[0]*ne0;
-	cpypardou(sti,stiini,&isiz,&num_cpus);
-	cpypardou(eme,emeini,&isiz,&num_cpus);
+      if (*ithermal != 2) {
+        isiz = 6 * mi[0] * ne0;
+        cpypardou(sti, stiini, &isiz, &num_cpus);
+        cpypardou(eme, emeini, &isiz, &num_cpus);
       }
-      if(*nener==1){
-	isiz=mi[0]*ne0;cpypardou(ener,enerini,&isiz,&num_cpus);}
+      if (*nener == 1) {
+        isiz = mi[0] * ne0;
+        cpypardou(ener, enerini, &isiz, &num_cpus);
+      }
 
-      isiz=*nstate_*mi[0]*(ne0+maxprevcontel);cpypardou(xstate,xstateini,
-							&isiz,&num_cpus);
+      isiz = *nstate_ * mi[0] * (ne0 + maxprevcontel);
+      cpypardou(xstate, xstateini,
+                &isiz, &num_cpus);
 
-      qam[0]=qamold[0];
-      qam[1]=qamold[1];
+      qam[0] = qamold[0];
+      qam[1] = qamold[1];
 
-      if(*mortar>1){
-	for (i=0;i<*ntie;i++){
-	  for(j=nslavnode[i];j<nslavnode[i+1];j++){
-	    islavact[j]=islavactini[j];
-	    bp[j]=bpini[j];
-	    for(k=0;k<mt;k++){
-	      cstress[mt*j+k]=cstressini[mt*j+k];
-	    }
-	  }    
-	} 
-	if(iflag_fric==1){
-	  for(i=0;i<3*iwan*nslavnode[*ntie];i++){
-	    lambdaiwan[i]=lambdaiwanini[i];      
-	  }
-	}
+      if (*mortar > 1) {
+        for (i = 0; i < *ntie; i++) {
+          for (j = nslavnode[i]; j < nslavnode[i + 1]; j++) {
+            islavact[j] = islavactini[j];
+            bp[j]       = bpini[j];
+            for (k = 0; k < mt; k++) {
+              cstress[mt * j + k] = cstressini[mt * j + k];
+            }
+          }
+        }
+        if (iflag_fric == 1) {
+          for (i = 0; i < 3 * iwan * nslavnode[*ntie]; i++) {
+            lambdaiwan[i] = lambdaiwanini[i];
+          }
+        }
       }
     }
-    
+
     /* face-to-face penalty */
 
-    if((*mortar==1)&&(icutb==0)){
-	
-      ntrimax=0;
-      for(i=0;i<*ntie;i++){	    
-	if(itietri[2*i+1]-itietri[2*i]+1>ntrimax)		
-	  ntrimax=itietri[2*i+1]-itietri[2*i]+1;  	
+    if ((*mortar == 1) && (icutb == 0)) {
+
+      ntrimax = 0;
+      for (i = 0; i < *ntie; i++) {
+        if (itietri[2 * i + 1] - itietri[2 * i] + 1 > ntrimax)
+          ntrimax = itietri[2 * i + 1] - itietri[2 * i] + 1;
       }
-      MNEW(xo,double,ntrimax);	    
-      MNEW(yo,double,ntrimax);	    
-      MNEW(zo,double,ntrimax);	    
-      MNEW(x,double,ntrimax);	    
-      MNEW(y,double,ntrimax);	    
-      MNEW(z,double,ntrimax);	   
-      MNEW(nx,ITG,ntrimax);	   
-      MNEW(ny,ITG,ntrimax);	    
-      MNEW(nz,ITG,ntrimax);
-      
+      MNEW(xo, double, ntrimax);
+      MNEW(yo, double, ntrimax);
+      MNEW(zo, double, ntrimax);
+      MNEW(x, double, ntrimax);
+      MNEW(y, double, ntrimax);
+      MNEW(z, double, ntrimax);
+      MNEW(nx, ITG, ntrimax);
+      MNEW(ny, ITG, ntrimax);
+      MNEW(nz, ITG, ntrimax);
+
       /*  Determination of active nodes (islavact) */
 
       //            printf("nonlingeo iinc=%d\n",iinc);
-      
-      FORTRAN(islavactive,(tieset,ntie,itietri,cg,straight,
-			   co,vold,xo,yo,zo,x,y,z,nx,ny,nz,mi,
-			   imastop,nslavnode,islavnode,islavact));
 
-      SFREE(xo);SFREE(yo);SFREE(zo);SFREE(x);SFREE(y);SFREE(z);SFREE(nx);
-      SFREE(ny);SFREE(nz);
+      FORTRAN(islavactive, (tieset, ntie, itietri, cg, straight,
+                            co, vold, xo, yo, zo, x, y, z, nx, ny, nz, mi,
+                            imastop, nslavnode, islavnode, islavact));
 
-      if(negpres==0){
-	if((*mortar==1)&&(1.-theta-dtheta<=1.e-6)&&(itruecontact==1)){
-	  printf(" pressure ratio (smallest/largest pressure over all contact areas) =%e\n\n",pressureratio);
-	  if(pressureratio<-0.05){
-	    printf(" zero-size increment is appended\n\n");
-	    negpres=1;theta=1.-1.e-6;dtheta=1.e-6;
-	  }
-	}
-      }else{negpres=0;}
+      SFREE(xo);
+      SFREE(yo);
+      SFREE(zo);
+      SFREE(x);
+      SFREE(y);
+      SFREE(z);
+      SFREE(nx);
+      SFREE(ny);
+      SFREE(nz);
 
+      if (negpres == 0) {
+        if ((*mortar == 1) && (1. - theta - dtheta <= 1.e-6) && (itruecontact == 1)) {
+          printf(" pressure ratio (smallest/largest pressure over all contact areas) =%e\n\n", pressureratio);
+          if (pressureratio < -0.05) {
+            printf(" zero-size increment is appended\n\n");
+            negpres = 1;
+            theta   = 1. - 1.e-6;
+            dtheta  = 1.e-6;
+          }
+        }
+      } else {
+        negpres = 0;
+      }
     }
 
     /* output */
 
-    if((jout[0]==jprint)&&(icutb==0)){
+    if ((jout[0] == jprint) && (icutb == 0)) {
 
-      jprint=0;
+      jprint = 0;
 
       /* calculating the displacements and the stresses and storing */
       /* the results in frd format  */
-	
-      MNEW(v,double,mt**nk);
-      //      NNEW(v,double,mt**nk);
-      MNEW(fn,double,mt**nk);
-      NNEW(stn,double,6**nk);
-      if(*ithermal>1) NNEW(qfn,double,3**nk);
-      NNEW(inum,ITG,*nk);
-      NNEW(stx,double,6*mi[0]**ne);
-      
-      if(strcmp1(&filab[261],"E   ")==0) NNEW(een,double,6**nk);
-      if(strcmp1(&filab[435],"PEEQ")==0) NNEW(epn,double,*nk);
-      if(strcmp1(&filab[522],"ENER")==0) NNEW(enern,double,*nk);
-      if(strcmp1(&filab[609],"SDV ")==0) NNEW(xstaten,double,*nstate_**nk);
-      if(strcmp1(&filab[2175],"CONT")==0) NNEW(cdn,double,6**nk);
-      if(strcmp1(&filab[2697],"ME  ")==0) NNEW(emn,double,6**nk);
 
-      isiz=mt**nk;cpypardou(v,vold,&isiz,&num_cpus);
+      MNEW(v, double, mt **nk);
+      //      NNEW(v,double,mt**nk);
+      MNEW(fn, double, mt **nk);
+      NNEW(stn, double, 6 * *nk);
+      if (*ithermal > 1)
+        NNEW(qfn, double, 3 * *nk);
+      NNEW(inum, ITG, *nk);
+      NNEW(stx, double, 6 * mi[0] * *ne);
+
+      if (strcmp1(&filab[261], "E   ") == 0)
+        NNEW(een, double, 6 * *nk);
+      if (strcmp1(&filab[435], "PEEQ") == 0)
+        NNEW(epn, double, *nk);
+      if (strcmp1(&filab[522], "ENER") == 0)
+        NNEW(enern, double, *nk);
+      if (strcmp1(&filab[609], "SDV ") == 0)
+        NNEW(xstaten, double, *nstate_ **nk);
+      if (strcmp1(&filab[2175], "CONT") == 0)
+        NNEW(cdn, double, 6 * *nk);
+      if (strcmp1(&filab[2697], "ME  ") == 0)
+        NNEW(emn, double, 6 * *nk);
+
+      isiz = mt * *nk;
+      cpypardou(v, vold, &isiz, &num_cpus);
       //      memcpy(&v[0],&vold[0],sizeof(double)*mt**nk);
 
-      iout=2;
-      icmd=3;
-      
-#ifdef COMPANY
-      FORTRAN(uinit,());
-#endif
-      results(co,nk,kon,ipkon,lakon,ne,v,stn,inum,stx,
-	      elcon,nelcon,rhcon,nrhcon,alcon,nalcon,alzero,ielmat,
-	      ielorien,norien,orab,ntmat_,t0,t1act,ithermal,
-	      prestr,iprestr,filab,eme,emn,een,iperturb,
-	      f,fn,nactdof,&iout,qa,vold,b,nodeboun,
-	      ndirboun,xbounact,nboun,ipompc,
-	      nodempc,coefmpc,labmpc,nmpc,nmethod,cam,&neq[1],veold,accold,
-              &bet,&gam,&dtime,&time,ttime,plicon,nplicon,plkcon,nplkcon,
-	      xstateini,xstiff,xstate,npmat_,epn,matname,mi,&ielas,&icmd,
-	      ncmat_,nstate_,stiini,vini,ikboun,ilboun,ener,enern,emeini,
-              xstaten,eei,enerini,cocon,ncocon,set,nset,istartset,iendset,
-              ialset,nprint,prlab,prset,qfx,qfn,trab,inotr,ntrans,fmpc,
-	      nelemload,nload,ikmpc,ilmpc,istep,&iinc,springarea,
-              &reltime,&ne0,thicke,shcon,nshcon,
-              sideload,xloadact,xloadold,&icfd,inomat,pslavsurf,pmastsurf,
-              mortar,islavact,cdn,islavnode,nslavnode,ntie,clearini,
-	      islavsurf,ielprop,prop,energyini,energy,&kscale,iponoel,
-              inoel,nener,orname,network,ipobody,xbodyact,ibody,typeboun,
-	      itiefac,tieset,smscale,&mscalmethod,nbody,t0g,t1g,
-	      islavelinv,autloc,irowtloc,jqtloc,&nboun2,
-	      ndirboun2,nodeboun2,xboun2,&nmpc2,ipompc2,nodempc2,coefmpc2,
-	      labmpc2,ikboun2,ilboun2,ikmpc2,ilmpc2,&mortartrafoflag,
-	      &intscheme);
-      
-      isiz=mt**nk;cpypardou(vold,v,&isiz,&num_cpus);
+      iout = 2;
+      icmd = 3;
 
-      iout=0;
-      if(*iexpl<=1) icmd=0;
-      
+#ifdef COMPANY
+      FORTRAN(uinit, ());
+#endif
+      results(co, nk, kon, ipkon, lakon, ne, v, stn, inum, stx,
+              elcon, nelcon, rhcon, nrhcon, alcon, nalcon, alzero, ielmat,
+              ielorien, norien, orab, ntmat_, t0, t1act, ithermal,
+              prestr, iprestr, filab, eme, emn, een, iperturb,
+              f, fn, nactdof, &iout, qa, vold, b, nodeboun,
+              ndirboun, xbounact, nboun, ipompc,
+              nodempc, coefmpc, labmpc, nmpc, nmethod, cam, &neq[1], veold, accold,
+              &bet, &gam, &dtime, &time, ttime, plicon, nplicon, plkcon, nplkcon,
+              xstateini, xstiff, xstate, npmat_, epn, matname, mi, &ielas, &icmd,
+              ncmat_, nstate_, stiini, vini, ikboun, ilboun, ener, enern, emeini,
+              xstaten, eei, enerini, cocon, ncocon, set, nset, istartset, iendset,
+              ialset, nprint, prlab, prset, qfx, qfn, trab, inotr, ntrans, fmpc,
+              nelemload, nload, ikmpc, ilmpc, istep, &iinc, springarea,
+              &reltime, &ne0, thicke, shcon, nshcon,
+              sideload, xloadact, xloadold, &icfd, inomat, pslavsurf, pmastsurf,
+              mortar, islavact, cdn, islavnode, nslavnode, ntie, clearini,
+              islavsurf, ielprop, prop, energyini, energy, &kscale, iponoel,
+              inoel, nener, orname, network, ipobody, xbodyact, ibody, typeboun,
+              itiefac, tieset, smscale, &mscalmethod, nbody, t0g, t1g,
+              islavelinv, autloc, irowtloc, jqtloc, &nboun2,
+              ndirboun2, nodeboun2, xboun2, &nmpc2, ipompc2, nodempc2, coefmpc2,
+              labmpc2, ikboun2, ilboun2, ikmpc2, ilmpc2, &mortartrafoflag,
+              &intscheme);
+
+      isiz = mt * *nk;
+      cpypardou(vold, v, &isiz, &num_cpus);
+
+      iout = 0;
+      if (*iexpl <= 1)
+        icmd = 0;
+
       ++*kode;
-      if(*mcs!=0){
-	ptime=*ttime+time;
+      if (*mcs != 0) {
+        ptime = *ttime + time;
 
-	if(*mortar>1){
-	  mortar_prefrd(ne,nslavs,mi,nk,nkon,&stx,cdisp,fn,cfs,cfm);       
-	}
-	
-	frdcyc(co,nk,kon,ipkon,lakon,ne,v,stn,inum,nmethod,kode,filab,een,
-	       t1act,fn,&ptime,epn,ielmat,matname,cs,mcs,nkon,enern,xstaten,
-               nstate_,istep,&iinc,iperturb,ener,mi,output,ithermal,qfn,
-               ialset,istartset,iendset,trab,inotr,ntrans,orab,ielorien,
-	       norien,stx,veold,&noddiam,set,nset,emn,thicke,jobnamec,&ne0,
-               cdn,mortar,nmat,qfx,ielprop,prop);
+        if (*mortar > 1) {
+          mortar_prefrd(ne, nslavs, mi, nk, nkon, &stx, cdisp, fn, cfs, cfm);
+        }
 
-	if(*mortar>1){
-	  mortar_postfrd(ne,nslavs,mi,nk,nkon,fn,cfs,cfm);      
-	}
+        frdcyc(co, nk, kon, ipkon, lakon, ne, v, stn, inum, nmethod, kode, filab, een,
+               t1act, fn, &ptime, epn, ielmat, matname, cs, mcs, nkon, enern, xstaten,
+               nstate_, istep, &iinc, iperturb, ener, mi, output, ithermal, qfn,
+               ialset, istartset, iendset, trab, inotr, ntrans, orab, ielorien,
+               norien, stx, veold, &noddiam, set, nset, emn, thicke, jobnamec, &ne0,
+               cdn, mortar, nmat, qfx, ielprop, prop);
+
+        if (*mortar > 1) {
+          mortar_postfrd(ne, nslavs, mi, nk, nkon, fn, cfs, cfm);
+        }
 #ifdef COMPANY
-	FORTRAN(uout,(v,mi,ithermal,filab,kode,output,jobnamec));
+        FORTRAN(uout, (v, mi, ithermal, filab, kode, output, jobnamec));
+#endif
+      } else {
+        if (strcmp1(&filab[1044], "ZZS") == 0) {
+          NNEW(neigh, ITG, 40 * *ne);
+          MNEW(ipneigh, ITG, *nk);
+        }
+
+        ptime = *ttime + time;
+
+        if (*mortar > 1) {
+          mortar_prefrd(ne, nslavs, mi, nk, nkon, &stx, cdisp, fn, cfs, cfm);
+        }
+        frd(co, nk, kon, ipkon, lakon, &ne0, v, stn, inum, nmethod,
+            kode, filab, een, t1act, fn, &ptime, epn, ielmat, matname, enern, xstaten,
+            nstate_, istep, &iinc, ithermal, qfn, &mode, &noddiam, trab, inotr,
+            ntrans, orab, ielorien, norien, description, ipneigh, neigh,
+            mi, stx, vr, vi, stnr, stni, vmax, stnmax, &ngraph, veold, ener, ne,
+            cs, set, nset, istartset, iendset, ialset, eenmax, fnr, fni, emn,
+            thicke, jobnamec, output, qfx, cdn, mortar, cdnr, cdni, nmat, ielprop,
+            prop, sti);
+        if (*mortar > 1) {
+          mortar_postfrd(ne, nslavs, mi, nk, nkon, fn, cfs, cfm);
+        }
+
+        if (strcmp1(&filab[1044], "ZZS") == 0) {
+          SFREE(ipneigh);
+          SFREE(neigh);
+        }
+#ifdef COMPANY
+        FORTRAN(uout, (v, mi, ithermal, filab, kode, output, jobnamec));
 #endif
       }
-      else{
-	if(strcmp1(&filab[1044],"ZZS")==0){
-	  NNEW(neigh,ITG,40**ne);
-	  MNEW(ipneigh,ITG,*nk);
-	}
 
-	ptime=*ttime+time;
-
-	if(*mortar>1){
-	  mortar_prefrd(ne,nslavs,mi,nk,nkon, &stx,cdisp,fn,cfs,cfm);       
-	}
-	frd(co,nk,kon,ipkon,lakon,&ne0,v,stn,inum,nmethod,
-	    kode,filab,een,t1act,fn,&ptime,epn,ielmat,matname,enern,xstaten,
-	    nstate_,istep,&iinc,ithermal,qfn,&mode,&noddiam,trab,inotr,
-	    ntrans,orab,ielorien,norien,description,ipneigh,neigh,
-	    mi,stx,vr,vi,stnr,stni,vmax,stnmax,&ngraph,veold,ener,ne,
-	    cs,set,nset,istartset,iendset,ialset,eenmax,fnr,fni,emn,
-	    thicke,jobnamec,output,qfx,cdn,mortar,cdnr,cdni,nmat,ielprop,
-	    prop,sti);
-	if(*mortar>1){
-	  mortar_postfrd(ne,nslavs,mi,nk,nkon,fn,cfs,cfm);      
-	}
-
-	if(strcmp1(&filab[1044],"ZZS")==0){SFREE(ipneigh);SFREE(neigh);}
-#ifdef COMPANY
-	FORTRAN(uout,(v,mi,ithermal,filab,kode,output,jobnamec));
-#endif
+      SFREE(v);
+      SFREE(fn);
+      SFREE(stn);
+      SFREE(inum);
+      SFREE(stx);
+      if (*ithermal > 1) {
+        SFREE(qfn);
       }
-      
-      SFREE(v);SFREE(fn);SFREE(stn);SFREE(inum);SFREE(stx);
-      if(*ithermal>1){SFREE(qfn);}
-      
-      if(strcmp1(&filab[261],"E   ")==0) SFREE(een);
-      if(strcmp1(&filab[435],"PEEQ")==0) SFREE(epn);
-      if(strcmp1(&filab[522],"ENER")==0) SFREE(enern);
-      if(strcmp1(&filab[609],"SDV ")==0) SFREE(xstaten);
-      if(strcmp1(&filab[2175],"CONT")==0) SFREE(cdn);
-      if(strcmp1(&filab[2697],"ME  ")==0) SFREE(emn);
+
+      if (strcmp1(&filab[261], "E   ") == 0)
+        SFREE(een);
+      if (strcmp1(&filab[435], "PEEQ") == 0)
+        SFREE(epn);
+      if (strcmp1(&filab[522], "ENER") == 0)
+        SFREE(enern);
+      if (strcmp1(&filab[609], "SDV ") == 0)
+        SFREE(xstaten);
+      if (strcmp1(&filab[2175], "CONT") == 0)
+        SFREE(cdn);
+      if (strcmp1(&filab[2697], "ME  ") == 0)
+        SFREE(emn);
     }
-    
   }
 
   /*********************************************************/
   /*   end of the increment loop                          */
   /*********************************************************/
 
-  if(jprint!=0){
+  if (jprint != 0) {
 
     /* calculating the displacements and the stresses and storing  
        the results in frd format */
-  
-    MNEW(v,double,mt**nk);
-    MNEW(fn,double,mt**nk);
-    NNEW(stn,double,6**nk);
-    if(*ithermal>1) NNEW(qfn,double,3**nk);
-    NNEW(inum,ITG,*nk);
-    NNEW(stx,double,6*mi[0]**ne);
-  
-    if(strcmp1(&filab[261],"E   ")==0) NNEW(een,double,6**nk);
-    if(strcmp1(&filab[435],"PEEQ")==0) NNEW(epn,double,*nk);
-    if(strcmp1(&filab[522],"ENER")==0) NNEW(enern,double,*nk);
-    if(strcmp1(&filab[609],"SDV ")==0) NNEW(xstaten,double,*nstate_**nk);
-    if(strcmp1(&filab[2175],"CONT")==0) NNEW(cdn,double,6**nk);
-    if(strcmp1(&filab[2697],"ME  ")==0) NNEW(emn,double,6**nk);
-    
-    isiz=mt**nk;cpypardou(v,vold,&isiz,&num_cpus);
-    iout=2;
-    icmd=3;
+
+    MNEW(v, double, mt **nk);
+    MNEW(fn, double, mt **nk);
+    NNEW(stn, double, 6 * *nk);
+    if (*ithermal > 1)
+      NNEW(qfn, double, 3 * *nk);
+    NNEW(inum, ITG, *nk);
+    NNEW(stx, double, 6 * mi[0] * *ne);
+
+    if (strcmp1(&filab[261], "E   ") == 0)
+      NNEW(een, double, 6 * *nk);
+    if (strcmp1(&filab[435], "PEEQ") == 0)
+      NNEW(epn, double, *nk);
+    if (strcmp1(&filab[522], "ENER") == 0)
+      NNEW(enern, double, *nk);
+    if (strcmp1(&filab[609], "SDV ") == 0)
+      NNEW(xstaten, double, *nstate_ **nk);
+    if (strcmp1(&filab[2175], "CONT") == 0)
+      NNEW(cdn, double, 6 * *nk);
+    if (strcmp1(&filab[2697], "ME  ") == 0)
+      NNEW(emn, double, 6 * *nk);
+
+    isiz = mt * *nk;
+    cpypardou(v, vold, &isiz, &num_cpus);
+    iout = 2;
+    icmd = 3;
 
 #ifdef COMPANY
-    FORTRAN(uinit,());
+    FORTRAN(uinit, ());
 #endif
-    results(co,nk,kon,ipkon,lakon,ne,v,stn,inum,stx,
-	    elcon,nelcon,rhcon,nrhcon,alcon,nalcon,alzero,ielmat,
-	    ielorien,norien,orab,ntmat_,t0,t1act,ithermal,
-	    prestr,iprestr,filab,eme,emn,een,iperturb,
-	    f,fn,nactdof,&iout,qa,vold,b,nodeboun,
-	    ndirboun,xbounact,nboun,ipompc,
-	    nodempc,coefmpc,labmpc,nmpc,nmethod,cam,&neq[1],veold,accold,
-            &bet,&gam,&dtime,&time,ttime,plicon,nplicon,plkcon,nplkcon,
-	    xstateini,xstiff,xstate,npmat_,epn,matname,mi,&ielas,&icmd,
-            ncmat_,nstate_,stiini,vini,ikboun,ilboun,ener,enern,emeini,
-            xstaten,eei,enerini,cocon,ncocon,set,nset,istartset,iendset,
-            ialset,nprint,prlab,prset,qfx,qfn,trab,inotr,ntrans,fmpc,
-	    nelemload,nload,ikmpc,ilmpc,istep,&iinc,springarea,
-            &reltime,&ne0,thicke,shcon,nshcon,
-            sideload,xloadact,xloadold,&icfd,inomat,pslavsurf,pmastsurf,
-            mortar,islavact,cdn,islavnode,nslavnode,ntie,clearini,
-	    islavsurf,ielprop,prop,energyini,energy,&kscale,iponoel,
-            inoel,nener,orname,network,ipobody,xbodyact,ibody,typeboun,
-	    itiefac,tieset,smscale,&mscalmethod,nbody,t0g,t1g,
-	    islavelinv,autloc,irowtloc,jqtloc,&nboun2,
-	    ndirboun2,nodeboun2,xboun2,&nmpc2,ipompc2,nodempc2,coefmpc2,
-	    labmpc2,ikboun2,ilboun2,ikmpc2,ilmpc2,&mortartrafoflag,
-	    &intscheme);
-    
-    isiz=mt**nk;cpypardou(vold,v,&isiz,&num_cpus);
+    results(co, nk, kon, ipkon, lakon, ne, v, stn, inum, stx,
+            elcon, nelcon, rhcon, nrhcon, alcon, nalcon, alzero, ielmat,
+            ielorien, norien, orab, ntmat_, t0, t1act, ithermal,
+            prestr, iprestr, filab, eme, emn, een, iperturb,
+            f, fn, nactdof, &iout, qa, vold, b, nodeboun,
+            ndirboun, xbounact, nboun, ipompc,
+            nodempc, coefmpc, labmpc, nmpc, nmethod, cam, &neq[1], veold, accold,
+            &bet, &gam, &dtime, &time, ttime, plicon, nplicon, plkcon, nplkcon,
+            xstateini, xstiff, xstate, npmat_, epn, matname, mi, &ielas, &icmd,
+            ncmat_, nstate_, stiini, vini, ikboun, ilboun, ener, enern, emeini,
+            xstaten, eei, enerini, cocon, ncocon, set, nset, istartset, iendset,
+            ialset, nprint, prlab, prset, qfx, qfn, trab, inotr, ntrans, fmpc,
+            nelemload, nload, ikmpc, ilmpc, istep, &iinc, springarea,
+            &reltime, &ne0, thicke, shcon, nshcon,
+            sideload, xloadact, xloadold, &icfd, inomat, pslavsurf, pmastsurf,
+            mortar, islavact, cdn, islavnode, nslavnode, ntie, clearini,
+            islavsurf, ielprop, prop, energyini, energy, &kscale, iponoel,
+            inoel, nener, orname, network, ipobody, xbodyact, ibody, typeboun,
+            itiefac, tieset, smscale, &mscalmethod, nbody, t0g, t1g,
+            islavelinv, autloc, irowtloc, jqtloc, &nboun2,
+            ndirboun2, nodeboun2, xboun2, &nmpc2, ipompc2, nodempc2, coefmpc2,
+            labmpc2, ikboun2, ilboun2, ikmpc2, ilmpc2, &mortartrafoflag,
+            &intscheme);
 
-    iout=0;
-    if(*iexpl<=1) icmd=0;
-    
+    isiz = mt * *nk;
+    cpypardou(vold, v, &isiz, &num_cpus);
+
+    iout = 0;
+    if (*iexpl <= 1)
+      icmd = 0;
+
     ++*kode;
-    if(*mcs>0){
-      ptime=*ttime+time;
-      if(*mortar>1){
-	mortar_prefrd(ne,nslavs,mi,nk,nkon, &stx,cdisp,fn,cfs,cfm);       
+    if (*mcs > 0) {
+      ptime = *ttime + time;
+      if (*mortar > 1) {
+        mortar_prefrd(ne, nslavs, mi, nk, nkon, &stx, cdisp, fn, cfs, cfm);
       }
-      frdcyc(co,nk,kon,ipkon,lakon,ne,v,stn,inum,nmethod,kode,filab,een,
-	     t1act,fn,&ptime,epn,ielmat,matname,cs,mcs,nkon,enern,xstaten,
-             nstate_,istep,&iinc,iperturb,ener,mi,output,ithermal,qfn,
-             ialset,istartset,iendset,trab,inotr,ntrans,orab,ielorien,
-	     norien,stx,veold,&noddiam,set,nset,emn,thicke,jobnamec,&ne0,
-             cdn,mortar,nmat,qfx,ielprop,prop);
-      if(*mortar>1){
-	mortar_postfrd(ne,nslavs,mi,nk,nkon,fn,cfs,cfm);      
+      frdcyc(co, nk, kon, ipkon, lakon, ne, v, stn, inum, nmethod, kode, filab, een,
+             t1act, fn, &ptime, epn, ielmat, matname, cs, mcs, nkon, enern, xstaten,
+             nstate_, istep, &iinc, iperturb, ener, mi, output, ithermal, qfn,
+             ialset, istartset, iendset, trab, inotr, ntrans, orab, ielorien,
+             norien, stx, veold, &noddiam, set, nset, emn, thicke, jobnamec, &ne0,
+             cdn, mortar, nmat, qfx, ielprop, prop);
+      if (*mortar > 1) {
+        mortar_postfrd(ne, nslavs, mi, nk, nkon, fn, cfs, cfm);
       }
 #ifdef COMPANY
-      FORTRAN(uout,(v,mi,ithermal,filab,kode,output,jobnamec));
+      FORTRAN(uout, (v, mi, ithermal, filab, kode, output, jobnamec));
 #endif
 
-    }else{
-      if(strcmp1(&filab[1044],"ZZS")==0){
-	NNEW(neigh,ITG,40**ne);
-	MNEW(ipneigh,ITG,*nk);
+    } else {
+      if (strcmp1(&filab[1044], "ZZS") == 0) {
+        NNEW(neigh, ITG, 40 * *ne);
+        MNEW(ipneigh, ITG, *nk);
       }
 
-      ptime=*ttime+time;
-      if(*mortar>1){
-	mortar_prefrd(ne,nslavs,mi,nk,nkon, &stx,cdisp,fn,cfs,cfm);       
+      ptime = *ttime + time;
+      if (*mortar > 1) {
+        mortar_prefrd(ne, nslavs, mi, nk, nkon, &stx, cdisp, fn, cfs, cfm);
       }
-      frd(co,nk,kon,ipkon,lakon,&ne0,v,stn,inum,nmethod,
-	  kode,filab,een,t1act,fn,&ptime,epn,ielmat,matname,enern,xstaten,
-	  nstate_,istep,&iinc,ithermal,qfn,&mode,&noddiam,trab,inotr,
-	  ntrans,orab,ielorien,norien,description,ipneigh,neigh,
-	  mi,stx,vr,vi,stnr,stni,vmax,stnmax,&ngraph,veold,ener,ne,
-	  cs,set,nset,istartset,iendset,ialset,eenmax,fnr,fni,emn,
-	  thicke,jobnamec,output,qfx,cdn,mortar,cdnr,cdni,nmat,ielprop,
-	  prop,sti);
-      if(*mortar>1){
-	mortar_postfrd(ne,nslavs,mi,nk,nkon,fn,cfs,cfm);      
+      frd(co, nk, kon, ipkon, lakon, &ne0, v, stn, inum, nmethod,
+          kode, filab, een, t1act, fn, &ptime, epn, ielmat, matname, enern, xstaten,
+          nstate_, istep, &iinc, ithermal, qfn, &mode, &noddiam, trab, inotr,
+          ntrans, orab, ielorien, norien, description, ipneigh, neigh,
+          mi, stx, vr, vi, stnr, stni, vmax, stnmax, &ngraph, veold, ener, ne,
+          cs, set, nset, istartset, iendset, ialset, eenmax, fnr, fni, emn,
+          thicke, jobnamec, output, qfx, cdn, mortar, cdnr, cdni, nmat, ielprop,
+          prop, sti);
+      if (*mortar > 1) {
+        mortar_postfrd(ne, nslavs, mi, nk, nkon, fn, cfs, cfm);
       }
 
-      if(strcmp1(&filab[1044],"ZZS")==0){SFREE(ipneigh);SFREE(neigh);}
+      if (strcmp1(&filab[1044], "ZZS") == 0) {
+        SFREE(ipneigh);
+        SFREE(neigh);
+      }
 #ifdef COMPANY
-      FORTRAN(uout,(v,mi,ithermal,filab,kode,output,jobnamec));
+      FORTRAN(uout, (v, mi, ithermal, filab, kode, output, jobnamec));
 #endif
     }
 
-    SFREE(v);SFREE(fn);SFREE(stn);SFREE(inum);SFREE(stx);
-    if(*ithermal>1){SFREE(qfn);}
-    
-    if(strcmp1(&filab[261],"E   ")==0) SFREE(een);
-    if(strcmp1(&filab[435],"PEEQ")==0) SFREE(epn);
-    if(strcmp1(&filab[522],"ENER")==0) SFREE(enern);
-    if(strcmp1(&filab[609],"SDV ")==0) SFREE(xstaten);
-    if(strcmp1(&filab[2175],"CONT")==0) SFREE(cdn);
-    if(strcmp1(&filab[2697],"ME  ")==0) SFREE(emn);
+    SFREE(v);
+    SFREE(fn);
+    SFREE(stn);
+    SFREE(inum);
+    SFREE(stx);
+    if (*ithermal > 1) {
+      SFREE(qfn);
+    }
 
+    if (strcmp1(&filab[261], "E   ") == 0)
+      SFREE(een);
+    if (strcmp1(&filab[435], "PEEQ") == 0)
+      SFREE(epn);
+    if (strcmp1(&filab[522], "ENER") == 0)
+      SFREE(enern);
+    if (strcmp1(&filab[609], "SDV ") == 0)
+      SFREE(xstaten);
+    if (strcmp1(&filab[2175], "CONT") == 0)
+      SFREE(cdn);
+    if (strcmp1(&filab[2697], "ME  ") == 0)
+      SFREE(emn);
   }
-    
+
   /* writing out the latest stiffness matrix for a subsequent
      sensitivity analysis */
 
-  if(isensitivity){
-      
-    strcpy(stiffmatrix,jobnamec);
-    strcat(stiffmatrix,".stm");
-      
-    if((f1=fopen(stiffmatrix,"wb"))==NULL){
+  if (isensitivity) {
+
+    strcpy(stiffmatrix, jobnamec);
+    strcat(stiffmatrix, ".stm");
+
+    if ((f1 = fopen(stiffmatrix, "wb")) == NULL) {
       printf("*ERROR in linstatic: cannot open stiffness matrix file for writing...");
       exit(0);
     }
-      
+
     /* storing the stiffness matrix */
 
     /* nzs,irow,jq and icol have to be stored too, since the static analysis
@@ -3908,326 +4209,522 @@ void nonlingeo_precice(double **cop, ITG *nk, ITG **konp, ITG **ipkonp, char **l
        taken into account while determining the structure of the stiffness
        matrix (in mastruct.c)
     */
-      
-    if(fwrite(&nasym,sizeof(ITG),1,f1)!=1){
+
+    if (fwrite(&nasym, sizeof(ITG), 1, f1) != 1) {
       printf("*ERROR saving the symmetry flag to the stiffness matrix file...");
       exit(0);
     }
-    if(fwrite(nzs,sizeof(ITG),3,f1)!=3){
+    if (fwrite(nzs, sizeof(ITG), 3, f1) != 3) {
       printf("*ERROR saving the number of subdiagonal nonzeros to the stiffness matrix file...");
       exit(0);
     }
-    if(fwrite(irow,sizeof(ITG),nzs[2],f1)!=nzs[2]){
+    if (fwrite(irow, sizeof(ITG), nzs[2], f1) != nzs[2]) {
       printf("*ERROR saving irow to the stiffness matrix file...");
       exit(0);
     }
-    if(fwrite(jq,sizeof(ITG),neq[1]+1,f1)!=neq[1]+1){
+    if (fwrite(jq, sizeof(ITG), neq[1] + 1, f1) != neq[1] + 1) {
       printf("*ERROR saving jq to the stiffness matrix file...");
       exit(0);
     }
-    if(fwrite(icol,sizeof(ITG),neq[1],f1)!=neq[1]){
+    if (fwrite(icol, sizeof(ITG), neq[1], f1) != neq[1]) {
       printf("*ERROR saving icol to the stiffness matrix file...");
       exit(0);
     }
-    if(fwrite(adcpy,sizeof(double),neq[1],f1)!=neq[1]){
+    if (fwrite(adcpy, sizeof(double), neq[1], f1) != neq[1]) {
       printf("*ERROR saving the diagonal of the stiffness matrix to the stiffness matrix file...");
       exit(0);
     }
-    if(fwrite(aucpy,sizeof(double),(nasym+1)*nzs[2],f1)!=(nasym+1)*nzs[2]){
+    if (fwrite(aucpy, sizeof(double), (nasym + 1) * nzs[2], f1) != (nasym + 1) * nzs[2]) {
       printf("*ERROR saving the off-diagonal terms of the stiffness matrix to the stiffness matrix file...");
       exit(0);
     }
     fclose(f1);
-    SFREE(adcpy);SFREE(aucpy);
+    SFREE(adcpy);
+    SFREE(aucpy);
   }
-  
+
   /* restoring the distributed loading  */
 
-  if((*ithermal==3)&&(ncont!=0)&&(*mortar==1)&&(*ncmat_>=11)){
-    *nload=nloadref;
-    RENEW(nelemload,ITG,2**nload);
-    isiz=2**nload;cpyparitg(nelemload,nelemloadref,&isiz,&num_cpus);
-    if(*nam>0){
-      RENEW(iamload,ITG,2**nload);
-      isiz=2**nload;cpyparitg(iamload,iamloadref,&isiz,&num_cpus);
+  if ((*ithermal == 3) && (ncont != 0) && (*mortar == 1) && (*ncmat_ >= 11)) {
+    *nload = nloadref;
+    RENEW(nelemload, ITG, 2 * *nload);
+    isiz = 2 * *nload;
+    cpyparitg(nelemload, nelemloadref, &isiz, &num_cpus);
+    if (*nam > 0) {
+      RENEW(iamload, ITG, 2 * *nload);
+      isiz = 2 * *nload;
+      cpyparitg(iamload, iamloadref, &isiz, &num_cpus);
     }
-    RENEW(sideload,char,20**nload);memcpy(&sideload[0],&sideloadref[0],
-					  sizeof(char)*20**nload);
-      
+    RENEW(sideload, char, 20 * *nload);
+    memcpy(&sideload[0], &sideloadref[0],
+           sizeof(char) * 20 * *nload);
+
     /* freeing the temporary fields */
-      
-    SFREE(nelemloadref);if(*nam>0){SFREE(iamloadref);};
+
+    SFREE(nelemloadref);
+    if (*nam > 0) {
+      SFREE(iamloadref);
+    };
     SFREE(sideloadref);
   }
 
   /* setting the velocity to zero at the end of a quasistatic or stationary
      step */
 
-  if(abs(*nmethod)==1){
-    for(k=0;k<mt**nk;++k){
-      veold[k]=0.;}
+  if (abs(*nmethod) == 1) {
+    for (k = 0; k < mt * *nk; ++k) {
+      veold[k] = 0.;
+    }
   }
 
   /* updating the loading at the end of the step; 
      important in case the amplitude at the end of the step
      is not equal to one */
 
-  for(k=0;k<*nboun;++k){
+  for (k = 0; k < *nboun; ++k) {
 
     /* thermal boundary conditions are updated only if the
        step was thermal or thermomechanical */
 
-    if(ndirboun[k]==0){
-      if(*ithermal<2) continue;
+    if (ndirboun[k] == 0) {
+      if (*ithermal < 2)
+        continue;
 
       /* mechanical boundary conditions are updated only
 	 if the step was not thermal or the node is a
 	 network node */
 
-    }else if((ndirboun[k]>0)&&(ndirboun[k]<4)){
-      node=nodeboun[k];
-      FORTRAN(nident,(itg,&node,&ntg,&id));
-      networknode=0;
-      if(id>0){
-	if(itg[id-1]==node) networknode=1;
+    } else if ((ndirboun[k] > 0) && (ndirboun[k] < 4)) {
+      node = nodeboun[k];
+      FORTRAN(nident, (itg, &node, &ntg, &id));
+      networknode = 0;
+      if (id > 0) {
+        if (itg[id - 1] == node)
+          networknode = 1;
       }
-      if((*ithermal==2)&&(networknode==0)) continue;
+      if ((*ithermal == 2) && (networknode == 0))
+        continue;
     }
-    xbounold[k]=xbounact[k];
+    xbounold[k] = xbounact[k];
   }
-  isiz=*nforc;cpypardou(xforcold,xforcact,&isiz,&num_cpus);
-  isiz=2**nload;cpypardou(xloadold,xloadact,&isiz,&num_cpus);
-  isiz=7**nbody;cpypardou(xbodyold,xbodyact,&isiz,&num_cpus);
-  if(*ithermal==1){
-    cpypardou(t1old,t1act,nk,&num_cpus);
-    for(k=0;k<*nk;++k){
-      vold[mt*k]=t1act[k];}
-  }
-  else if(*ithermal>1){
-    for(k=0;k<*nk;++k){
-      t1[k]=vold[mt*k];}
-    if(*ithermal>=3){
-      cpypardou(t1old,t1act,nk,&num_cpus);
+  isiz = *nforc;
+  cpypardou(xforcold, xforcact, &isiz, &num_cpus);
+  isiz = 2 * *nload;
+  cpypardou(xloadold, xloadact, &isiz, &num_cpus);
+  isiz = 7 * *nbody;
+  cpypardou(xbodyold, xbodyact, &isiz, &num_cpus);
+  if (*ithermal == 1) {
+    cpypardou(t1old, t1act, nk, &num_cpus);
+    for (k = 0; k < *nk; ++k) {
+      vold[mt * k] = t1act[k];
+    }
+  } else if (*ithermal > 1) {
+    for (k = 0; k < *nk; ++k) {
+      t1[k] = vold[mt * k];
+    }
+    if (*ithermal >= 3) {
+      cpypardou(t1old, t1act, nk, &num_cpus);
     }
   }
 
-  qaold[0]=qa[0];
-  qaold[1]=qa[1];
+  qaold[0] = qa[0];
+  qaold[1] = qa[1];
 
   /*CC: DEBUG close energy.txt*/
- // TODO CMT also add for massless?
-  
-  if(*iexpl>1){
+  // TODO CMT also add for massless?
+
+  if (*iexpl > 1) {
     SFREE(smscale);
 
-    if((mscalmethod==1)||(mscalmethod==3)){
-      if(*isolver==0){
+    if ((mscalmethod == 1) || (mscalmethod == 3)) {
+      if (*isolver == 0) {
 #ifdef SPOOLES
-	spooles_cleanup();
+        spooles_cleanup();
 #endif
-      }
-      else if(*isolver==4){
+      } else if (*isolver == 4) {
 #ifdef SGI
-	sgi_cleanup(token);
+        sgi_cleanup(token);
 #endif
-      }
-      else if(*isolver==5){
+      } else if (*isolver == 5) {
 #ifdef TAUCS
-	tau_cleanup();
+        tau_cleanup();
 #endif
-      }
-      else if(*isolver==7){
+      } else if (*isolver == 7) {
 #ifdef PARDISO
-	pardiso_cleanup(&neq[0],&symmetryflag,&inputformat);
+        pardiso_cleanup(&neq[0], &symmetryflag, &inputformat);
 #endif
-      }
-      else if(*isolver==8){
+      } else if (*isolver == 8) {
 #ifdef PASTIX
 #endif
       }
     }
   }
-  
-  SFREE(f);SFREE(b);
-  SFREE(xbounact);SFREE(xforcact);SFREE(xloadact);SFREE(xbodyact);
-  
+
+  SFREE(f);
+  SFREE(b);
+  SFREE(xbounact);
+  SFREE(xforcact);
+  SFREE(xloadact);
+  SFREE(xbodyact);
+
   //  if(*nbody>0) SFREE(ipobody);
 
-  if(*inewton==1){SFREE(cgr);}
-  SFREE(fext);SFREE(ampli);SFREE(xbounini);SFREE(xstiff);
-  if((*ithermal==1)||(*ithermal>=3)){SFREE(t1act);SFREE(t1ini);}
+  if (*inewton == 1) {
+    SFREE(cgr);
+  }
+  SFREE(fext);
+  SFREE(ampli);
+  SFREE(xbounini);
+  SFREE(xstiff);
+  if ((*ithermal == 1) || (*ithermal >= 3)) {
+    SFREE(t1act);
+    SFREE(t1ini);
+  }
 
-  if(*ithermal>1){
-    SFREE(itg);SFREE(ieg);SFREE(kontri);SFREE(nloadtr);
-    SFREE(nactdog);SFREE(nacteq);SFREE(ineighe);
-    SFREE(tarea);SFREE(tenv);SFREE(fenv);SFREE(qfx);
-    SFREE(erad);SFREE(ac);SFREE(bc);SFREE(ipiv);
-    SFREE(bcr);SFREE(ipivr);SFREE(adview);SFREE(auview);SFREE(adrad);
-    SFREE(aurad);SFREE(irowrad);SFREE(jqrad);SFREE(icolrad);
-    if((*mcs>0)&&(ntr>0)){SFREE(inocs);}
-    if((*network>0)||(ntg>0)){SFREE(iponoel);SFREE(inoel);}
-    if(ntr>0){
+  if (*ithermal > 1) {
+    SFREE(itg);
+    SFREE(ieg);
+    SFREE(kontri);
+    SFREE(nloadtr);
+    SFREE(nactdog);
+    SFREE(nacteq);
+    SFREE(ineighe);
+    SFREE(tarea);
+    SFREE(tenv);
+    SFREE(fenv);
+    SFREE(qfx);
+    SFREE(erad);
+    SFREE(ac);
+    SFREE(bc);
+    SFREE(ipiv);
+    SFREE(bcr);
+    SFREE(ipivr);
+    SFREE(adview);
+    SFREE(auview);
+    SFREE(adrad);
+    SFREE(aurad);
+    SFREE(irowrad);
+    SFREE(jqrad);
+    SFREE(icolrad);
+    if ((*mcs > 0) && (ntr > 0)) {
+      SFREE(inocs);
+    }
+    if ((*network > 0) || (ntg > 0)) {
+      SFREE(iponoel);
+      SFREE(inoel);
+    }
+    if (ntr > 0) {
     }
   }
 
-  if(icfd==1){
-  }else if(icfd==2){
-    SFREE(sideface);SFREE(nelemface);SFREE(ifreestream);
-    SFREE(isolidsurf);SFREE(neighsolidsurf);SFREE(iponoelf);SFREE(inoelf);
-    SFREE(inomat);SFREE(ipface);
-    if(*ithermal==1) SFREE(qfx);
-	 
-    SFREE(ipkonf);SFREE(lakonf);SFREE(ielmatf);SFREE(nelold);SFREE(nelnew);
-    SFREE(cof);SFREE(voldf);SFREE(nkold);SFREE(nknew);SFREE(konf);
-    SFREE(ipompcf);SFREE(nodempcf);SFREE(coefmpcf);SFREE(nodebounf);
-    SFREE(ndirbounf);SFREE(xbounf);SFREE(nelemloadf);SFREE(xloadf);
-    SFREE(sideloadf);SFREE(ikbounf);SFREE(ilbounf);
-    SFREE(ikmpcf);SFREE(ilmpcf);SFREE(xbounoldf);SFREE(xbounactf);
-    SFREE(xloadoldf);SFREE(xloadactf);SFREE(inotrf);
-    if(*norien>0) SFREE(ielorienf);
-    if(*nbody>0) SFREE(ipobodyf);
-    if(*nam>0){SFREE(iambounf);SFREE(iamloadf);}
+  if (icfd == 1) {
+  } else if (icfd == 2) {
+    SFREE(sideface);
+    SFREE(nelemface);
+    SFREE(ifreestream);
+    SFREE(isolidsurf);
+    SFREE(neighsolidsurf);
+    SFREE(iponoelf);
+    SFREE(inoelf);
+    SFREE(inomat);
+    SFREE(ipface);
+    if (*ithermal == 1)
+      SFREE(qfx);
+
+    SFREE(ipkonf);
+    SFREE(lakonf);
+    SFREE(ielmatf);
+    SFREE(nelold);
+    SFREE(nelnew);
+    SFREE(cof);
+    SFREE(voldf);
+    SFREE(nkold);
+    SFREE(nknew);
+    SFREE(konf);
+    SFREE(ipompcf);
+    SFREE(nodempcf);
+    SFREE(coefmpcf);
+    SFREE(nodebounf);
+    SFREE(ndirbounf);
+    SFREE(xbounf);
+    SFREE(nelemloadf);
+    SFREE(xloadf);
+    SFREE(sideloadf);
+    SFREE(ikbounf);
+    SFREE(ilbounf);
+    SFREE(ikmpcf);
+    SFREE(ilmpcf);
+    SFREE(xbounoldf);
+    SFREE(xbounactf);
+    SFREE(xloadoldf);
+    SFREE(xloadactf);
+    SFREE(inotrf);
+    if (*norien > 0)
+      SFREE(ielorienf);
+    if (*nbody > 0)
+      SFREE(ipobodyf);
+    if (*nam > 0) {
+      SFREE(iambounf);
+      SFREE(iamloadf);
+    }
   }
 
   SFREE(fini);
-  if(*nmethod==4){
-    SFREE(aux2);SFREE(fextini);SFREE(veini);SFREE(accini);
-    SFREE(adb);SFREE(aub);SFREE(cvini);SFREE(cv);SFREE(fnext);
+  if (*nmethod == 4) {
+    SFREE(aux2);
+    SFREE(fextini);
+    SFREE(veini);
+    SFREE(accini);
+    SFREE(adb);
+    SFREE(aub);
+    SFREE(cvini);
+    SFREE(cv);
+    SFREE(fnext);
     SFREE(fnextini);
   }
-  SFREE(eei);SFREE(stiini);SFREE(emeini);
-  if(*nener==1)SFREE(enerini);
-  if(*nstate_!=0){SFREE(xstateini);}
-
-  SFREE(aux);SFREE(iaux);SFREE(vini);
-
-  if(icascade==2){
-    memmpc_=memmpcref_;mpcfree=mpcfreeref;maxlenmpc=maxlenmpcref;
-    RENEW(nodempc,ITG,3*memmpcref_);
-    for(k=0;k<3*memmpcref_;k++){
-      nodempc[k]=nodempcref[k];}
-    RENEW(coefmpc,double,memmpcref_);
-    for(k=0;k<memmpcref_;k++){
-      coefmpc[k]=coefmpcref[k];}
-    SFREE(nodempcref);SFREE(coefmpcref);
+  SFREE(eei);
+  SFREE(stiini);
+  SFREE(emeini);
+  if (*nener == 1)
+    SFREE(enerini);
+  if (*nstate_ != 0) {
+    SFREE(xstateini);
   }
 
-  if(ncont!=0){
-    *ne=ne0;*nkon=nkon0;
-    if(*nener==1){
-      RENEW(ener,double,mi[0]**ne*2);
-    }
-    RENEW(ipkon,ITG,*ne);
-    RENEW(lakon,char,8**ne);
-    RENEW(kon,ITG,*nkon);
-    if(*norien>0){
-      RENEW(ielorien,ITG,mi[2]**ne);
-    }
-    RENEW(ielmat,ITG,mi[2]**ne);
+  SFREE(aux);
+  SFREE(iaux);
+  SFREE(vini);
 
-    if(*mortar>1){
-      
+  if (icascade == 2) {
+    memmpc_   = memmpcref_;
+    mpcfree   = mpcfreeref;
+    maxlenmpc = maxlenmpcref;
+    RENEW(nodempc, ITG, 3 * memmpcref_);
+    for (k = 0; k < 3 * memmpcref_; k++) {
+      nodempc[k] = nodempcref[k];
+    }
+    RENEW(coefmpc, double, memmpcref_);
+    for (k = 0; k < memmpcref_; k++) {
+      coefmpc[k] = coefmpcref[k];
+    }
+    SFREE(nodempcref);
+    SFREE(coefmpcref);
+  }
+
+  if (ncont != 0) {
+    *ne   = ne0;
+    *nkon = nkon0;
+    if (*nener == 1) {
+      RENEW(ener, double, mi[0] * *ne * 2);
+    }
+    RENEW(ipkon, ITG, *ne);
+    RENEW(lakon, char, 8 * *ne);
+    RENEW(kon, ITG, *nkon);
+    if (*norien > 0) {
+      RENEW(ielorien, ITG, mi[2] * *ne);
+    }
+    RENEW(ielmat, ITG, mi[2] * *ne);
+
+    if (*mortar > 1) {
+
       /// needed for next step coloumb friction
-      
-      for (i=0;i<*ntie;i++){
-	if(tieset[i*(81*3)+80]=='C'){
-	  if(*nstate_*mi[0]>0){
-	    for(j=nslavnode[i];j<nslavnode[i+1];j++){	  	     
-	      for(k=0;k<3;k++){	    	       
-		xstate[*nstate_*mi[0]*(*ne+j)+k]=cstress[mt*j+k]; 
-	      } 	    	       
-	      xstate[*nstate_*mi[0]*(*ne+j)+3]=islavact[j]+0.5;
-	      if(iflag_fric==1){
-		for(k=0;k<3*iwan;k++){
-		  xstate[*nstate_*mi[0]*(*ne+j)+4+k]=lambdaiwan[3*iwan*j+k];
-		}
-	      }
-	    }
-		      
-	  }
-	}
+
+      for (i = 0; i < *ntie; i++) {
+        if (tieset[i * (81 * 3) + 80] == 'C') {
+          if (*nstate_ * mi[0] > 0) {
+            for (j = nslavnode[i]; j < nslavnode[i + 1]; j++) {
+              for (k = 0; k < 3; k++) {
+                xstate[*nstate_ * mi[0] * (*ne + j) + k] = cstress[mt * j + k];
+              }
+              xstate[*nstate_ * mi[0] * (*ne + j) + 3] = islavact[j] + 0.5;
+              if (iflag_fric == 1) {
+                for (k = 0; k < 3 * iwan; k++) {
+                  xstate[*nstate_ * mi[0] * (*ne + j) + 4 + k] = lambdaiwan[3 * iwan * j + k];
+                }
+              }
+            }
+          }
+        }
       }
     }
-      
-    SFREE(cg);SFREE(straight);
-    SFREE(imastop);SFREE(itiefac);SFREE(islavnode);
-    SFREE(nslavnode);SFREE(iponoels);SFREE(inoels);SFREE(imastnode);
-    SFREE(nmastnode);SFREE(itietri);SFREE(koncont);SFREE(xnoels);
-    SFREE(springarea);SFREE(xmastnor);
 
-    if(*mortar==-1){
-      SFREE(kslav);SFREE(lslav);SFREE(ktot);SFREE(ltot);
-      SFREE(adc);SFREE(auc);SFREE(areaslav);
-    }else if(*mortar==0){
+    SFREE(cg);
+    SFREE(straight);
+    SFREE(imastop);
+    SFREE(itiefac);
+    SFREE(islavnode);
+    SFREE(nslavnode);
+    SFREE(iponoels);
+    SFREE(inoels);
+    SFREE(imastnode);
+    SFREE(nmastnode);
+    SFREE(itietri);
+    SFREE(koncont);
+    SFREE(xnoels);
+    SFREE(springarea);
+    SFREE(xmastnor);
+
+    if (*mortar == -1) {
+      SFREE(kslav);
+      SFREE(lslav);
+      SFREE(ktot);
+      SFREE(ltot);
+      SFREE(adc);
+      SFREE(auc);
       SFREE(areaslav);
-    }else if(*mortar==1){
-      SFREE(pmastsurf);SFREE(ipe);SFREE(ime);
+    } else if (*mortar == 0) {
+      SFREE(areaslav);
+    } else if (*mortar == 1) {
+      SFREE(pmastsurf);
+      SFREE(ipe);
+      SFREE(ime);
       SFREE(islavact);
-    }else if(*mortar>1){
-      SFREE(islavact);SFREE(gap);SFREE(slavnor);SFREE(slavtan);
-      SFREE(cstress);SFREE(ipe);SFREE(ime);SFREE(cfs);SFREE(cfm);
-      SFREE(cdisp);SFREE(bp);SFREE(islavactdoftie);
-      SFREE(nslavspc);SFREE(islavspc);SFREE(nslavmpc);SFREE(islavmpc);
-      SFREE(nslavspc2);SFREE(islavspc2);SFREE(nslavmpc2);SFREE(islavmpc2);
-      SFREE(nmastspc);SFREE(imastspc);SFREE(nmastmpc);SFREE(imastmpc);
-      SFREE(nmastmpc2);SFREE(imastmpc2);
-      SFREE(xboun2);SFREE(ndirboun2);SFREE(nodeboun2);
-      SFREE(coefmpc2);SFREE(nodempc2);SFREE(ipompc2);
-      SFREE(ikmpc2);SFREE(ilmpc2);SFREE(ikboun2);SFREE(ilboun2);
+    } else if (*mortar > 1) {
+      SFREE(islavact);
+      SFREE(gap);
+      SFREE(slavnor);
+      SFREE(slavtan);
+      SFREE(cstress);
+      SFREE(ipe);
+      SFREE(ime);
+      SFREE(cfs);
+      SFREE(cfm);
+      SFREE(cdisp);
+      SFREE(bp);
+      SFREE(islavactdoftie);
+      SFREE(nslavspc);
+      SFREE(islavspc);
+      SFREE(nslavmpc);
+      SFREE(islavmpc);
+      SFREE(nslavspc2);
+      SFREE(islavspc2);
+      SFREE(nslavmpc2);
+      SFREE(islavmpc2);
+      SFREE(nmastspc);
+      SFREE(imastspc);
+      SFREE(nmastmpc);
+      SFREE(imastmpc);
+      SFREE(nmastmpc2);
+      SFREE(imastmpc2);
+      SFREE(xboun2);
+      SFREE(ndirboun2);
+      SFREE(nodeboun2);
+      SFREE(coefmpc2);
+      SFREE(nodempc2);
+      SFREE(ipompc2);
+      SFREE(ikmpc2);
+      SFREE(ilmpc2);
+      SFREE(ikboun2);
+      SFREE(ilboun2);
       SFREE(labmpc2);
-      SFREE(pslavdual);SFREE(pslavdualpg);
-      SFREE(cstressini);SFREE(bpini);SFREE(islavactini);
-      SFREE(autloc);SFREE(irowtloc);SFREE(jqtloc);
-      SFREE(autlocinv);SFREE(irowtlocinv);SFREE(jqtlocinv);
-      SFREE(Bd);SFREE(irowb);SFREE(jqb);
-      SFREE(Bdhelp);SFREE(irowbhelp);SFREE(jqbhelp);
-      SFREE(Dd);SFREE(irowd);SFREE(jqd);
-      SFREE(Ddtil);SFREE(irowdtil);SFREE(jqdtil);
-      SFREE(Bdtil);SFREE(irowbtil);SFREE(jqbtil);
-      SFREE(Bpgd);SFREE(irowbpg);SFREE(jqbpg);
-      SFREE(Dpgd);SFREE(irowdpg);SFREE(jqdpg);
-      SFREE(Dpgdtil);SFREE(irowdpgtil);SFREE(jqdpgtil);
-      SFREE(Bpgdtil);SFREE(irowbpgtil);SFREE(jqbpgtil);
-      SFREE(islavnodeinv);SFREE(islavelinv);
-      SFREE(nodeforc2);SFREE(ndirforc2);SFREE(xforc2);
-      if(iflag_fric==1){
-	SFREE(lambdaiwanini);SFREE(lambdaiwan); 
+      SFREE(pslavdual);
+      SFREE(pslavdualpg);
+      SFREE(cstressini);
+      SFREE(bpini);
+      SFREE(islavactini);
+      SFREE(autloc);
+      SFREE(irowtloc);
+      SFREE(jqtloc);
+      SFREE(autlocinv);
+      SFREE(irowtlocinv);
+      SFREE(jqtlocinv);
+      SFREE(Bd);
+      SFREE(irowb);
+      SFREE(jqb);
+      SFREE(Bdhelp);
+      SFREE(irowbhelp);
+      SFREE(jqbhelp);
+      SFREE(Dd);
+      SFREE(irowd);
+      SFREE(jqd);
+      SFREE(Ddtil);
+      SFREE(irowdtil);
+      SFREE(jqdtil);
+      SFREE(Bdtil);
+      SFREE(irowbtil);
+      SFREE(jqbtil);
+      SFREE(Bpgd);
+      SFREE(irowbpg);
+      SFREE(jqbpg);
+      SFREE(Dpgd);
+      SFREE(irowdpg);
+      SFREE(jqdpg);
+      SFREE(Dpgdtil);
+      SFREE(irowdpgtil);
+      SFREE(jqdpgtil);
+      SFREE(Bpgdtil);
+      SFREE(irowbpgtil);
+      SFREE(jqbpgtil);
+      SFREE(islavnodeinv);
+      SFREE(islavelinv);
+      SFREE(nodeforc2);
+      SFREE(ndirforc2);
+      SFREE(xforc2);
+      if (iflag_fric == 1) {
+        SFREE(lambdaiwanini);
+        SFREE(lambdaiwan);
       }
     }
   }
 
   /* reset icascade */
 
-  if(icascade==1){icascade=0;}
+  if (icascade == 1) {
+    icascade = 0;
+  }
 
-  mpcinfo[0]=memmpc_;mpcinfo[1]=mpcfree;mpcinfo[2]=icascade;
-  mpcinfo[3]=maxlenmpc;
+  mpcinfo[0] = memmpc_;
+  mpcinfo[1] = mpcfree;
+  mpcinfo[2] = icascade;
+  mpcinfo[3] = maxlenmpc;
 
-  if(iglob==1){SFREE(integerglob);SFREE(doubleglob);}
+  if (iglob == 1) {
+    SFREE(integerglob);
+    SFREE(doubleglob);
+  }
 
-  *icolp=icol;*irowp=irow;*cop=co;*voldp=vold;
+  *icolp = icol;
+  *irowp = irow;
+  *cop   = co;
+  *voldp = vold;
 
-  *ipompcp=ipompc;*labmpcp=labmpc;*ikmpcp=ikmpc;*ilmpcp=ilmpc;
-  *fmpcp=fmpc;*nodempcp=nodempc;*coefmpcp=coefmpc;*nelemloadp=nelemload;
-  *iamloadp=iamload;*sideloadp=sideload;
+  *ipompcp    = ipompc;
+  *labmpcp    = labmpc;
+  *ikmpcp     = ikmpc;
+  *ilmpcp     = ilmpc;
+  *fmpcp      = fmpc;
+  *nodempcp   = nodempc;
+  *coefmpcp   = coefmpc;
+  *nelemloadp = nelemload;
+  *iamloadp   = iamload;
+  *sideloadp  = sideload;
 
-  *ipkonp=ipkon;*lakonp=lakon;*konp=kon;*ielorienp=ielorien;
-  *ielmatp=ielmat;*enerp=ener;*xstatep=xstate;
+  *ipkonp    = ipkon;
+  *lakonp    = lakon;
+  *konp      = kon;
+  *ielorienp = ielorien;
+  *ielmatp   = ielmat;
+  *enerp     = ener;
+  *xstatep   = xstate;
 
-  *islavsurfp=islavsurf;*pslavsurfp=pslavsurf;*clearinip=clearini;
+  *islavsurfp = islavsurf;
+  *pslavsurfp = pslavsurf;
+  *clearinip  = clearini;
 
-  (*tmin)*=(*tper);
-  (*tmax)*=(*tper);
+  (*tmin) *= (*tper);
+  (*tmax) *= (*tper);
 
   SFREE(nactdofinv);
   // MPADD start
-  if((*nmethod==4)&&(*ithermal!=2)&&(*iexpl<=1)&&(icfd==0)){ SFREE(adblump);}
+  if ((*nmethod == 4) && (*ithermal != 2) && (*iexpl <= 1) && (icfd == 0)) {
+    SFREE(adblump);
+  }
   // MPADD end
-  
-  (*ttime)+=(*tper);
+
+  (*ttime) += (*tper);
 
   /* Adapter: Free the memory */
-  Precice_FreeData( &simulationData );
-  
+  Precice_FreeData(&simulationData);
+
   return;
 }

--- a/tools/format-code.sh
+++ b/tools/format-code.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+# Format all adapter C and C++ files with clang-format
+find ./adapter/ \( -iname "*.h*" -o -iname "*.c*" \) -exec clang-format -i {} \;

--- a/tools/format-code.sh
+++ b/tools/format-code.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 
 # Format all adapter C and C++ files with clang-format
-find ./adapter/ \( -iname "*.h*" -o -iname "*.c*" \) -exec clang-format -i {} \;
+find ./ \( -iname "*.h" -o -iname "*.hpp" -o -iname "*.c" -o -iname "*.cpp" \) -exec clang-format -i {} \;


### PR DESCRIPTION
We need some automatic formatting to maintain the history clean and understandable. 

This adds the following:
- A script `tools/format-code.sh`, which formats all the C and C++ files.
- The same clang-format config as in preCICE. I guess some familiarity with the style helps.
- A GitHub Actions workflow to check the formatting.

Closes #69. Replaces #74.

Note that merging this could cause some merge conflicts in already open merge requests.