### PR TITLE
Makefile: Adjust FFLAGS 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,7 @@ endif
 FC = mpifort
 # FC = mpif90
 # FC = gfortran
-FFLAGS = -Wall -O3 -fopenmp $(INCLUDES) ${ADDITIONAL_FFLAGS} -Wno-implicit-function-declaration
+FFLAGS = -Wall -O3 -fopenmp $(INCLUDES) ${ADDITIONAL_FFLAGS}
 ifeq ($(findstring GNU,$(shell $(FC) --version)),GNU)
   GCC_VERSION_MAJOR := $(shell $(FC) -dumpversion | cut -d. -f1)
   ifeq ($(shell [ $(GCC_VERSION_MAJOR) -ge 10 ] && echo yes),yes)


### PR DESCRIPTION
This PR cherry-picks https://github.com/precice/calculix-adapter/commit/2efa5634e8111d39259d66686796687c5017dda1 by @gdenayer. It removes the `-Wno-implicit-function-declaration` from the `FFLAGS`, which is a valid option for gcc but not for gfortran (originally added for both in the context of adding fkYAML, https://github.com/precice/calculix-adapter/pull/143).

Original commit message:

> -Wno-implicit-function-declaration is a C compiler warning flag. It has no meaning for Fortran.