### PR TITLE
Fix uninitialized PreciceInterface counters

### DIFF
--- a/adapter/PreciceInterface.c
+++ b/adapter/PreciceInterface.c
@@ -471,11 +471,11 @@ void PreciceInterface_Create(PreciceInterface *interface, SimulationData *sim, I
     }
   }
 
-  // Initialize counters (see issue #152 on https://github.com/precice/calculix-adapter/issues/152)
-  interface->numNodes              = 0;
-  interface->nodeSetID             = 0;
-  interface->numElements           = 0;
-  interface->faceSetID             = 0;
+  // Initialize counters
+  interface->numNodes    = 0;
+  interface->nodeSetID   = 0;
+  interface->numElements = 0;
+  interface->faceSetID   = 0;
 
   // Initialize pointers as NULL
   interface->elementIDs            = NULL;

--- a/adapter/PreciceInterface.c
+++ b/adapter/PreciceInterface.c
@@ -471,6 +471,12 @@ void PreciceInterface_Create(PreciceInterface *interface, SimulationData *sim, I
     }
   }
 
+  // Initialize counters (see issue #152 on https://github.com/precice/calculix-adapter/issues/152)
+  interface->numNodes              = 0;
+  interface->nodeSetID             = 0;
+  interface->numElements           = 0;
+  interface->faceSetID             = 0;
+
   // Initialize pointers as NULL
   interface->elementIDs            = NULL;
   interface->faceIDs               = NULL;


### PR DESCRIPTION
This PR cherry-picks https://github.com/precice/calculix-adapter/commit/5a8d567c74f5f7ba9c8dfdb8f8fdf3fcc5b12ee0 (by @gdenayer) to fix #152. FYI @failed33.

Original commit message:

> Fix uninitialized PreciceInterface counters. Initialize integer members in PreciceInterface_Create() to prevent undefined behavior and ASan errors caused by accessing uninitialized values (see https://github.com/precice/calculix-adapter/issues/152).
