### PR TITLE
Extend velocities writing for the 2D3D case

### DIFF
--- a/adapter/PreciceInterface.c
+++ b/adapter/PreciceInterface.c
@@ -394,8 +394,13 @@ void Precice_WriteCouplingData(SimulationData *sim)
         printf("Writing DISPLACEMENTDELTAS coupling data.\n");
         break;
       case VELOCITIES:
-        getNodeVelocities(interfaces[i]->nodeIDs, interfaces[i]->numNodes, interfaces[i]->dim, sim->veold, sim->mt, interfaces[i]->nodeVectorData);
-        precicec_writeData(interfaces[i]->couplingMeshName, interfaces[i]->velocities, interfaces[i]->numNodes, interfaces[i]->preciceNodeIDs, interfaces[i]->nodeVectorData);
+        if (isQuasi2D3D(interfaces[i]->quasi2D3D)) {
+          getNodeVelocities(interfaces[i]->nodeIDs, interfaces[i]->numNodes, interfaces[i]->dimCCX, sim->veold, sim->mt, interfaces[i]->mappingQuasi2D3D->bufferVector3D);
+          consistentVectorWrite(interfaces[i]->mappingQuasi2D3D, interfaces[i]->couplingMeshName, interfaces[i]->velocities);
+        } else {
+          getNodeVelocities(interfaces[i]->nodeIDs, interfaces[i]->numNodes, interfaces[i]->dimCCX, sim->veold, sim->mt, interfaces[i]->nodeVectorData);
+          precicec_writeData(interfaces[i]->couplingMeshName, interfaces[i]->velocities, interfaces[i]->numNodes, interfaces[i]->preciceNodeIDs, interfaces[i]->nodeVectorData);
+        }
         printf("Writing VELOCITIES coupling data.\n");
         break;
       case POSITIONS:


### PR DESCRIPTION
It looks like when reading velocities, we were not performing the same tests for the pseudo-2D case as in the rest, most probably as a result of how and when the writing of the various fields has been added to the codebase.

@IshaanDesai I think you implemented the 2D-3D mapping a while ago. Do you think this makes sense? Do you see any other places where we have similar issues?

Also related to #136: I changed one `dim` to `dimCCX`, for consistency at least in the same `case` branch.

Bug reported and fix proposed by a user in https://precice.discourse.group/t/error-happend-when-writing-velocites-from-calculix/2270
