### PR TITLE
Makefile improvements: compiler paths and version-aware flags

### DIFF
--- a/.github/workflows/request-deb-package.yaml
+++ b/.github/workflows/request-deb-package.yaml
@@ -31,7 +31,6 @@ on:
         type: string
       fflags:
         description: 'Additional fflags'
-        default: "-fallow-argument-mismatch"
         required: true
         type: string
       precice:

--- a/.github/workflows/ubuntu_build.yml
+++ b/.github/workflows/ubuntu_build.yml
@@ -18,10 +18,8 @@ jobs:
         include:
           - os: ubuntu-22.04
             name: jammy
-            flags: -fallow-argument-mismatch
           - os: ubuntu-24.04
             name: noble
-            flags: -fallow-argument-mismatch
 
     runs-on: ${{matrix.os}}
     container: precice/precice:develop

--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,9 @@ LIBS = \
 #CFLAGS = -g -Wall -std=c++11 -O0 -fopenmp $(INCLUDES) -DARCH="Linux" -DSPOOLES -DARPACK -DMATRIXSTORAGE
 #FFLAGS = -g -Wall -O0 -fopenmp $(INCLUDES)
 
-CFLAGS = -Wall -O3 -fopenmp $(INCLUDES) -DARCH="Linux" -DSPOOLES -DARPACK -DMATRIXSTORAGE -DUSE_MT -Wno-implicit-function-declaration -Wno-incompatible-pointer-types
+CFLAGS  = -Wall -O3 -fopenmp $(INCLUDES)
+CFLAGS += -DARCH="Linux" -DSPOOLES -DARPACK -DMATRIXSTORAGE -DUSE_MT
+CFLAGS += -Wno-implicit-function-declaration -Wno-incompatible-pointer-types
 
 # OS-specific options
 UNAME_S := $(shell uname -s)

--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ CFLAGS += -Wno-implicit-function-declaration -Wno-incompatible-pointer-types
 # OS-specific options
 UNAME_S := $(shell uname -s)
 ifeq ($(UNAME_S),Darwin)
-	CC = /usr/local/bin/gcc
+	CC = clang
 	LIBS += -lc++
 else
 	CC = mpicc

--- a/Makefile
+++ b/Makefile
@@ -52,9 +52,11 @@ CFLAGS += -Wno-implicit-function-declaration -Wno-incompatible-pointer-types
 UNAME_S := $(shell uname -s)
 ifeq ($(UNAME_S),Darwin)
 	CC = clang
+	CXX = clang++
 	LIBS += -lc++
 else
 	CC = mpicc
+	CXX = g++
 	LIBS += -lstdc++
 endif
 
@@ -82,7 +84,7 @@ $(OBJDIR)/%.o : %.f
 $(OBJDIR)/%.o : adapter/%.c
 	$(CC) $(CFLAGS) $(INCLUDES) -c $< -o $@
 $(OBJDIR)/%.o : adapter/%.cpp
-	g++ -std=c++11 $(CFLAGS) $(INCLUDES) -c $< -o $@ $(LIBS)
+	$(CXX) -std=c++11 $(CFLAGS) $(INCLUDES) -c $< -o $@ $(LIBS)
 	#$(CC) $(CFLAGS) $(INCLUDES) -c $< -o $@ $(LIBS)
 
 # Source files in the $(CCX) folder

--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,6 @@ INCLUDES = \
 LIBS = \
 	$(SPOOLES_LIBS) \
 	$(PKGCONF_LIBS) \
-	-lstdc++ \
 	$(ARPACK_LIBS) \
 	-lpthread -lm -lc
 
@@ -51,8 +50,10 @@ CFLAGS = -Wall -O3 -fopenmp $(INCLUDES) -DARCH="Linux" -DSPOOLES -DARPACK -DMATR
 UNAME_S := $(shell uname -s)
 ifeq ($(UNAME_S),Darwin)
 	CC = /usr/local/bin/gcc
+	LIBS += -lc++
 else
 	CC = mpicc
+	LIBS += -lstdc++
 endif
 
 FFLAGS = -Wall -O3 -fopenmp $(INCLUDES) ${ADDITIONAL_FFLAGS} -Wno-implicit-function-declaration

--- a/Makefile
+++ b/Makefile
@@ -48,9 +48,6 @@ CFLAGS  = -Wall -O3 -fopenmp $(INCLUDES)
 CFLAGS += -DARCH="Linux" -DSPOOLES -DARPACK -DMATRIXSTORAGE -DUSE_MT
 CFLAGS += -Wno-implicit-function-declaration -Wno-incompatible-pointer-types
 
-# yaml-cpp 0.6.0+ requires C++11
-CXXFLAGS += -std=c++11
-
 # OS-specific options
 UNAME_S := $(shell uname -s)
 ifeq ($(UNAME_S),Darwin)
@@ -90,7 +87,7 @@ $(OBJDIR)/%.o : %.f
 $(OBJDIR)/%.o : adapter/%.c
 	$(CC) $(CFLAGS) -c $< -o $@
 $(OBJDIR)/%.o : adapter/%.cpp
-	$(CXX) $(CXXFLAGS) $(CFLAGS) -c $< -o $@
+	$(CXX) $(CFLAGS) -c $< -o $@
 
 # Source files in the $(CCX) folder
 $(OBJDIR)/%.o : $(CCX)/%.c

--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ ifeq ($(UNAME_S),Darwin)
 	LIBS += -lc++
 else
 	CC = mpicc
-	CXX = g++
+	CXX = mpic++
 	LIBS += -lstdc++
 endif
 

--- a/Makefile
+++ b/Makefile
@@ -85,10 +85,9 @@ $(OBJDIR)/%.o : %.c
 $(OBJDIR)/%.o : %.f
 	$(FC) $(FFLAGS) -c $< -o $@
 $(OBJDIR)/%.o : adapter/%.c
-	$(CC) $(CFLAGS) $(INCLUDES) -c $< -o $@
+	$(CC) $(CFLAGS) -c $< -o $@
 $(OBJDIR)/%.o : adapter/%.cpp
-	$(CXX) -std=c++11 $(CFLAGS) $(INCLUDES) -c $< -o $@ $(LIBS)
-	#$(CC) $(CFLAGS) $(INCLUDES) -c $< -o $@ $(LIBS)
+	$(CXX) -std=c++11 $(CFLAGS) -c $< -o $@
 
 # Source files in the $(CCX) folder
 $(OBJDIR)/%.o : $(CCX)/%.c

--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,10 @@ else
 endif
 
 FFLAGS = -Wall -O3 -fopenmp $(INCLUDES) ${ADDITIONAL_FFLAGS} -Wno-implicit-function-declaration
-# Note for GCC 10 or newer: add -fallow-argument-mismatch in the above flags
+GCC_VERSION_MAJOR := $(shell $(CC) -dumpversion | cut -d. -f1)
+ifeq ($(shell [ $(GCC_VERSION_MAJOR) -ge 10 ] && echo yes),yes)
+	FFLAGS += -fallow-argument-mismatch
+endif
 FC = mpifort
 # FC = mpif90
 # FC = gfortran

--- a/Makefile
+++ b/Makefile
@@ -48,6 +48,9 @@ CFLAGS  = -Wall -O3 -fopenmp $(INCLUDES)
 CFLAGS += -DARCH="Linux" -DSPOOLES -DARPACK -DMATRIXSTORAGE -DUSE_MT
 CFLAGS += -Wno-implicit-function-declaration -Wno-incompatible-pointer-types
 
+# yaml-cpp 0.6.0+ requires C++11
+CXXFLAGS += -std=c++11
+
 # OS-specific options
 UNAME_S := $(shell uname -s)
 ifeq ($(UNAME_S),Darwin)
@@ -87,7 +90,7 @@ $(OBJDIR)/%.o : %.f
 $(OBJDIR)/%.o : adapter/%.c
 	$(CC) $(CFLAGS) -c $< -o $@
 $(OBJDIR)/%.o : adapter/%.cpp
-	$(CXX) -std=c++11 $(CFLAGS) -c $< -o $@
+	$(CXX) $(CXXFLAGS) $(CFLAGS) -c $< -o $@
 
 # Source files in the $(CCX) folder
 $(OBJDIR)/%.o : $(CCX)/%.c

--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ LIBS = \
 #CFLAGS = -g -Wall -std=c++11 -O0 -fopenmp $(INCLUDES) -DARCH="Linux" -DSPOOLES -DARPACK -DMATRIXSTORAGE
 #FFLAGS = -g -Wall -O0 -fopenmp $(INCLUDES)
 
-CFLAGS = -Wall -O3 -fopenmp $(INCLUDES) -DARCH="Linux" -DSPOOLES -DARPACK -DMATRIXSTORAGE -DUSE_MT -Wno-implicit-function-declaration
+CFLAGS = -Wall -O3 -fopenmp $(INCLUDES) -DARCH="Linux" -DSPOOLES -DARPACK -DMATRIXSTORAGE -DUSE_MT -Wno-implicit-function-declaration -Wno-incompatible-pointer-types
 
 # OS-specific options
 UNAME_S := $(shell uname -s)

--- a/Makefile
+++ b/Makefile
@@ -60,14 +60,17 @@ else
 	LIBS += -lstdc++
 endif
 
-FFLAGS = -Wall -O3 -fopenmp $(INCLUDES) ${ADDITIONAL_FFLAGS} -Wno-implicit-function-declaration
-GCC_VERSION_MAJOR := $(shell $(CC) -dumpversion | cut -d. -f1)
-ifeq ($(shell [ $(GCC_VERSION_MAJOR) -ge 10 ] && echo yes),yes)
-	FFLAGS += -fallow-argument-mismatch
-endif
 FC = mpifort
 # FC = mpif90
 # FC = gfortran
+FFLAGS = -Wall -O3 -fopenmp $(INCLUDES) ${ADDITIONAL_FFLAGS} -Wno-implicit-function-declaration
+FC_NAME := $(shell $(FC) --version 2>/dev/null | head -n 1 | cut -d' ' -f1)
+ifeq ($(FC_NAME),GNU)
+  GCC_VERSION_MAJOR := $(shell $(FC) -dumpversion | cut -d. -f1)
+  ifeq ($(shell [ $(GCC_VERSION_MAJOR) -ge 10 ] && echo yes),yes)
+    FFLAGS += -fallow-argument-mismatch
+  endif
+endif
 
 # Include a list of all the source files
 include $(CCX)/Makefile.inc

--- a/Makefile
+++ b/Makefile
@@ -64,8 +64,7 @@ FC = mpifort
 # FC = mpif90
 # FC = gfortran
 FFLAGS = -Wall -O3 -fopenmp $(INCLUDES) ${ADDITIONAL_FFLAGS} -Wno-implicit-function-declaration
-FC_NAME := $(shell $(FC) --version 2>/dev/null | head -n 1 | cut -d' ' -f1)
-ifeq ($(FC_NAME),GNU)
+ifeq ($(findstring GNU,$(shell $(FC) --version)),GNU)
   GCC_VERSION_MAJOR := $(shell $(FC) -dumpversion | cut -d. -f1)
   ifeq ($(shell [ $(GCC_VERSION_MAJOR) -ge 10 ] && echo yes),yes)
     FFLAGS += -fallow-argument-mismatch


### PR DESCRIPTION
Hi,

This is a PR based on [this discussion](https://precice.discourse.group/t/problem-linking-adapted-calculix-against-yaml-cpp-macos/2264). The main goal is to update `:/Makefile` so that the adapter can be built on macOS as well.

In short, the adaptor couldn't link against `yaml-cpp`, because the compilation was done using `gcc`, `g++` and `-lstdc++`. Changing these to `clang`, `clang++`, and `-lc++` fixed that.

Other compilation issues encountered included:
- (C) Implicit declaration of functions
- (C) Incompatible pointer types
- (Fortran) -fallow-argument-mismatch