### PR TITLE
Fixed implicit coupling in modal dynamic simulation.

### DIFF
--- a/dyna_precice.c
+++ b/dyna_precice.c
@@ -1432,11 +1432,11 @@ void dyna_precice(double **cop, ITG *nk, ITG **konp, ITG **ipkonp, char **lakonp
     if (Precice_IsWriteCheckpointRequired()) {
       printf("WARNING: implicit coupling with modal dynamic simulations is not working in the current version of the adapter.\n");
       Precice_WriteIterationCheckpoint(&simulationData, vini);
+      // Otherwise, each iteration in implicit coupling would be written as a new step
+      iinc++;
+      jprint++;
       Precice_FulfilledWriteCheckpoint();
     }
-
-    iinc++;
-    jprint++;
 
     if (dashpot)
       RENEW(rpar, double, 4 + nev * (3 + nev));

--- a/dyna_precice.c
+++ b/dyna_precice.c
@@ -2041,7 +2041,8 @@ void dyna_precice(double **cop, ITG *nk, ITG **konp, ITG **ipkonp, char **lakonp
       printf("WARNING: implicit coupling with modal dynamic simulations is not working in the current version of the adapter.\n");
       if (*nmethod == 4) {
         Precice_ReadIterationCheckpoint(&simulationData, vold);
-        icutb++;
+        memcpy(&bj[0], &cd[0], sizeof(double) * nev);
+        memcpy(&bjp[0], &cv[0], sizeof(double) * nev);
       }
       Precice_FulfilledReadCheckpoint();
     }

--- a/dyna_precice.c
+++ b/dyna_precice.c
@@ -1430,7 +1430,6 @@ void dyna_precice(double **cop, ITG *nk, ITG **konp, ITG **ipkonp, char **lakonp
       }
     }
     if (Precice_IsWriteCheckpointRequired()) {
-      printf("WARNING: implicit coupling with modal dynamic simulations is not working in the current version of the adapter.\n");
       Precice_WriteIterationCheckpoint(&simulationData, vini);
       // Otherwise, each iteration in implicit coupling would be written as a new step
       iinc++;
@@ -2038,7 +2037,6 @@ void dyna_precice(double **cop, ITG *nk, ITG **konp, ITG **ipkonp, char **lakonp
     Precice_Advance(&simulationData);
     /* Adapter: If the coupling does not converge, read the checkpoint */
     if (Precice_IsReadCheckpointRequired()) {
-      printf("WARNING: implicit coupling with modal dynamic simulations is not working in the current version of the adapter.\n");
       if (*nmethod == 4) {
         Precice_ReadIterationCheckpoint(&simulationData, vold);
         memcpy(&bj[0], &cd[0], sizeof(double) * nev);


### PR DESCRIPTION
See https://github.com/precice/calculix-adapter/issues/93.
Implicit coupling now seems to work as expected, I have a modified version of the perpendicular flap tutorial adapted to modal dynamic simulations that gives plausible results (although slightly different than the reference solution, but since I used a smaller number of frequencies it makes sense).

The fix is quite simple to understand (but was tricky to find in the hundred of lines of badly-documented code :sweat_smile: ) : since the simulation is done in frequency space, checkpointing must restore DOFs in the corresponding eigenmodes, not just the final displacements. So when reading I checkpoint I update these.

I also removed the use of the `icutb` variable, which is actually unused