### PR TITLE
Fixed crash when freeing unused pointers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ LIBS = \
 #CFLAGS = -g -Wall -std=c++11 -O0 -fopenmp $(INCLUDES) -DARCH="Linux" -DSPOOLES -DARPACK -DMATRIXSTORAGE
 #FFLAGS = -g -Wall -O0 -fopenmp $(INCLUDES)
 
-CFLAGS = -Wall -O3 -fopenmp $(INCLUDES) -DARCH="Linux" -DSPOOLES -DARPACK -DMATRIXSTORAGE -DUSE_MT
+CFLAGS = -Wall -O0 -fopenmp $(INCLUDES) -DARCH="Linux" -DSPOOLES -DARPACK -DMATRIXSTORAGE -DUSE_MT -g
 
 # OS-specific options
 UNAME_S := $(shell uname -s)
@@ -62,7 +62,7 @@ else
 	CC = mpicc
 endif
 
-FFLAGS = -Wall -O3 -fopenmp $(INCLUDES) ${ADDITIONAL_FFLAGS}
+FFLAGS = -Wall -O0 -fopenmp $(INCLUDES) ${ADDITIONAL_FFLAGS} -g
 # Note for GCC 10 or newer: add -fallow-argument-mismatch in the above flags
 FC = mpifort
 # FC = mpif90

--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ LIBS = \
 #CFLAGS = -g -Wall -std=c++11 -O0 -fopenmp $(INCLUDES) -DARCH="Linux" -DSPOOLES -DARPACK -DMATRIXSTORAGE
 #FFLAGS = -g -Wall -O0 -fopenmp $(INCLUDES)
 
-CFLAGS = -Wall -O0 -fopenmp $(INCLUDES) -DARCH="Linux" -DSPOOLES -DARPACK -DMATRIXSTORAGE -DUSE_MT -g
+CFLAGS = -Wall -O3 -fopenmp $(INCLUDES) -DARCH="Linux" -DSPOOLES -DARPACK -DMATRIXSTORAGE -DUSE_MT
 
 # OS-specific options
 UNAME_S := $(shell uname -s)
@@ -62,7 +62,7 @@ else
 	CC = mpicc
 endif
 
-FFLAGS = -Wall -O0 -fopenmp $(INCLUDES) ${ADDITIONAL_FFLAGS} -g
+FFLAGS = -Wall -O3 -fopenmp $(INCLUDES) ${ADDITIONAL_FFLAGS}
 # Note for GCC 10 or newer: add -fallow-argument-mismatch in the above flags
 FC = mpifort
 # FC = mpif90

--- a/adapter/PreciceInterface.c
+++ b/adapter/PreciceInterface.c
@@ -700,6 +700,8 @@ void PreciceInterface_ConfigureCouplingData(PreciceInterface *interface, Simulat
   interface->numWriteData = config->numWriteData;
   if (config->numWriteData > 0)
     interface->writeData = malloc(config->numWriteData * sizeof(int));
+  else 
+    interface->writeData = NULL;
 
   for (i = 0; i < config->numWriteData; i++) {
     if (isEqual(config->writeDataNames[i], "Temperature")) {

--- a/adapter/PreciceInterface.c
+++ b/adapter/PreciceInterface.c
@@ -700,7 +700,7 @@ void PreciceInterface_ConfigureCouplingData(PreciceInterface *interface, Simulat
   interface->numWriteData = config->numWriteData;
   if (config->numWriteData > 0)
     interface->writeData = malloc(config->numWriteData * sizeof(int));
-  else 
+  else
     interface->writeData = NULL;
 
   for (i = 0; i < config->numWriteData; i++) {

--- a/adapter/PreciceInterface.c
+++ b/adapter/PreciceInterface.c
@@ -433,6 +433,8 @@ void PreciceInterface_Create(PreciceInterface *interface, SimulationData *sim, I
   interface->xbounIndices          = NULL;
   interface->xloadIndices          = NULL;
   interface->xforcIndices          = NULL;
+  interface->writeData             = NULL;
+  interface->readData              = NULL;
 
   // Initialize data ids to -1
   interface->temperatureDataID            = -1;
@@ -700,8 +702,6 @@ void PreciceInterface_ConfigureCouplingData(PreciceInterface *interface, Simulat
   interface->numWriteData = config->numWriteData;
   if (config->numWriteData > 0)
     interface->writeData = malloc(config->numWriteData * sizeof(int));
-  else
-    interface->writeData = NULL;
 
   for (i = 0; i < config->numWriteData; i++) {
     if (isEqual(config->writeDataNames[i], "Temperature")) {

--- a/tools/format-code.sh
+++ b/tools/format-code.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 
 # Format all adapter C and C++ files with clang-format
-find ./ \( -iname "*.h" -o -iname "*.hpp" -o -iname "*.c" -o -iname "*.cpp" \) -exec clang-format -i {} \;
+find ./ \( -iname "*.h" -o -iname "*.hpp" -o -iname "*.c" -o -iname "*.cpp" \) -exec clang-format-11 -i {} \;


### PR DESCRIPTION
When one interface doesn't write data, an unitialized pointer gets freed in the end. This PR initalizes it to NULL when necessary.
Example to reproduce: https://github.com/precice/tutorials/pull/271.