### PR TITLE
Fix two memory leaks in PreciceInterface.c

### DIFF
--- a/adapter/PreciceInterface.c
+++ b/adapter/PreciceInterface.c
@@ -629,6 +629,8 @@ void PreciceInterface_ConfigureNodesMesh(PreciceInterface *interface, Simulation
   interface->numNodes  = getNumSetElements(interface->nodeSetID, sim->istartset, sim->iendset);
   interface->nodeIDs   = &sim->ialset[sim->istartset[interface->nodeSetID] - 1]; // Lucia: make a copy
 
+  free(nodeSetName);
+
   interface->nodeCoordinates = malloc(interface->numNodes * interface->dimCCX * sizeof(double));
   getNodeCoordinates(interface->nodeIDs, interface->numNodes, interface->dimCCX, sim->co, sim->vold, sim->mt, interface->nodeCoordinates);
 
@@ -824,6 +826,9 @@ void PreciceInterface_FreeData(PreciceInterface *preciceInterface)
   free(preciceInterface->xforcIndices);
 
   freeMapping(preciceInterface->mappingQuasi2D3D);
+
+  // Patch name
+  free(preciceInterface->name);
 
   // Mesh names
   free(preciceInterface->faceCentersMeshName);


### PR DESCRIPTION
This PR cherry-picks https://github.com/precice/calculix-adapter/commit/0a109c22ca47597295b66a3248c1ae7f39b9240c (by @gdenayer) and fixes two memory leaks found by Valgrind in PreciceInterface.c:

- `nodeSetName` in `PreciceInterface_ConfigureNodesMesh` (free after not needed anymore) -> Btw: This is only used once, so it could also be handled in-place.
- `preciceInterface->name` in `PreciceInterface_FreeData`.
