### PR TITLE
Prepare documentation for rendering in Hugo

### DIFF
--- a/docs/adapter-calculix-configure.md
+++ b/docs/adapter-calculix-configure.md
@@ -1,6 +1,7 @@
 ---
 title: Configure the CalculiX adapter
 permalink: adapter-calculix-config.html
+url: /adapter-calculix-config.html
 keywords: adapter, calculix, configuration, config.yml
 summary: "Write a config.yml, write a CalculiX case input file, and run an adapted CalculiX executable."
 ---

--- a/docs/adapter-calculix-configure.md
+++ b/docs/adapter-calculix-configure.md
@@ -1,7 +1,8 @@
 ---
 title: Configure the CalculiX adapter
 permalink: adapter-calculix-config.html
-url: /adapter-calculix-config.html
+aliases:
+  - /adapter-calculix-config.html
 keywords: adapter, calculix, configuration, config.yml
 summary: "Write a config.yml, write a CalculiX case input file, and run an adapted CalculiX executable."
 ---

--- a/docs/adapter-calculix-get-adapter.md
+++ b/docs/adapter-calculix-get-adapter.md
@@ -1,7 +1,8 @@
 ---
 title: Get the CalculiX adapter
 permalink: adapter-calculix-get-adapter.html
-url: /adapter-calculix-get-adapter.html
+aliases:
+  - /adapter-calculix-get-adapter.html
 keywords: adapter, calculix, building
 summary: "The CalculiX adapter provides the executable `ccx_preCICE`. You can get the adapter either from a Debian package (on Ubuntu), or build it from source."
 ---

--- a/docs/adapter-calculix-get-adapter.md
+++ b/docs/adapter-calculix-get-adapter.md
@@ -1,6 +1,7 @@
 ---
 title: Get the CalculiX adapter
 permalink: adapter-calculix-get-adapter.html
+url: /adapter-calculix-get-adapter.html
 keywords: adapter, calculix, building
 summary: "The CalculiX adapter provides the executable `ccx_preCICE`. You can get the adapter either from a Debian package (on Ubuntu), or build it from source."
 ---

--- a/docs/adapter-calculix-get-calculix.md
+++ b/docs/adapter-calculix-get-calculix.md
@@ -1,6 +1,7 @@
 ---
 title: Get CalculiX
 permalink: adapter-calculix-get-calculix.html
+url: /adapter-calculix-get-calculix.html
 keywords: adapter, calculix, building, spooles, arpack, yaml-cpp
 summary: "Building CalculiX itself can already be quite a challenge. That's why we collected here some recipe."
 ---

--- a/docs/adapter-calculix-get-calculix.md
+++ b/docs/adapter-calculix-get-calculix.md
@@ -1,7 +1,8 @@
 ---
 title: Get CalculiX
 permalink: adapter-calculix-get-calculix.html
-url: /adapter-calculix-get-calculix.html
+aliases:
+  - /adapter-calculix-get-calculix.html
 keywords: adapter, calculix, building, spooles, arpack, yaml-cpp
 summary: "Building CalculiX itself can already be quite a challenge. That's why we collected here some recipe."
 ---

--- a/docs/adapter-calculix-overview.md
+++ b/docs/adapter-calculix-overview.md
@@ -1,6 +1,9 @@
 ---
 title: The CalculiX adapter
 permalink: adapter-calculix-overview.html
+url: /adapter-calculix-overview.html
+aliases:
+  - /adapter-calculix.html
 redirect_from: adapter-calculix.html
 keywords: adapter, calculix
 summary: "The CalculiX adapter can be used to couple CalculiX to CFD solvers for FSI or CHT application or even to couple CalculiX to itself."

--- a/docs/adapter-calculix-overview.md
+++ b/docs/adapter-calculix-overview.md
@@ -1,8 +1,8 @@
 ---
 title: The CalculiX adapter
 permalink: adapter-calculix-overview.html
-url: /adapter-calculix-overview.html
 aliases:
+  - /adapter-calculix-overview.html
   - /adapter-calculix.html
 redirect_from: adapter-calculix.html
 keywords: adapter, calculix

--- a/docs/adapter-calculix-pastix-build.md
+++ b/docs/adapter-calculix-pastix-build.md
@@ -1,7 +1,8 @@
 ---
 title: Building the Calculix adapter with PaStiX (and CalculiX 2.17)
 permalink: adapter-calculix-pastix-build.html
-url: /adapter-calculix-pastix-build.html
+aliases:
+  - /adapter-calculix-pastix-build.html
 keywords: adapter, calculix, pastix
 summary: "Since version 2.17, CalculiX can be built with the PaStiX library to increase performance with CUDA. Building the preCICE adapter
 is somehow harder with this version. This page gives a detailed walkthrough to build the modified adapter."

--- a/docs/adapter-calculix-pastix-build.md
+++ b/docs/adapter-calculix-pastix-build.md
@@ -1,6 +1,7 @@
 ---
 title: Building the Calculix adapter with PaStiX (and CalculiX 2.17)
 permalink: adapter-calculix-pastix-build.html
+url: /adapter-calculix-pastix-build.html
 keywords: adapter, calculix, pastix
 summary: "Since version 2.17, CalculiX can be built with the PaStiX library to increase performance with CUDA. Building the preCICE adapter
 is somehow harder with this version. This page gives a detailed walkthrough to build the modified adapter."

--- a/docs/adapter-calculix-supermuc.md
+++ b/docs/adapter-calculix-supermuc.md
@@ -1,6 +1,7 @@
 ---
 title: Building the CalculiX adapter on SuperMUC
 permalink: adapter-calculix-supermuc.html
+url: /adapter-calculix-supermuc.html
 keywords: adapter, calculix, cluster, modules
 summary: "This page explains how to build the CalculiX adapter on SuperMUC. Even though SuperMUC was shut down in 2019, this page may still be useful for other clusters."
 ---

--- a/docs/adapter-calculix-supermuc.md
+++ b/docs/adapter-calculix-supermuc.md
@@ -1,7 +1,8 @@
 ---
 title: Building the CalculiX adapter on SuperMUC
 permalink: adapter-calculix-supermuc.html
-url: /adapter-calculix-supermuc.html
+aliases:
+  - /adapter-calculix-supermuc.html
 keywords: adapter, calculix, cluster, modules
 summary: "This page explains how to build the CalculiX adapter on SuperMUC. Even though SuperMUC was shut down in 2019, this page may still be useful for other clusters."
 ---

--- a/docs/adapter-calculix-troubleshooting.md
+++ b/docs/adapter-calculix-troubleshooting.md
@@ -1,7 +1,8 @@
 ---
 title: Troubleshooting the CalculiX adapter
 permalink: adapter-calculix-troubleshooting.html
-url: /adapter-calculix-troubleshooting.html
+aliases:
+  - /adapter-calculix-troubleshooting.html
 keywords: adapter, calculix, error
 summary: "While working with the CalculiX adapter, you may run onto common issues. This is a collection of what we know could go wrong."
 ---

--- a/docs/adapter-calculix-troubleshooting.md
+++ b/docs/adapter-calculix-troubleshooting.md
@@ -1,6 +1,7 @@
 ---
 title: Troubleshooting the CalculiX adapter
 permalink: adapter-calculix-troubleshooting.html
+url: /adapter-calculix-troubleshooting.html
 keywords: adapter, calculix, error
 summary: "While working with the CalculiX adapter, you may run onto common issues. This is a collection of what we know could go wrong."
 ---


### PR DESCRIPTION
Preserve the existing calculix-adapter documentation URL for the Hugo migration
