### PR TITLE
CI: Remove ubuntu-20.04, add ubuntu-24.04

### DIFF
--- a/.github/workflows/ubuntu_build.yml
+++ b/.github/workflows/ubuntu_build.yml
@@ -14,13 +14,13 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-20.04, ubuntu-22.04]
+        os: [ubuntu-22.04, ubuntu-24.04]
         include:
-          - os: ubuntu-20.04
-            name: focal
-            flags: -fallow-argument-mismatch
           - os: ubuntu-22.04
             name: jammy
+            flags: -fallow-argument-mismatch
+          - os: ubuntu-24.04
+            name: noble
             flags: -fallow-argument-mismatch
 
     runs-on: ${{matrix.os}}


### PR DESCRIPTION
The `ubuntu-20.04` runners are scheduled for removal soon. At the same time, we are not testing the build on Ubuntu 24.04.

This PR removes 20.04 and adds 24.04 in the `ubuntu_build.yml` workflow.