### PR TITLE
Annotate adapter-related code in the main CalculiX file

### DIFF
--- a/ccx_2.20.c
+++ b/ccx_2.20.c
@@ -107,6 +107,7 @@ int main(int argc, char *argv[])
   double totalCalculixTime;
 
   /*
+ * Adapter:
  * Additional variables for the coupling with preCICE
  * preCICE is used only if a participant name is provided as a command line argument!
  */
@@ -149,6 +150,7 @@ int main(int argc, char *argv[])
 	strcpy(output,argv[i+1]);break;}
 	}*/
 
+    /* Adapter: parse a second time all command lines argument to see if some are relevant to preCICE */
     for (i = 1; i < argc; i++) {
       if (strcmp1(argv[i], "-o") == 0) {
         strcpy(output, argv[i + 1]);
@@ -1307,6 +1309,9 @@ int main(int argc, char *argv[])
     /* nmethod=14: Robustness w.r.t. to geometric tolerances */
     /* nmethod=15: Crack propagation */
     /* nmethod=16: Feasible direction based on sensitivity information */
+
+    /* Adapter: if preCICE is used, override the main loop and use our own. */
+
     if (preciceUsed) {
       int isStaticOrDynamic = ((nmethod == 1) || (nmethod == 4)) && (iperturb[0] > 1);
       int isDynamic         = ((nmethod == 4) && (iperturb[0] > 1));


### PR DESCRIPTION
First suggested by @boris-martin in #85. Instead of resolving the conflicts in that old PR, I am breaking it into parts and opening individual PRs.

There was also an assertion suggested in the same file (`assert(i + 1 < argc);`), but I don't think this is needed in that loop: the index is not modified, and there are fixed bounds set.