### PR TITLE
Fixed mesh configuration 2D coupling with Face meshes

### DIFF
--- a/adapter/PreciceInterface.c
+++ b/adapter/PreciceInterface.c
@@ -511,7 +511,6 @@ void PreciceInterface_ConfigureFaceCentersMesh(PreciceInterface *interface, Simu
   interface->preciceFaceCenterIDs = malloc(interface->numElements * sizeof(int));
 
   sendFaceCentersVertices(interface);
-  //precicec_setMeshVertices(interface->faceCentersMeshID, interface->numElements, interface->faceCenterCoordinates, interface->preciceFaceCenterIDs);
 }
 
 void sendFaceCentersVertices(PreciceInterface *interface)

--- a/adapter/PreciceInterface.c
+++ b/adapter/PreciceInterface.c
@@ -510,7 +510,25 @@ void PreciceInterface_ConfigureFaceCentersMesh(PreciceInterface *interface, Simu
   interface->faceCentersMeshID    = precicec_getMeshID(interface->faceCentersMeshName);
   interface->preciceFaceCenterIDs = malloc(interface->numElements * sizeof(int));
 
-  precicec_setMeshVertices(interface->faceCentersMeshID, interface->numElements, interface->faceCenterCoordinates, interface->preciceFaceCenterIDs);
+  sendFaceCentersVertices(interface);
+  //precicec_setMeshVertices(interface->faceCentersMeshID, interface->numElements, interface->faceCenterCoordinates, interface->preciceFaceCenterIDs);
+}
+
+void sendFaceCentersVertices(PreciceInterface *interface)
+{
+  // Send the data of face centers to preCICE. If 2D coupling is used, skip the z component!
+
+  if (!isQuasi2D3D(interface->quasi2D3D)) {
+    precicec_setMeshVertices(interface->faceCentersMeshID, interface->numElements, interface->faceCenterCoordinates, interface->preciceFaceCenterIDs);
+  } else {
+    double *coordinates2D = malloc(interface->numElements * 2 * sizeof(double));
+    for (int i = 0; i < interface->numElements; ++i) {
+      coordinates2D[2 * i]     = interface->faceCenterCoordinates[3 * i];
+      coordinates2D[2 * i + 1] = interface->faceCenterCoordinates[3 * i + 1];
+    }
+    precicec_setMeshVertices(interface->faceCentersMeshID, interface->numElements, coordinates2D, interface->preciceFaceCenterIDs);
+    free(coordinates2D);
+  }
 }
 
 void PreciceInterface_ConfigureNodesMesh(PreciceInterface *interface, SimulationData *sim)

--- a/adapter/PreciceInterface.h
+++ b/adapter/PreciceInterface.h
@@ -247,11 +247,19 @@ void Precice_FreeData(SimulationData *sim);
 void PreciceInterface_Create(PreciceInterface *interface, SimulationData *sim, InterfaceConfig const *config);
 
 /**
- * @brief Configures the face centers mesh and calls setMeshVertices on preCICE
+ * @brief Configures the face centers mesh and calls sendFaceCentersVertices, 
+ * who is responsible for calling preCICE
  * @param interface
  * @param sim
  */
 void PreciceInterface_ConfigureFaceCentersMesh(PreciceInterface *interface, SimulationData *sim);
+
+/**
+ * @brief Send the faces centers to preCICE.
+ * 
+ * @param interface 
+ */
+void sendFaceCentersVertices(PreciceInterface *interface);
 
 /**
  * @brief Configures the nodes mesh


### PR DESCRIPTION
# Context

Quasi2D simulations are currently supported with nodal meshes (for FSI typically) but weren't supported for faces mesh. (i.e. to transfer pressure, heat fluxes, film temperature or convection coefficient, so mostly heat transfer)
While with nodal meshes we need some elaborate tricks to convert from 3D to 2D (because there is more than one 3D vertex for a 2D vertex), face meshes are simpler: just cropping the Z-component should work. Since all mappings are consistent, there is no need to pay attention to the number of faces etc.

# Changes

When configuring a face mesh in 2D, nothing changes except that if preCICE is configured in 2D, we crop the Z-component when sending the mesh. Previously, sent data was erroneous (CalculiX sends data in the format "x1 y1 z1 x2 y2 z2..." but preCICE expects 2D data so the x-coordinate of the second vertex is z1, and so on).