### PR TITLE
Update actions/upload-artifact version

### DIFF
--- a/.github/workflows/ubuntu_build.yml
+++ b/.github/workflows/ubuntu_build.yml
@@ -56,7 +56,7 @@ jobs:
     - name: Compute SHA256 checksum
       run: sha256sum "packaging/${{env.PACKAGE_NAME}}_${{matrix.name}}.deb" > "packaging/${{env.PACKAGE_NAME}}_${{matrix.name}}.deb.sha256"
     - name: Store SHA256 checksum as artifact
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: "${{env.PACKAGE_NAME}}_${{matrix.name}}.deb.sha256"
         path: "packaging/${{env.PACKAGE_NAME}}_${{matrix.name}}.deb.sha256"

--- a/.github/workflows/ubuntu_build.yml
+++ b/.github/workflows/ubuntu_build.yml
@@ -49,7 +49,7 @@ jobs:
         cp ./bin/ccx_preCICE ./packaging/calculix-precice3_2.20.1-1_amd64/usr/bin/ccx_preCICE &&
         cd packaging && pwd && bash ./make_deb.sh ${{matrix.name}}
     - name: Store Debian package artifact
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: "${{env.PACKAGE_NAME}}_${{matrix.name}}.deb"
         path: "packaging/${{env.PACKAGE_NAME}}_${{matrix.name}}.deb"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 repos:
 # Official repo for the clang-format hook
 - repo: https://github.com/pre-commit/mirrors-clang-format
-  rev: 'v19.1.2'
+  rev: 'v8.0.1'
   hooks:
   - id: clang-format
     files: "^adapter"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 repos:
 # Official repo for the clang-format hook
 - repo: https://github.com/pre-commit/mirrors-clang-format
-  rev: 'v8.0.1'
+  rev: 'v19.1.2'
   hooks:
   - id: clang-format
     files: "^adapter"


### PR DESCRIPTION
This PR updates the used versions of https://github.com/pre-commit/mirrors-clang-format and actions/upload-artifact to more newer versions.