### PR TITLE
Add documentation on maintaining the adapter

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/release.md
+++ b/.github/PULL_REQUEST_TEMPLATE/release.md
@@ -1,0 +1,29 @@
+## Release checklist
+
+I updated the adapter version in the following:
+
+- [ ] The version listed in `README.md`
+- [ ] The `CCX_VERSION` in the Makefile(s)
+- [ ] The `pastix_pre_build.sh` file
+- [ ] Files related to the build of the Debian Package, in the `packaging` folder:
+  - `debian/DEBIAN/control`
+  - `make_deb.sh`
+  - `changelog.Debian` (where an entry should be added)
+- [ ] The Github workflow file:
+  - `.github/workflows/ubuntu_build.yml`
+  - `.github/workflows/request-deb-package.yaml`
+- [ ] The documentation pages
+- [ ] `CHANGELOG.md`
+
+Outside this repository:
+
+- [ ] [website](https://github.com/precice/precice.github.io): Update the variables:
+  - `calculix_adapter_version`
+  - `calculix_version`
+- [ ] [tutorials](https://github.com/precice/tutorials/tree/develop/tools/tests): Update the default CalculiX version in the system tests:
+  - `components.yaml`
+  - `reference_versions.yaml` (if the reference results need to be updated)
+
+System tests:
+
+- [ ] I triggered the system tests by adding the `trigger-system-tests` label.

--- a/docs/adapter-calculix-calculix-support.md
+++ b/docs/adapter-calculix-calculix-support.md
@@ -1,0 +1,49 @@
+---
+title: CalculiX support
+permalink: adapter-calculix-calculix-support.html
+aliases:
+  - /adapter-calculix-calculix-support.html
+keywords: adapter, calculix, support, versions
+summary: "Supported CalculiX versions and porting the CalculiX adapter to a different CalculiX version."
+---
+
+The CalculiX adapter directly modifies the source files of CalculiX and, as such, is made for a specific version of CalculiX.
+This page includes some hints on porting the adapter to different versions.
+
+{% tip %}
+Have you upgraded the supported CalculiX version to a newer one? Contribute back to the repository and make it available for everyone!
+{% endtip  %}
+
+## Porting the adapter to a new CalculiX version
+
+When a new CalculiX version is released, some files need to be updated:
+
+- `CalculiX.h`
+- `nonlingeo_precice.c`
+- `cxx_2._version_.c` (version-specific: a new file replaces the previous one)
+
+The adapter files in the `adapter/` folder should continue working independently of the CalculiX version.
+
+Overall, the main loop of the solver must be modified to insert preCICE calls (time-stepping, communication, checkpointing, ...). The adapter files describe how these must be done (e.g. read data from CalculiX to write them into preCICE buffers, etc.).
+
+{% tip %}
+It is easier and safer to re-apply the (few) adapter-specific changes in the source files of the specific CalculiX version, instead of updating the source files and resolving the merge conflicts.
+{% endtip %}
+
+### File CalculiX.h
+
+Simply copy the one from CalculiX and add the declaration of a function called `nonlingeo_precice`, which is the same as the existing `nonlingeo` but with two additional arguments at the end of the list: `char *preciceParticipantName, char *configFilename`.
+
+### File nonlingeo_precice.c
+
+Copy the file `nonlingeo.c` from CalculiX and add the adapter code. Use as reference the previous version: the difference between your `nonlingeo_precice.c` and the corresponding `nonlingeo.c` should be similar to the difference between the previous `nonlingeo_precice.c` and the `nonlingeo.c` of the previous CalculiX version. A good way to see what must be done is to use a graphical diff tool (e.g., [Meld](https://meldmerge.org/)). To make the diff smaller, try formatting the CalculiX code with the same `.clang-format` specification, or hiding whitespace changes and blank lines (e.g., with `diff -w -B`).
+
+Adapter-specific changes are documented with a comment of the form `/* Adapter: doing XXX*/`. Finding these (i.e., looking for occurrences of the word `Adapter`) in the current version of the adapter can help ensure you didn't miss anything. *Return the courtesy by maintaining these comments!*
+
+### File ccx_X.YY.c
+
+Once again, copy the corresponding file, and add the adapter-specific changes, as above:
+
+- Define the adapter-related variables
+- Parse command line arguments to see if and how preCICE is being used
+- If preCICE is being used, use the adapter-specific solver loop. This takes the form `if (preciceUsed) {custom loop} else if (some CCX code){...}`, replacing `if (some CCX code) {...}`.

--- a/docs/adapter-calculix-calculix-support.md
+++ b/docs/adapter-calculix-calculix-support.md
@@ -48,6 +48,6 @@ Once again, copy the corresponding file, and add the adapter-specific changes, a
 - Parse command line arguments to see if and how preCICE is being used
 - If preCICE is being used, use the adapter-specific solver loop. This takes the form `if (preciceUsed) {custom loop} else if (some CCX code){...}`, replacing `if (some CCX code) {...}`.
 
-## Making a new release
+## Bumping versions
 
 There are several files where the CalculiX version or the adapter version and other details need to be updated. See the pull request template `.github/PULL_REQUEST_TEMPLATE/release.md` for a checklist.

--- a/docs/adapter-calculix-calculix-support.md
+++ b/docs/adapter-calculix-calculix-support.md
@@ -47,3 +47,7 @@ Once again, copy the corresponding file, and add the adapter-specific changes, a
 - Define the adapter-related variables
 - Parse command line arguments to see if and how preCICE is being used
 - If preCICE is being used, use the adapter-specific solver loop. This takes the form `if (preciceUsed) {custom loop} else if (some CCX code){...}`, replacing `if (some CCX code) {...}`.
+
+## Making a new release
+
+There are several files where the CalculiX version or the adapter version and other details need to be updated. See the pull request template `.github/PULL_REQUEST_TEMPLATE/release.md` for a checklist.


### PR DESCRIPTION
This PR adds:

- A new documentation page `CalculiX support`, explaining how to port the adapter to a new CalculiX version. (needs to be added to the website sidebar - I will do that)
- A pull request template, with a checklist on which files to update.

Derived from the `MAINTAINING.md` file suggested in #85 by @boris-martin. Instead of that file, this PR exposes the upgrading documentation to the user in the same place as the rest of the documentation, and makes the checklist actionable by putting it into a PR template.

In the same file, there was also a versioning system documentation, which I have already integrated in #159.