### PR TITLE
Remove definition of function setDoubleArrayZero from CCXHelpers.h

### DIFF
--- a/adapter/CCXHelpers.h
+++ b/adapter/CCXHelpers.h
@@ -358,14 +358,6 @@ bool isDoubleEqual(const double a, const double b);
  */
 bool isQuasi2D3D(const int quasi2D3D);
 
-/**
- * @brief Set all values of an array to 0
- * @param values is the array carrying double values
- * @param length is the number of elements in array
- * @param dim is the dimension of the array data
- */
-void setDoubleArrayZero(double *values, const int length, const int dim);
-
 /* Error messages */
 
 /**


### PR DESCRIPTION
This PR removes the definition of the function `setDoubleArrayZero` from the file `CCXHelpers.h` because it is staticely defined in `2D3DCoupling.cpp` (where it is used). The stale definition is a remnant of a previous cleanup and was noticed in https://github.com/precice/calculix-adapter/pull/118