### PR TITLE
Bump versions of GitHub Actions and pre-commit hooks

### DIFF
--- a/.github/workflows/request-deb-package.yaml
+++ b/.github/workflows/request-deb-package.yaml
@@ -61,7 +61,7 @@ jobs:
       - name: preCICE version
         run: precice-tools version
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ github.event.inputs.release }}
 

--- a/.github/workflows/run-checks.yml
+++ b/.github/workflows/run-checks.yml
@@ -19,7 +19,7 @@ jobs:
           python-version: '3.14'
           check-latest: true
       - name: Install pre-commit
-        run: pip install setuptools pre-commit
+        run: pip install setuptools~=81.0 pre-commit # See https://github.com/pypa/setuptools/issues/3085 and https://setuptools.pypa.io/en/stable/history.html#v82-0-0
       - name: Run checks
         run: pre-commit run -a -v
       - name: Git status

--- a/.github/workflows/run-checks.yml
+++ b/.github/workflows/run-checks.yml
@@ -16,10 +16,10 @@ jobs:
       - name: Setup python
         uses: actions/setup-python@v6
         with:
-          python-version: '3.10'
+          python-version: '3.14'
           check-latest: true
       - name: Install pre-commit
-        run: pip install setuptools~=75.0 pre-commit # See https://github.com/pypa/setuptools/issues/3085 and https://setuptools.pypa.io/en/stable/history.html#v82-0-0
+        run: pip install pre-commit
       - name: Run checks
         run: pre-commit run -a -v
       - name: Git status

--- a/.github/workflows/run-checks.yml
+++ b/.github/workflows/run-checks.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup python
         uses: actions/setup-python@v6
         with:
-          python-version: '3.14'
+          python-version: '3.10'
           check-latest: true
       - name: Install pre-commit
         run: pip install setuptools~=75.0 pre-commit # See https://github.com/pypa/setuptools/issues/3085 and https://setuptools.pypa.io/en/stable/history.html#v82-0-0

--- a/.github/workflows/run-checks.yml
+++ b/.github/workflows/run-checks.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup python
         uses: actions/setup-python@v6
         with:
-          python-version: '3.10'
+          python-version: '3.14'
           check-latest: true
       - name: Install pre-commit
         run: pip install pre-commit

--- a/.github/workflows/run-checks.yml
+++ b/.github/workflows/run-checks.yml
@@ -12,9 +12,9 @@ jobs:
     name: pre-commit checks
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Setup python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.10'
           check-latest: true

--- a/.github/workflows/run-checks.yml
+++ b/.github/workflows/run-checks.yml
@@ -19,7 +19,7 @@ jobs:
           python-version: '3.14'
           check-latest: true
       - name: Install pre-commit
-        run: pip install pre-commit
+        run: pip install setuptools pre-commit
       - name: Run checks
         run: pre-commit run -a -v
       - name: Git status

--- a/.github/workflows/run-checks.yml
+++ b/.github/workflows/run-checks.yml
@@ -19,7 +19,7 @@ jobs:
           python-version: '3.14'
           check-latest: true
       - name: Install pre-commit
-        run: pip install setuptools~=81.0 pre-commit # See https://github.com/pypa/setuptools/issues/3085 and https://setuptools.pypa.io/en/stable/history.html#v82-0-0
+        run: pip install setuptools~=75.0 pre-commit # See https://github.com/pypa/setuptools/issues/3085 and https://setuptools.pypa.io/en/stable/history.html#v82-0-0
       - name: Run checks
         run: pre-commit run -a -v
       - name: Git status

--- a/.github/workflows/ubuntu_build.yml
+++ b/.github/workflows/ubuntu_build.yml
@@ -33,7 +33,7 @@ jobs:
         apt-get -qq update
         apt-get -qq install sudo
         sudo apt update && sudo apt upgrade -y
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v6
       with:
         ref: ${{ github.ref }}
     - name: install dependencies
@@ -54,14 +54,14 @@ jobs:
         cp ./bin/ccx_preCICE ./packaging/calculix-precice3_2.20.1-1_amd64/usr/bin/ccx_preCICE &&
         cd packaging && pwd && bash ./make_deb.sh ${{matrix.name}}
     - name: Store Debian package artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: "${{env.PACKAGE_NAME}}_${{matrix.name}}.deb"
         path: "packaging/${{env.PACKAGE_NAME}}_${{matrix.name}}.deb"
     - name: Compute SHA256 checksum
       run: sha256sum "packaging/${{env.PACKAGE_NAME}}_${{matrix.name}}.deb" > "packaging/${{env.PACKAGE_NAME}}_${{matrix.name}}.deb.sha256"
     - name: Store SHA256 checksum as artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: "${{env.PACKAGE_NAME}}_${{matrix.name}}.deb.sha256"
         path: "packaging/${{env.PACKAGE_NAME}}_${{matrix.name}}.deb.sha256"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 repos:
 # Official repo for the clang-format hook
 - repo: https://github.com/pre-commit/mirrors-clang-format
-  rev: 'v10.0.1'
+  rev: 'v11.1.0'
   hooks:
   - id: clang-format
     files: "^adapter"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 repos:
 # Official repo for the clang-format hook
 - repo: https://github.com/pre-commit/mirrors-clang-format
-  rev: 'v8.0.1'
+  rev: 'v22.1.5'
   hooks:
   - id: clang-format
     files: "^adapter"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 repos:
 # Official repo for the clang-format hook
 - repo: https://github.com/pre-commit/mirrors-clang-format
-  rev: 'v11.1.0'
+  rev: 'v12.0.1'
   hooks:
   - id: clang-format
     files: "^adapter"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
     exclude: "^adapter/fkYAML.hpp"
 # Official repo for default hooks
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: 'v4.3.0'
+  rev: 'v6.0.0'
   hooks:
   - id: check-xml
   - id: check-merge-conflict

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 repos:
 # Official repo for the clang-format hook
 - repo: https://github.com/pre-commit/mirrors-clang-format
-  rev: 'v22.1.5'
+  rev: 'v10.0.1'
   hooks:
   - id: clang-format
     files: "^adapter"


### PR DESCRIPTION
This PR:

1. Fixes the pre-commit failure

```
Traceback (most recent call last):
  File "/home/runner/.cache/pre-commit/repo2fd_4n10/py_env-python3.14/bin/clang-format", line 3, in <module>
    from clang_format import clang_format
  File "/home/runner/.cache/pre-commit/repo2fd_4n10/py_env-python3.14/lib/python3.14/site-packages/clang_format/__init__.py", line 5, in <module>
    import pkg_resources
ModuleNotFoundError: No module named 'pkg_resources'
```

by upgrading https://github.com/pre-commit/mirrors-clang-format to v12. This is the most recent version that works and does not modify the formatting of this codebase (without changing the specification file).

2. Fixes the warning

```
 Warning:  repo `https://github.com/pre-commit/pre-commit-hooks` uses deprecated stage names (commit, push) which will be removed in a future version.
```

by upgrading https://github.com/pre-commit/pre-commit-hooks to the latest version.

3. Bumps the versions of the used GitHub Actions.
4. Bumps the Python version used by the `setup-python` action.