### PR TITLE
Use includes in more build steps

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -84,9 +84,9 @@ $(OBJDIR)/%.o : %.c
 $(OBJDIR)/%.o : %.f
 	$(FC) $(FFLAGS) -c $< -o $@
 $(OBJDIR)/%.o : adapter/%.c
-	$(CC) $(CFLAGS) -c $< -o $@
+	$(CC) $(CFLAGS) $(INCLUDES) -c $< -o $@
 $(OBJDIR)/%.o : adapter/%.cpp
-	g++ -std=c++11 $(YAML_INCLUDE) -c $< -o $@ $(LIBS)
+	g++ -std=c++11 $(CFLAGS) $(INCLUDES) -c $< -o $@ $(LIBS)
 	#$(CC) $(CFLAGS) $(INCLUDES) -c $< -o $@ $(LIBS)
 
 # Source files in the $(CCX) folder


### PR DESCRIPTION
Without these, I cannot build with preCICE in the build directory, without modifying my `INCLUDE_PATH` etc. I never could, but now with v2.5.1, I was sure that it should somehow work only with pkgconfig.