### PR TITLE
Config: Prevent access to size of non-existent read-data/write-data

### DIFF
--- a/adapter/ConfigReader.cpp
+++ b/adapter/ConfigReader.cpp
@@ -63,10 +63,8 @@ void ConfigReader_Read(char const *configFilename, char const *participantName, 
     std::transform(patchName.begin(), patchName.end(), patchName.begin(), toupper);
     interface.patchName = strdup(patchName.c_str());
 
-    interface.numWriteData = config["participants"][participantName]["interfaces"][i]["write-data"].size();
-    interface.numReadData  = config["participants"][participantName]["interfaces"][i]["read-data"].size();
-
     if (config["participants"][participantName]["interfaces"][i].contains("write-data")) {
+      interface.numWriteData = config["participants"][participantName]["interfaces"][i]["write-data"].size();
       if (interface.numWriteData == 0) {
         // write-data is a string
         interface.numWriteData      = 1;
@@ -83,6 +81,7 @@ void ConfigReader_Read(char const *configFilename, char const *participantName, 
     }
 
     if (config["participants"][participantName]["interfaces"][i].contains("read-data")) {
+      interface.numReadData = config["participants"][participantName]["interfaces"][i]["read-data"].size();
       if (interface.numReadData == 0) {
         // read-data is a string
         interface.numReadData      = 1;


### PR DESCRIPTION
Bugfix for an issue reported by a user in https://precice.discourse.group/t/error-from-the-calculix-adapter-for-cht-coupling-with-heat-flux/2718

Running the `flow-over-heated-plate-two-meshes` tutorial, the CalculiX adapter fails with:

```
terminate called after throwing an instance of ‘fkyaml::v0_4_2::type_error’
what():  type_error: The target node is not of a container type. type=NULL_OBJECT
```

because the configuration only includes one of `write-data`/`read-data` per interface, but not both:

```
participants:
    Solid:
        interfaces:
        - nodes-mesh: Solid-Mesh-nodes
          patch: yend
          read-data: [Temperature]
        - faces-mesh: Solid-Mesh
          patch: flux_interface
          write-data: [Heat-Flux]
```

triggering a behavior similar to the one described in #35 for uni-directional coupling per interface.

This PR moves the `config["participants"][participantName]["interfaces"][i]["write-data"].size();` operator into the branch that first checks if `config["participants"][participantName]["interfaces"][i]["write-data"]` exists.

No changelog entry is needed, since this has not been released yet (introduced after the latest release, in #143).

Merging to ship it to the user. Changes are rather trivial, and I considered documentation.

System test is following.