### PR TITLE
Add Ubuntu 26.04 to the docs and CI

### DIFF
--- a/.github/workflows/request-deb-package.yaml
+++ b/.github/workflows/request-deb-package.yaml
@@ -26,7 +26,7 @@ on:
         type: string
       version:
         description: 'Distribution version'
-        default: "24.04"
+        default: "26.04"
         required: true
         type: string
       fflags:

--- a/.github/workflows/ubuntu_build.yml
+++ b/.github/workflows/ubuntu_build.yml
@@ -14,12 +14,14 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-22.04, ubuntu-24.04]
+        os: [ubuntu-22.04, ubuntu-24.04, ubuntu-26.04]
         include:
           - os: ubuntu-22.04
             name: jammy
           - os: ubuntu-24.04
             name: noble
+          - os: ubuntu-26.04
+            name: resolute
 
     runs-on: ${{matrix.os}}
     container: precice/precice:develop

--- a/docs/get-adapter.md
+++ b/docs/get-adapter.md
@@ -15,17 +15,17 @@ There are two ways to get the adapter: (a) get a binary package (Ubuntu-only), o
 
 You can download version-specific Ubuntu (Debian) packages from each [adapter release](https://github.com/precice/calculix-adapter/releases/latest). To install, open it in your software center.
 
-Alternatively, download & install it from the command line. For Ubuntu 24.04 (Noble Numbat):
+Alternatively, download & install it from the command line. For Ubuntu 26.04 (Resolute Raccoon):
 
 ```bash
-wget https://github.com/precice/calculix-adapter/releases/download/v{{ site.calculix_adapter_version }}/calculix-precice3_{{ site.calculix_adapter_version }}-1_amd64_noble.deb
-sudo apt install ./calculix-precice3_{{ site.calculix_adapter_version }}-1_amd64_noble.deb
+wget https://github.com/precice/calculix-adapter/releases/download/v{{ site.calculix_adapter_version }}/calculix-precice3_{{ site.calculix_adapter_version }}-1_amd64_resolute.deb
+sudo apt install ./calculix-precice3_{{ site.calculix_adapter_version }}-1_amd64_resolute.deb
 ```
 
 This requires that also preCICE itself has been installed from a Debian package.
 
 {% tip %}
-Replace `noble` with `jammy` to get the package for Ubuntu 22.04 (Jammy Jellyfish).
+Replace `resolute` with `noble` to get the package for Ubuntu 24.04 (Noble Numbat), or with `jammy` for Ubuntu 22.04 (Jammy Jellyfish).
 {% endtip  %}
 
 {% note %}


### PR DESCRIPTION
- Makes Ubuntu 26.04 the default in the documentation for getting a Debian package, and the default in the CI for generating a Debian package.
- Adds Ubuntu 26.04 to the test matrix of the the `build_ubuntu.yml` workflow.