### PR TITLE
Fixed DOF 0 bug & removed useless memcpy

### DIFF
--- a/nonlingeo_precice.c
+++ b/nonlingeo_precice.c
@@ -3694,7 +3694,6 @@ void nonlingeo_precice(double **cop, ITG *nk, ITG **konp, ITG **ipkonp, char **l
 
     /* Adapter: Copy necessary data for coupling */
     simulationData.fn = fn;
-    memcpy(&vold[0], &v[0], sizeof(double) * mt * *nk);
 
     Precice_WriteCouplingData(&simulationData);
     /* Adapter: Advance the coupling */


### PR DESCRIPTION
# Content

This PR seems to fix https://github.com/precice/calculix-adapter/issues/86
Following a suggestion from Matthias Freimuth, I removed a `memcpy` statement that seems to fixe the bug. Extensive testing is needed to ensure nothing else is broken. For the record, I am absolutely clueless as to 1) why removing this line fixes the bug 2) what was the purpose of it at first. So, mostly empirical stuff.

In my opinion, three things should be checked:
- Do all the tutorials work correctly with this change?
- Does this change fix the #86 bug wherever it occurs?
- Does this change impact memory consumption or something related? (I don't think so, but worth monitoring I guess)

@KyleDavisSA any idea what's happening here ?

# Checklist

On my side:

## Fixing the bug?

- [x] Perpendicular flap modified as suggested by Andres Pedemontes (see #86 ) is fixed.
- [x] The test case I introduced at https://github.com/precice/calculix-adapter/pull/92#issuecomment-1061668873 is fixed.

## Non-regression

- [x] Does the perpendicular flap work as before ?
- [x]  Does the heat exchanger work as before ?
- [x]  Does the elastic-tube-3d work as before ?
- [x]  Does the flow over heated plate work as before ?
- [ ]  Does the partitioned beam work as before ?

## Memory checks

Nothing done so far.