### PR TITLE
Improved error message (for missing mesh)

### DIFF
--- a/adapter/PreciceInterface.c
+++ b/adapter/PreciceInterface.c
@@ -573,7 +573,7 @@ void PreciceInterface_NodeConnectivity(PreciceInterface *interface, SimulationDa
   PreciceInterface_ConfigureTetraFaces(interface, sim);
 }
 
-void PreciceInterface_EnsureValidNodesMeshID(PreciceInterface *interface, const char* type)
+void PreciceInterface_EnsureValidNodesMeshID(PreciceInterface *interface, const char *type)
 {
   if (interface->nodesMeshID < 0) {
     printf("Nodes mesh not provided in YAML config file. They are required for writing/reading the data %s.\n", type);
@@ -597,7 +597,8 @@ void PreciceInterface_ConfigureTetraFaces(PreciceInterface *interface, Simulatio
   }
 }
 
-void PreciceInterface_EnsureValidFacesMeshID(PreciceInterface* interface, const char *type) {
+void PreciceInterface_EnsureValidFacesMeshID(PreciceInterface *interface, const char *type)
+{
   if (interface->faceCentersMeshID < 0) {
     printf("Face centers mesh not provided in YAML config file. They are required for writing/reading the data %s.\n", type);
     fflush(stdout);
@@ -651,7 +652,7 @@ void PreciceInterface_ConfigureCouplingData(PreciceInterface *interface, Simulat
       interface->kDeltaTemperatureReadDataID = precicec_getDataID(config->readDataNames[i], interface->faceCentersMeshID);
       printf("Read data '%s' found with ID # '%d'.\n", config->readDataNames[i], interface->kDeltaTemperatureReadDataID);
     } else if (startsWith(config->readDataNames[i], "Heat-Transfer-Coefficient-")) {
-      interface->readData[i]      = HEAT_TRANSFER_COEFF;
+      interface->readData[i] = HEAT_TRANSFER_COEFF;
       PreciceInterface_EnsureValidFacesMeshID(interface, "Heat Transfer Coefficient");
       interface->kDeltaReadDataID = precicec_getDataID(config->readDataNames[i], interface->faceCentersMeshID);
       printf("Read data '%s' found with ID # '%d'.\n", config->readDataNames[i], interface->kDeltaReadDataID);
@@ -688,15 +689,15 @@ void PreciceInterface_ConfigureCouplingData(PreciceInterface *interface, Simulat
     } else if (isEqual(config->writeDataNames[i], "Heat-Flux")) {
       interface->writeData[i] = HEAT_FLUX;
       PreciceInterface_EnsureValidFacesMeshID(interface, "Heat Flux");
-      interface->fluxDataID   = precicec_getDataID("Heat-Flux", interface->faceCentersMeshID);
+      interface->fluxDataID = precicec_getDataID("Heat-Flux", interface->faceCentersMeshID);
       printf("Write data '%s' found with ID # '%d'.\n", config->writeDataNames[i], interface->fluxDataID);
     } else if (startsWith(config->writeDataNames[i], "Sink-Temperature-")) {
-      interface->writeData[i]                 = SINK_TEMPERATURE;
+      interface->writeData[i] = SINK_TEMPERATURE;
       PreciceInterface_EnsureValidFacesMeshID(interface, "Sink temperature");
       interface->kDeltaTemperatureWriteDataID = precicec_getDataID(config->writeDataNames[i], interface->faceCentersMeshID);
       printf("Write data '%s' found with ID # '%d'.\n", config->writeDataNames[i], interface->kDeltaTemperatureWriteDataID);
     } else if (startsWith(config->writeDataNames[i], "Heat-Transfer-Coefficient-")) {
-      interface->writeData[i]      = HEAT_TRANSFER_COEFF;
+      interface->writeData[i] = HEAT_TRANSFER_COEFF;
       PreciceInterface_EnsureValidFacesMeshID(interface, "Heat Transfer Coefficient");
       interface->kDeltaWriteDataID = precicec_getDataID(config->writeDataNames[i], interface->faceCentersMeshID);
       printf("Write data '%s' found with ID # '%d'.\n", config->writeDataNames[i], interface->kDeltaWriteDataID);

--- a/adapter/PreciceInterface.c
+++ b/adapter/PreciceInterface.c
@@ -716,7 +716,10 @@ void PreciceInterface_ConfigureCouplingData(PreciceInterface *interface, Simulat
       interface->writeData[i]    = POSITIONS;
       interface->positionsDataID = precicec_getDataID(config->writeDataNames[i], interface->nodesMeshID);
       printf("Write data '%s' found with ID # '%d'.\n", config->writeDataNames[i], interface->positionsDataID);
-    } else if (startsWith(config->writeDataNames[i], "Velocity")) {
+
+    }
+    /* Both "Velocities" and "Velocity" are valid, so we accept Velocit[...]*/
+    else if (startsWith(config->writeDataNames[i], "Velocit")) {
       PreciceInterface_EnsureValidNodesMeshID(interface, "Velocity");
       interface->writeData[i]     = VELOCITIES;
       interface->velocitiesDataID = precicec_getDataID(config->writeDataNames[i], interface->nodesMeshID);

--- a/adapter/PreciceInterface.c
+++ b/adapter/PreciceInterface.c
@@ -715,7 +715,7 @@ void PreciceInterface_ConfigureCouplingData(PreciceInterface *interface, Simulat
       interface->writeData[i]    = POSITIONS;
       interface->positionsDataID = precicec_getDataID(config->writeDataNames[i], interface->nodesMeshID);
       printf("Write data '%s' found with ID # '%d'.\n", config->writeDataNames[i], interface->positionsDataID);
-    } else if (startsWith(config->writeDataNames[i], "Velocit")) {
+    } else if (startsWith(config->writeDataNames[i], "Velocity")) {
       PreciceInterface_EnsureValidNodesMeshID(interface);
       interface->writeData[i]     = VELOCITIES;
       interface->velocitiesDataID = precicec_getDataID(config->writeDataNames[i], interface->nodesMeshID);

--- a/adapter/PreciceInterface.c
+++ b/adapter/PreciceInterface.c
@@ -577,7 +577,8 @@ void PreciceInterface_EnsureValidNodesMeshID(PreciceInterface *interface, const 
 {
   if (interface->nodesMeshID < 0) {
     printf("Nodes mesh configuration not provided in YAML config file. They are required for writing/reading the data %s.\n"
-           " Please check you configured a nodes-mesh or nodes-mesh-with-connectivity in the config file.\n", type);
+           " Please check you configured a nodes-mesh or nodes-mesh-with-connectivity in the config file.\n",
+           type);
     fflush(stdout);
     exit(EXIT_FAILURE);
   }
@@ -602,7 +603,8 @@ void PreciceInterface_EnsureValidFacesMeshID(PreciceInterface *interface, const 
 {
   if (interface->faceCentersMeshID < 0) {
     printf("Faces centers mesh configuration not provided in YAML config file. They are required for writing/reading the data %s.\n"
-           " Please check you configured a faces-mesh (mesh) in the config file.\n", type);
+           " Please check you configured a faces-mesh (mesh) in the config file.\n",
+           type);
     fflush(stdout);
     exit(EXIT_FAILURE);
   }

--- a/adapter/PreciceInterface.c
+++ b/adapter/PreciceInterface.c
@@ -476,7 +476,7 @@ void PreciceInterface_Create(PreciceInterface *interface, SimulationData *sim, I
 
 void PreciceInterface_ConfigureFaceCentersMesh(PreciceInterface *interface, SimulationData *sim)
 {
-  printf("Entering ConfigureFaceCentersMesh \n");
+  //printf("Entering ConfigureFaceCentersMesh \n");
   char *faceSetName      = toFaceSetName(interface->name);
   interface->faceSetID   = getSetID(faceSetName, sim->set, sim->nset);
   interface->numElements = getNumSetElements(interface->faceSetID, sim->istartset, sim->iendset);
@@ -497,7 +497,7 @@ void PreciceInterface_ConfigureFaceCentersMesh(PreciceInterface *interface, Simu
 
 void PreciceInterface_ConfigureNodesMesh(PreciceInterface *interface, SimulationData *sim)
 {
-  printf("Entering configureNodesMesh \n");
+  //printf("Entering configureNodesMesh \n");
   char *nodeSetName    = toNodeSetName(interface->name);
   interface->nodeSetID = getSetID(nodeSetName, sim->set, sim->nset);
   interface->numNodes  = getNumSetElements(interface->nodeSetID, sim->istartset, sim->iendset);

--- a/adapter/PreciceInterface.c
+++ b/adapter/PreciceInterface.c
@@ -576,7 +576,7 @@ void PreciceInterface_NodeConnectivity(PreciceInterface *interface, SimulationDa
 void PreciceInterface_EnsureValidNodesMeshID(PreciceInterface *interface, const char* type)
 {
   if (interface->nodesMeshID < 0) {
-    printf("Nodes mesh not provided in YAML config file. They are required for writing/reading the data %s\n", type);
+    printf("Nodes mesh not provided in YAML config file. They are required for writing/reading the data %s.\n", type);
     fflush(stdout);
     exit(EXIT_FAILURE);
   }
@@ -599,7 +599,7 @@ void PreciceInterface_ConfigureTetraFaces(PreciceInterface *interface, Simulatio
 
 void PreciceInterface_EnsureValidFacesMeshID(PreciceInterface* interface, const char *type) {
   if (interface->faceCentersMeshID < 0) {
-    printf("Face centers mesh not provided in YAML config file. They are required for writing/reading the data %s\n", type);
+    printf("Face centers mesh not provided in YAML config file. They are required for writing/reading the data %s.\n", type);
     fflush(stdout);
     exit(EXIT_FAILURE);
   }

--- a/adapter/PreciceInterface.c
+++ b/adapter/PreciceInterface.c
@@ -576,7 +576,8 @@ void PreciceInterface_NodeConnectivity(PreciceInterface *interface, SimulationDa
 void PreciceInterface_EnsureValidNodesMeshID(PreciceInterface *interface, const char *type)
 {
   if (interface->nodesMeshID < 0) {
-    printf("Nodes mesh not provided in YAML config file. They are required for writing/reading the data %s.\n", type);
+    printf("Nodes mesh configuration not provided in YAML config file. They are required for writing/reading the data %s.\n"
+           " Please check you configured a nodes-mesh or nodes-mesh-with-connectivity in the config file.\n", type);
     fflush(stdout);
     exit(EXIT_FAILURE);
   }
@@ -600,7 +601,8 @@ void PreciceInterface_ConfigureTetraFaces(PreciceInterface *interface, Simulatio
 void PreciceInterface_EnsureValidFacesMeshID(PreciceInterface *interface, const char *type)
 {
   if (interface->faceCentersMeshID < 0) {
-    printf("Face centers mesh not provided in YAML config file. They are required for writing/reading the data %s.\n", type);
+    printf("Faces centers mesh configuration not provided in YAML config file. They are required for writing/reading the data %s.\n"
+           " Please check you configured a faces-mesh (mesh) in the config file.\n", type);
     fflush(stdout);
     exit(EXIT_FAILURE);
   }

--- a/adapter/PreciceInterface.h
+++ b/adapter/PreciceInterface.h
@@ -263,8 +263,16 @@ void PreciceInterface_ConfigureNodesMesh(PreciceInterface *interface, Simulation
 /**
  * @brief Terminate execution if the nodes mesh ID is not valid
  * @param interface
+ * @param type of data requiring mesh ID
  */
-void PreciceInterface_EnsureValidNodesMeshID(PreciceInterface *interface);
+void PreciceInterface_EnsureValidNodesMeshID(PreciceInterface *interface, const char* type);
+
+/**
+ * @brief Terminate execution if the faces mesh ID is not valid
+ * @param interface
+ * @param type of data requiring mesh ID
+ */
+void PreciceInterface_EnsureValidFacesMeshID(PreciceInterface* interface, const char *type):
 
 /**
  * @brief Configures the faces mesh (for tetrahedral elements only)

--- a/adapter/PreciceInterface.h
+++ b/adapter/PreciceInterface.h
@@ -265,21 +265,22 @@ void PreciceInterface_ConfigureNodesMesh(PreciceInterface *interface, Simulation
  * @param interface
  * @param type of data requiring mesh ID
  */
-void PreciceInterface_EnsureValidNodesMeshID(PreciceInterface *interface, const char* type);
+void PreciceInterface_EnsureValidNodesMeshID(PreciceInterface *interface, const char *type);
 
 /**
  * @brief Terminate execution if the faces mesh ID is not valid
  * @param interface
  * @param type of data requiring mesh ID
  */
-void PreciceInterface_EnsureValidFacesMeshID(PreciceInterface* interface, const char *type):
+void PreciceInterface_EnsureValidFacesMeshID(PreciceInterface *interface, const char *type)
+    :
 
-/**
+      /**
  * @brief Configures the faces mesh (for tetrahedral elements only)
  * @param interface
  * @param sim
  */
-void PreciceInterface_ConfigureTetraFaces(PreciceInterface *interface, SimulationData *sim);
+      void PreciceInterface_ConfigureTetraFaces(PreciceInterface * interface, SimulationData * sim);
 
 /**
  * @brief Configures the node connectivity for nearest-projection mapping

--- a/adapter/PreciceInterface.h
+++ b/adapter/PreciceInterface.h
@@ -272,15 +272,14 @@ void PreciceInterface_EnsureValidNodesMeshID(PreciceInterface *interface, const 
  * @param interface
  * @param type of data requiring mesh ID
  */
-void PreciceInterface_EnsureValidFacesMeshID(PreciceInterface *interface, const char *type)
-    :
+void PreciceInterface_EnsureValidFacesMeshID(PreciceInterface *interface, const char *type);
 
-      /**
+/**
  * @brief Configures the faces mesh (for tetrahedral elements only)
  * @param interface
  * @param sim
  */
-      void PreciceInterface_ConfigureTetraFaces(PreciceInterface * interface, SimulationData * sim);
+void PreciceInterface_ConfigureTetraFaces(PreciceInterface *interface, SimulationData *sim);
 
 /**
  * @brief Configures the node connectivity for nearest-projection mapping


### PR DESCRIPTION
Current code contains a message to warn the user when he doesn't provide a nodal mesh (i.e. a face mesh is sent instead) despite being required. But the opposite wasn't true: if you send a nodal mesh when a face mesh is required, you get a very unhelpful "array out of bounds" crash, which was a pain to debug.

I thus added this error message. I also made them (both missing nodal and missing face mesh) slightly more explicit. Roughly speaking, instead of "You don't provide X", it is replaced by "you don't provide X, which is needed for using Y", with Y the cause of the error. (For instance if you try to read displacements on a face mesh, or heat flux on a nodal mesh).

**Examples**:
Writing a heat flux on a nodes mesh crashed without reason, now it says `Face centers mesh not provided in YAML config file. They are required for writing/reading the data Heat Flux.`

Reading a temperature on a face centers mesh used to give the message `Nodes mesh not provided in YAML config file` but now it gives `Nodes mesh not provided in YAML config file. They are required for writing/reading the data Temperature.`.

(I also fixed a typo where "Velocit" is used instead of "Velocity". This was fixed a while ago by @IshaanDesai but it seems we overrode it at some point when merging everything)