### PR TITLE
Update packaging script to Ubuntu 22.04 LTS

### DIFF
--- a/.github/workflows/ubuntu_build.yml
+++ b/.github/workflows/ubuntu_build.yml
@@ -7,14 +7,10 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-20.04, ubuntu-21.04, ubuntu-21.10, ubuntu-22.04]
+        os: [ubuntu-20.04, ubuntu-22.04]
         include:
           - os: ubuntu-20.04
             name: focal
-          - os: ubuntu-21.04
-            name: hirsute
-          - os: ubuntu-21.10
-            name: impish
           - os: ubuntu-22.04
             name: jammy
             flags: -fallow-argument-mismatch

--- a/.github/workflows/ubuntu_build.yml
+++ b/.github/workflows/ubuntu_build.yml
@@ -7,10 +7,14 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-20.04, ubuntu-22.04]
+        os: [ubuntu-20.04, ubuntu-21.10, ubuntu-22.04]
         include:
           - os: ubuntu-20.04
             name: focal
+          - os: ubuntu-21.04
+            name: hirsute
+          - os: ubuntu-21.10
+            name: impish
           - os: ubuntu-22.04
             name: jammy
             flags: -fallow-argument-mismatch

--- a/.github/workflows/ubuntu_build.yml
+++ b/.github/workflows/ubuntu_build.yml
@@ -7,7 +7,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-20.04, ubuntu-21.10, ubuntu-22.04]
+        os: [ubuntu-20.04, ubuntu-21.0.4, ubuntu-21.10, ubuntu-22.04]
         include:
           - os: ubuntu-20.04
             name: focal

--- a/.github/workflows/ubuntu_build.yml
+++ b/.github/workflows/ubuntu_build.yml
@@ -7,12 +7,14 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-18.04, ubuntu-20.04]
+        os: [ubuntu-18.04, ubuntu-20.04, ubuntu-22.04]
         include:
           - os: ubuntu-18.04
             name: bionic
           - os: ubuntu-20.04
             name: focal
+          - os: ubuntu-20.04
+            name: jammy
     runs-on: ${{matrix.os}}
     continue-on-error: true
     env: # Versioning is "calculix-preciceX_2.YY-Z[...]" with X the major preCICE version, YY the minor CCX version and Z the package version

--- a/.github/workflows/ubuntu_build.yml
+++ b/.github/workflows/ubuntu_build.yml
@@ -9,12 +9,12 @@ jobs:
       matrix:
         os: [ubuntu-18.04, ubuntu-20.04, ubuntu-22.04]
         include:
-          - os: ubuntu-18.04
-            name: bionic
           - os: ubuntu-20.04
             name: focal
           - os: ubuntu-20.04
             name: jammy
+            flags: -fallow-argument-mismatch
+
     runs-on: ${{matrix.os}}
     continue-on-error: true
     env: # Versioning is "calculix-preciceX_2.YY-Z[...]" with X the major preCICE version, YY the minor CCX version and Z the package version
@@ -26,9 +26,9 @@ jobs:
     - uses: actions/checkout@v2
       with:
         ref: ${{ github.ref }}
-    - name: Get preCICE v2.3.0
-      run: wget https://github.com/precice/precice/releases/download/v2.3.0/libprecice2_2.3.0_${{matrix.name}}.deb &&
-        sudo apt install ./libprecice2_2.3.0_${{matrix.name}}.deb -y
+    - name: Get preCICE v2.4.0
+      run: wget https://github.com/precice/precice/releases/download/v2.4.0/libprecice2_2.4.0_${{matrix.name}}.deb &&
+        sudo apt install ./libprecice2_2.4.0_${{matrix.name}}.deb -y
     - name: install dependencies
       run: sudo apt install libarpack2-dev libspooles-dev libyaml-cpp-dev -y
     - name: Download CalculiX
@@ -36,7 +36,7 @@ jobs:
     - name: Unpack Calculix
       run: tar -xjf ccx_2.19.src.tar.bz2
     - name: make
-      run: make -j 4 CCX="./CalculiX/ccx_2.19/src"
+      run: make -j 4 CCX="./CalculiX/ccx_2.19/src" ADDITIONAL_FFLAGS="${{matrix.flags}}"
     - name: Test run
       run: ./bin/ccx_preCICE -h
     - name: Download tools for packaging

--- a/.github/workflows/ubuntu_build.yml
+++ b/.github/workflows/ubuntu_build.yml
@@ -7,7 +7,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-20.04, ubuntu-21.0.4, ubuntu-21.10, ubuntu-22.04]
+        os: [ubuntu-20.04, ubuntu-21.04, ubuntu-21.10, ubuntu-22.04]
         include:
           - os: ubuntu-20.04
             name: focal

--- a/.github/workflows/ubuntu_build.yml
+++ b/.github/workflows/ubuntu_build.yml
@@ -7,11 +7,11 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-18.04, ubuntu-20.04, ubuntu-22.04]
+        os: [ubuntu-20.04, ubuntu-22.04]
         include:
           - os: ubuntu-20.04
             name: focal
-          - os: ubuntu-20.04
+          - os: ubuntu-22.04
             name: jammy
             flags: -fallow-argument-mismatch
 

--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,7 @@ else
 	CC = mpicc
 endif
 
-FFLAGS = -Wall -O3 -fopenmp $(INCLUDES)
+FFLAGS = -Wall -O3 -fopenmp $(INCLUDES) ${ADDITIONAL_FFLAGS}
 # Note for GCC 10 or newer: add -fallow-argument-mismatch in the above flags
 FC = mpifort
 # FC = mpif90


### PR DESCRIPTION
Packaging now supports Ubuntu 22.04 & 20.04.
Makefile has been changed to allow for the -fallow-argument-mismatch flag to be used where necessary.