### PR TITLE
Fixed subcycling in implicit coupling (for regular simulations)

### DIFF
--- a/adapter/PreciceInterface.c
+++ b/adapter/PreciceInterface.c
@@ -443,6 +443,14 @@ void Precice_FreeData(SimulationData *sim)
     free(sim->coupling_init_v);
   }
 
+  if (sim->coupling_init_ve != NULL) {
+    free(sim->coupling_init_ve);
+  }
+
+  if (sim->coupling_init_acc != NULL) {
+    free(sim->coupling_init_acc);
+  }
+
   for (i = 0; i < sim->numPreciceInterfaces; i++) {
     PreciceInterface_FreeData(sim->preciceInterfaces[i]);
     free(sim->preciceInterfaces[i]);

--- a/adapter/PreciceInterface.c
+++ b/adapter/PreciceInterface.c
@@ -51,6 +51,9 @@ void Precice_Setup(char *configFilename, char *participantName, SimulationData *
 
   // Initialize variables needed for the coupling
   NNEW(sim->coupling_init_v, double, sim->mt * sim->nk);
+  NNEW(sim->coupling_init_ve, double, sim->mt * sim->nk);
+  NNEW(sim->coupling_init_acc, double, sim->mt * sim->nk);
+  NNEW(sim->coupling_init_xboun, double, sim->nboun);
 
   // Initialize preCICE
   sim->precice_dt = precicec_initialize();
@@ -128,7 +131,7 @@ void Precice_FulfilledWriteCheckpoint()
   precicec_markActionFulfilled("write-iteration-checkpoint");
 }
 
-void Precice_ReadIterationCheckpoint(SimulationData *sim, double *v)
+void Precice_ReadIterationCheckpoint(SimulationData *sim, double *v, double *ve, double* acc)
 {
 
   printf("Adapter reading checkpoint...\n");
@@ -142,9 +145,11 @@ void Precice_ReadIterationCheckpoint(SimulationData *sim, double *v)
 
   // Reload solution vector v
   memcpy(v, sim->coupling_init_v, sizeof(double) * sim->mt * sim->nk);
+  memcpy(ve, sim->coupling_init_ve, sizeof(double) * sim->mt * sim->nk);
+  memcpy(acc, sim->coupling_init_acc, sizeof(double) * sim->mt * sim->nk);
 }
 
-void Precice_WriteIterationCheckpoint(SimulationData *sim, double *v)
+void Precice_WriteIterationCheckpoint(SimulationData *sim, double *v, double *ve, double *acc)
 {
 
   printf("Adapter writing checkpoint...\n");
@@ -158,6 +163,8 @@ void Precice_WriteIterationCheckpoint(SimulationData *sim, double *v)
 
   // Save solution vector v
   memcpy(sim->coupling_init_v, v, sizeof(double) * sim->mt * sim->nk);
+  memcpy(sim->coupling_init_ve, ve, sizeof(double) * sim->mt * sim->nk);
+  memcpy(sim->coupling_init_acc, acc, sizeof(double) * sim->mt * sim->nk);
 }
 
 void Precice_ReadIterationCheckpointModal(SimulationData *sim, double *dofs, double *derivatives, int nev)

--- a/adapter/PreciceInterface.c
+++ b/adapter/PreciceInterface.c
@@ -130,7 +130,7 @@ void Precice_FulfilledWriteCheckpoint()
   precicec_markActionFulfilled("write-iteration-checkpoint");
 }
 
-void Precice_ReadIterationCheckpoint(SimulationData *sim, double *v, double *ve, double* acc)
+void Precice_ReadIterationCheckpoint(SimulationData *sim, double *v, double *ve, double *acc)
 {
 
   printf("Adapter reading checkpoint...\n");

--- a/adapter/PreciceInterface.c
+++ b/adapter/PreciceInterface.c
@@ -53,7 +53,6 @@ void Precice_Setup(char *configFilename, char *participantName, SimulationData *
   NNEW(sim->coupling_init_v, double, sim->mt * sim->nk);
   NNEW(sim->coupling_init_ve, double, sim->mt * sim->nk);
   NNEW(sim->coupling_init_acc, double, sim->mt * sim->nk);
-  NNEW(sim->coupling_init_xboun, double, sim->nboun);
 
   // Initialize preCICE
   sim->precice_dt = precicec_initialize();

--- a/adapter/PreciceInterface.h
+++ b/adapter/PreciceInterface.h
@@ -136,6 +136,9 @@ typedef struct SimulationData {
 
   // Coupling data
   double *coupling_init_v;
+  double *coupling_init_ve;
+  double *coupling_init_acc;
+  double *coupling_init_xboun;
   double  coupling_init_theta;
   double  coupling_init_dtheta;
   double  precice_dt;
@@ -213,15 +216,19 @@ void Precice_FulfilledWriteCheckpoint();
  * @brief Reads iteration checkpoint
  * @param sim: Structure with CalculiX data
  * @param v: CalculiX array with the temperature and displacement values
+ * @param ve: CalculiX array with the temperature and displacement derivatives
+ * @param acc: CalculiX array with the temperature and displacement acceleration
  */
-void Precice_ReadIterationCheckpoint(SimulationData *sim, double *v);
+void Precice_ReadIterationCheckpoint(SimulationData *sim, double *v, double *ve, double *acc);
 
 /**
  * @brief Writes iteration checkpoint
  * @param sim: Structure with CalculiX data
  * @param v: CalculiX array with the temperature and displacement values
+ * @param ve: CalculiX array with the temperature and displacement derivatives
+ * @param acc: CalculiX array with the temperature and displacement acceleration
  */
-void Precice_WriteIterationCheckpoint(SimulationData *sim, double *v);
+void Precice_WriteIterationCheckpoint(SimulationData *sim, double *v, double *ve, double *acc);
 
 /**
  * @brief Reads iteration checkpoint (in dyna_precice)

--- a/adapter/PreciceInterface.h
+++ b/adapter/PreciceInterface.h
@@ -138,7 +138,6 @@ typedef struct SimulationData {
   double *coupling_init_v;
   double *coupling_init_ve;
   double *coupling_init_acc;
-  double *coupling_init_xboun;
   double  coupling_init_theta;
   double  coupling_init_dtheta;
   double  precice_dt;

--- a/nonlingeo_precice.c
+++ b/nonlingeo_precice.c
@@ -1635,9 +1635,6 @@ void nonlingeo_precice(double **cop, ITG *nk, ITG **konp, ITG **ipkonp, char **l
   /* Adapter: Create the interfaces and initialize the coupling */
   Precice_Setup(configFilename, preciceParticipantName, &simulationData);
 
-  /* Adapter: create an output buffer */
-  printf("Creating a buffer to output correctly when subcycling is used.\n");
-  outputBuffer *out_buffer = BufferCreate();
 
   ITG     kode_backup;
   int iinc_old, jprint_old;

--- a/nonlingeo_precice.c
+++ b/nonlingeo_precice.c
@@ -38,7 +38,6 @@
 
 /* Adapter: Add header */
 #include "adapter/PreciceInterface.h"
-#include "adapter/OutputBuffer.h"
 
 #define max(a, b) ((a) >= (b) ? (a) : (b))
 

--- a/nonlingeo_precice.c
+++ b/nonlingeo_precice.c
@@ -1673,14 +1673,10 @@ void nonlingeo_precice(double **cop, ITG *nk, ITG **konp, ITG **ipkonp, char **l
         iinc++;
         jprint++;
 
-
         kode_backup = *kode;
-
-        // TODO
         iinc_old = iinc;
         jprint_old = jprint;
 
-        //END TODO
         Precice_FulfilledWriteCheckpoint();
       }
 

--- a/nonlingeo_precice.c
+++ b/nonlingeo_precice.c
@@ -1637,7 +1637,6 @@ void nonlingeo_precice(double **cop, ITG *nk, ITG **konp, ITG **ipkonp, char **l
 
 
   ITG     kode_backup;
-  int iinc_old, jprint_old;
 
   while (Precice_IsCouplingOngoing()) {
 
@@ -1671,8 +1670,8 @@ void nonlingeo_precice(double **cop, ITG *nk, ITG **konp, ITG **ipkonp, char **l
         jprint++;
 
         kode_backup = *kode;
-        iinc_old = iinc;
-        jprint_old = jprint;
+        simulationData.stored_iinc = iinc;
+        simulationData.stored_jprint = jprint;
 
         Precice_FulfilledWriteCheckpoint();
       }
@@ -3719,14 +3718,12 @@ void nonlingeo_precice(double **cop, ITG *nk, ITG **konp, ITG **ipkonp, char **l
     if (Precice_IsReadCheckpointRequired()) {
       if (*nmethod == 4) {
         Precice_ReadIterationCheckpoint(&simulationData, vini, veini, accini);
-        iinc = iinc_old;
-        jprint = jprint_old;
+        iinc = simulationData.stored_iinc;
+        jprint simulationData.stored_jprint;
 
         icutb++;
 
         *kode = kode_backup;
-
-
       }
       Precice_FulfilledReadCheckpoint();
     }

--- a/nonlingeo_precice.c
+++ b/nonlingeo_precice.c
@@ -1640,15 +1640,9 @@ void nonlingeo_precice(double **cop, ITG *nk, ITG **konp, ITG **ipkonp, char **l
   printf("Creating a buffer to output correctly when subcycling is used.\n");
   outputBuffer *out_buffer = BufferCreate();
 
-  double* vold_checkpoint, *xbounact_checkpoint, *fini_checkpoint, *veini_checkpoint, *accinit_checkpoint; //Value at the beginning of a time window
   ITG     kode_backup;
   int iinc_old, jprint_old;
-  NNEW(vold_checkpoint, double, mt **nk);
-  NNEW(veini_checkpoint, double, mt **nk);
-  NNEW(accinit_checkpoint, double, mt **nk);
 
-  NNEW(xbounact_checkpoint, double, *nboun);
-  NNEW(fini_checkpoint, double, neq[1]);
   while (Precice_IsCouplingOngoing()) {
 
     /* Adapter: Adjust solver time step */
@@ -1686,31 +1680,6 @@ void nonlingeo_precice(double **cop, ITG *nk, ITG **konp, ITG **ipkonp, char **l
         // TODO
         iinc_old = iinc;
         jprint_old = jprint;
-
-        if (*nmethod == 4) {
-          if (*iexpl <= 1) {
-            isiz = mt * *nk;
-            cpypardou(veini_checkpoint, veold, &isiz, &num_cpus);
-            cpypardou(accinit_checkpoint, accold, &isiz, &num_cpus);
-          }
-          isiz = mt * *nk;
-          cpypardou(fnextini, fnext, &isiz, &num_cpus);
-
-          isiz = neq[1];
-          cpypardou(fextini, fext, &isiz, &num_cpus);
-          cpypardou(cvini, cv, &isiz, &num_cpus);
-
-          if (*ithermal < 2) {
-            allwkini = allwk;
-            // MPADD start
-            if (idamping == 1)
-              dampwkini = dampwk;
-            for (k = 0; k < 4; k++) {
-              energyini[k] = energy[k];
-            }
-            // MPADD end
-          }
-        }
 
         //END TODO
         Precice_FulfilledWriteCheckpoint();

--- a/nonlingeo_precice.c
+++ b/nonlingeo_precice.c
@@ -1680,17 +1680,8 @@ void nonlingeo_precice(double **cop, ITG *nk, ITG **konp, ITG **ipkonp, char **l
         iinc++;
         jprint++;
 
-        // Save start-of-increment things.
-        isiz = mt * *nk;
-        cpypardou(vold_checkpoint, vold, &isiz, &num_cpus);
-
-        isiz = *nboun;
-        cpypardou(xbounact_checkpoint, xbounact, &isiz, &num_cpus);
 
         kode_backup = *kode;
-
-        isiz = neq[1];
-        cpypardou(fini_checkpoint, f, &isiz, &num_cpus);
 
         // TODO
         iinc_old = iinc;
@@ -3770,17 +3761,10 @@ void nonlingeo_precice(double **cop, ITG *nk, ITG **konp, ITG **ipkonp, char **l
         iinc = iinc_old;
         jprint = jprint_old;
 
-        isiz = *nboun;
-
-        cpypardou(xbounact, xbounact_checkpoint, &isiz, &num_cpus);
-        cpypardou(xbounini, xbounact_checkpoint, &isiz, &num_cpus);
         icutb++;
 
         *kode = kode_backup;
 
-        isiz = neq[1];
-        cpypardou(fini, fini_checkpoint, &isiz, &num_cpus);
-        cpypardou(f, fini_checkpoint, &isiz, &num_cpus);
 
       }
       Precice_FulfilledReadCheckpoint();

--- a/nonlingeo_precice.c
+++ b/nonlingeo_precice.c
@@ -3719,7 +3719,7 @@ void nonlingeo_precice(double **cop, ITG *nk, ITG **konp, ITG **ipkonp, char **l
       if (*nmethod == 4) {
         Precice_ReadIterationCheckpoint(&simulationData, vini, veini, accini);
         iinc = simulationData.stored_iinc;
-        jprint simulationData.stored_jprint;
+        jprint = simulationData.stored_jprint;
 
         icutb++;
 

--- a/nonlingeo_precice.c
+++ b/nonlingeo_precice.c
@@ -1635,8 +1635,7 @@ void nonlingeo_precice(double **cop, ITG *nk, ITG **konp, ITG **ipkonp, char **l
   /* Adapter: Create the interfaces and initialize the coupling */
   Precice_Setup(configFilename, preciceParticipantName, &simulationData);
 
-
-  ITG     kode_backup;
+  ITG kode_backup;
 
   while (Precice_IsCouplingOngoing()) {
 
@@ -1649,7 +1648,6 @@ void nonlingeo_precice(double **cop, ITG *nk, ITG **konp, ITG **ipkonp, char **l
 
       /* previous increment converged: update the initial values */
 
-      
       /* store number of elements (important for implicit dynamic
    contact */
 
@@ -1669,8 +1667,8 @@ void nonlingeo_precice(double **cop, ITG *nk, ITG **konp, ITG **ipkonp, char **l
         iinc++;
         jprint++;
 
-        kode_backup = *kode;
-        simulationData.stored_iinc = iinc;
+        kode_backup                  = *kode;
+        simulationData.stored_iinc   = iinc;
         simulationData.stored_jprint = jprint;
 
         Precice_FulfilledWriteCheckpoint();
@@ -3718,7 +3716,7 @@ void nonlingeo_precice(double **cop, ITG *nk, ITG **konp, ITG **ipkonp, char **l
     if (Precice_IsReadCheckpointRequired()) {
       if (*nmethod == 4) {
         Precice_ReadIterationCheckpoint(&simulationData, vini, veini, accini);
-        iinc = simulationData.stored_iinc;
+        iinc   = simulationData.stored_iinc;
         jprint = simulationData.stored_jprint;
 
         icutb++;

--- a/nonlingeo_precice.c
+++ b/nonlingeo_precice.c
@@ -1675,7 +1675,7 @@ void nonlingeo_precice(double **cop, ITG *nk, ITG **konp, ITG **ipkonp, char **l
       cpypardou(xbounini, xbounact, &isiz, &num_cpus);
 
       if (Precice_IsWriteCheckpointRequired()) {
-        Precice_WriteIterationCheckpoint(&simulationData, vini);
+        Precice_WriteIterationCheckpoint(&simulationData, vini, veini, accini);
 
         iinc++;
         jprint++;
@@ -3766,13 +3766,13 @@ void nonlingeo_precice(double **cop, ITG *nk, ITG **konp, ITG **ipkonp, char **l
     /* Adapter: If the coupling does not converge, read the checkpoint */
     if (Precice_IsReadCheckpointRequired()) {
       if (*nmethod == 4) {
-        Precice_ReadIterationCheckpoint(&simulationData, vold);
+        Precice_ReadIterationCheckpoint(&simulationData, vini, veini, accini);
         iinc = iinc_old;
         jprint = jprint_old;
 
         isiz = mt * *nk;
-        cpypardou(vold, vold_checkpoint, &isiz, &num_cpus);
-        cpypardou(vini, vold_checkpoint, &isiz, &num_cpus);
+        //cpypardou(vold, vold_checkpoint, &isiz, &num_cpus);
+        //cpypardou(vini, vold_checkpoint, &isiz, &num_cpus);
         isiz = *nboun;
 
         cpypardou(xbounact, xbounact_checkpoint, &isiz, &num_cpus);
@@ -3786,11 +3786,11 @@ void nonlingeo_precice(double **cop, ITG *nk, ITG **konp, ITG **ipkonp, char **l
         cpypardou(f, fini_checkpoint, &isiz, &num_cpus);
 
         isiz = mt * *nk;
-        cpypardou(veini, veini_checkpoint, &isiz, &num_cpus);
-        cpypardou(veold, veini_checkpoint, &isiz, &num_cpus);
+        //cpypardou(veini, veini_checkpoint, &isiz, &num_cpus);
+        //cpypardou(veold, veini_checkpoint, &isiz, &num_cpus);
 
-        cpypardou(accini, accinit_checkpoint, &isiz, &num_cpus);
-        cpypardou(accold, accinit_checkpoint, &isiz, &num_cpus);
+        //cpypardou(accini, accinit_checkpoint, &isiz, &num_cpus);
+        //cpypardou(accold, accinit_checkpoint, &isiz, &num_cpus);
       }
       Precice_FulfilledReadCheckpoint();
     }

--- a/nonlingeo_precice.c
+++ b/nonlingeo_precice.c
@@ -3770,9 +3770,6 @@ void nonlingeo_precice(double **cop, ITG *nk, ITG **konp, ITG **ipkonp, char **l
         iinc = iinc_old;
         jprint = jprint_old;
 
-        isiz = mt * *nk;
-        //cpypardou(vold, vold_checkpoint, &isiz, &num_cpus);
-        //cpypardou(vini, vold_checkpoint, &isiz, &num_cpus);
         isiz = *nboun;
 
         cpypardou(xbounact, xbounact_checkpoint, &isiz, &num_cpus);
@@ -3785,12 +3782,6 @@ void nonlingeo_precice(double **cop, ITG *nk, ITG **konp, ITG **ipkonp, char **l
         cpypardou(fini, fini_checkpoint, &isiz, &num_cpus);
         cpypardou(f, fini_checkpoint, &isiz, &num_cpus);
 
-        isiz = mt * *nk;
-        //cpypardou(veini, veini_checkpoint, &isiz, &num_cpus);
-        //cpypardou(veold, veini_checkpoint, &isiz, &num_cpus);
-
-        //cpypardou(accini, accinit_checkpoint, &isiz, &num_cpus);
-        //cpypardou(accold, accinit_checkpoint, &isiz, &num_cpus);
       }
       Precice_FulfilledReadCheckpoint();
     }


### PR DESCRIPTION
(Depends on #105 )

Fixes https://github.com/precice/calculix-adapter/issues/9. Essentially, checkpointing stores more data than previously (not only positions, but velocities and a few more things), because those additional fields must be stored when going back from more than an increment (time step). So previous implementation worked only when there was one step per window.

Still WIP:

- [x] Refactoring & cleaning
- [ ] Outputting once per time step instead of once per window (using the buffer from #105)
- [ ] Allow user-defined output frequency (once every N steps)
- [ ] Testing on more cases, including thermal cases (only perpendicular flap so far)
- [x] Check for redundancy (I may have copied more data than necessary?)
