### PR TITLE
Move `struct SimulationData` to just before `Precice_Setup`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 
+- Moved `struct SimulationData` in `nonlingeo_precice.h` to just before `Precice_Setup` ([#154](https://github.com/precice/calculix-adapter/pull/154))
 - Improved Makefile with respect to compiler flags and version-aware flags ([#139](https://github.com/precice/calculix-adapter/pull/139)).
 - Migrated to header-only yaml-cpp ([#143](https://github.com/precice/calculix-adapter/pull/143)).
 

--- a/nonlingeo_precice.c
+++ b/nonlingeo_precice.c
@@ -308,50 +308,6 @@ void nonlingeo_precice(double **cop, ITG *nk, ITG **konp, ITG **ipkonp, char **l
   tmax  = &timepar[3];
   tincf = &timepar[4];
 
-  /* Adapter: Put all the CalculiX data that is needed for the coupling into an array */
-  struct SimulationData simulationData = {
-      .ialset               = ialset,
-      .ielmat               = ielmat,
-      .istartset            = istartset,
-      .iendset              = iendset,
-      .kon                  = kon,
-      .ipkon                = ipkon,
-      .lakon                = lakon,
-      .co                   = co,
-      .set                  = set,
-      .nset                 = *nset,
-      .ikboun               = ikboun,
-      .ikforc               = ikforc,
-      .ilboun               = ilboun,
-      .ilforc               = ilforc,
-      .nboun                = *nboun,
-      .nforc                = *nforc,
-      .nelemload            = nelemload,
-      .nload                = *nload,
-      .sideload             = sideload,
-      .mt                   = mt,
-      .nk                   = *nk,
-      .ne                   = *ne,
-      .theta                = &theta,
-      .dtheta               = &dtheta,
-      .tper                 = tper,
-      .nmethod              = nmethod,
-      .xload                = xload,
-      .xforc                = xforc,
-      .xboun                = xboun,
-      .ntmat_               = ntmat_,
-      .vold                 = vold,
-      .veold                = veold,
-      .fn                   = fn,
-      .cocon                = cocon,
-      .ncocon               = ncocon,
-      .mi                   = mi,
-      .isModalDynamic       = 0,
-      .eigenDOFs            = NULL,
-      .eigenDOFsDerivatives = NULL,
-      .stored_iinc          = iinc,
-      .stored_jprint        = jprint};
-
   if (*ithermal == 4) {
     uncoupled = 1;
     *ithermal = 3;
@@ -1653,6 +1609,50 @@ void nonlingeo_precice(double **cop, ITG *nk, ITG **konp, ITG **ipkonp, char **l
 
   /* Adapter: Give preCICE the control of the time stepping */
   // while((1.-theta>1.e-6)||(negpres==1)){
+
+  /* Adapter: Put all the CalculiX data that is needed for the coupling into an array */
+  struct SimulationData simulationData = {
+      .ialset               = ialset,
+      .ielmat               = ielmat,
+      .istartset            = istartset,
+      .iendset              = iendset,
+      .kon                  = kon,
+      .ipkon                = ipkon,
+      .lakon                = lakon,
+      .co                   = co,
+      .set                  = set,
+      .nset                 = *nset,
+      .ikboun               = ikboun,
+      .ikforc               = ikforc,
+      .ilboun               = ilboun,
+      .ilforc               = ilforc,
+      .nboun                = *nboun,
+      .nforc                = *nforc,
+      .nelemload            = nelemload,
+      .nload                = *nload,
+      .sideload             = sideload,
+      .mt                   = mt,
+      .nk                   = *nk,
+      .ne                   = *ne,
+      .theta                = &theta,
+      .dtheta               = &dtheta,
+      .tper                 = tper,
+      .nmethod              = nmethod,
+      .xload                = xload,
+      .xforc                = xforc,
+      .xboun                = xboun,
+      .ntmat_               = ntmat_,
+      .vold                 = vold,
+      .veold                = veold,
+      .fn                   = fn,
+      .cocon                = cocon,
+      .ncocon               = ncocon,
+      .mi                   = mi,
+      .isModalDynamic       = 0,
+      .eigenDOFs            = NULL,
+      .eigenDOFsDerivatives = NULL,
+      .stored_iinc          = iinc,
+      .stored_jprint        = jprint};
 
   /* Adapter: Create the interfaces and initialize the coupling */
   Precice_Setup(configFilename, preciceParticipantName, &simulationData);


### PR DESCRIPTION
During debugging of https://github.com/precice/calculix-adapter/pull/135, I observed that initializing `SimulationData` just before `Precice_Setup` ensures that the data structures passed to it are initialized. This resolves memory access issues during adapter initialization.

Closes #145 