### PR TITLE
Document known issues with Intel OneAPI and SPOOLES MT

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,7 @@ CCX             = $(HOME)/CalculiX/ccx_$(CCX_VERSION)/src
 # SPOOLES include flags (e.g. -I$(HOME)/SPOOLES.2.2 )
 SPOOLES_INCLUDE   = -I/usr/include/spooles/
 # SPOOLES library flags (e.g. $(HOME)/SPOOLES.2.2/spooles.a)
+# If available, you might need to define both spoolesMT.a and spooles.a, in this order.
 SPOOLES_LIBS      = -lspooles
 #
 # ARPACK include flags (e.g. -I$(HOME)/ARPACK)

--- a/docs/get-adapter.md
+++ b/docs/get-adapter.md
@@ -116,6 +116,8 @@ ADDITIONAL_FFLAGS="-nofor-main` make
 
 to specify that the main program is not written in Fortran. Read more in the [Intel compiler reference](https://www.intel.com/content/www/us/en/docs/fortran-compiler/developer-guide-reference/2026-1/nofor-main.html).
 
+You might also get undefined references to SPOOLES. In that case, you need to modify `SPOOLES_LIBS` in the `Makefile` to include the paths to both `spoolesMT.a` (multithreading, if available), and to `spooles.a`, in this order.
+
 ### Notes on preCICE versions
 
 <details markdown="1"><summary>In case you are using some very old preCICE version, please upgrade. Our <a href="https://precice.discourse.group/" title="preCICE forum">community</a> is happy to help you. Click here and keep reading if you loved preCICE v1.x and (optionally) wish The Beatles were still around.</summary>

--- a/docs/get-adapter.md
+++ b/docs/get-adapter.md
@@ -100,6 +100,22 @@ To work around this, you need to add `-fallow-argument-mismatch` to the `FFLAGS`
 + FFLAGS = -Wall -O3 -fopenmp -fallow-argument-mismatch $(INCLUDES)
 ```
 
+### Compiling with Intel OneAPI
+
+If you compile the adapter with Intel OneAPI, you will get the following error at link time, originating from CalculiX:
+
+```text
+undefined reference to MAIN__
+```
+
+To work around this, you need to add the `-nofor-main` to the `FFLAGS` inside `Makefile`. The easiest way is to define `ADDITIONAL_FFLAGS`:
+
+```shell
+ADDITIONAL_FFLAGS="-nofor-main` make
+```
+
+to specify that the main program is not written in Fortran. Read more in the [Intel compiler reference](https://www.intel.com/content/www/us/en/docs/fortran-compiler/developer-guide-reference/2026-1/nofor-main.html).
+
 ### Notes on preCICE versions
 
 <details markdown="1"><summary>In case you are using some very old preCICE version, please upgrade. Our <a href="https://precice.discourse.group/" title="preCICE forum">community</a> is happy to help you. Click here and keep reading if you loved preCICE v1.x and (optionally) wish The Beatles were still around.</summary>

--- a/docs/get-adapter.md
+++ b/docs/get-adapter.md
@@ -85,43 +85,4 @@ The variables `YAML_INCLUDE` and `YAML_LIBS` are only relevant up to the adapter
 
 You may also want to adjust the compiler `FC` from `mpifort` to `mpif90` or to any other compiler your system uses.
 
-### Compiling with GCC 10 or newer
-
-If you compile the adapter (v2.20.1 or earlier) with GCC 10 or newer, you will get the following error, originating from CalculiX:
-
-```text
-Error: Rank mismatch between actual argument at (1) and actual argument at (2) (rank-1 and scalar)
-```
-
-To work around this, you need to add `-fallow-argument-mismatch` to the `FFLAGS` inside `Makefile`:
-
-```diff
-- FFLAGS = -Wall -O3 -fopenmp $(INCLUDES)
-+ FFLAGS = -Wall -O3 -fopenmp -fallow-argument-mismatch $(INCLUDES)
-```
-
-### Compiling with Intel OneAPI
-
-If you compile the adapter with Intel OneAPI, you will get the following error at link time, originating from CalculiX:
-
-```text
-undefined reference to MAIN__
-```
-
-To work around this, you need to add the `-nofor-main` to the `FFLAGS` inside `Makefile`. The easiest way is to define `ADDITIONAL_FFLAGS`:
-
-```shell
-ADDITIONAL_FFLAGS="-nofor-main` make
-```
-
-to specify that the main program is not written in Fortran. Read more in the [Intel compiler reference](https://www.intel.com/content/www/us/en/docs/fortran-compiler/developer-guide-reference/2026-1/nofor-main.html).
-
-You might also get undefined references to SPOOLES. In that case, you need to modify `SPOOLES_LIBS` in the `Makefile` to include the paths to both `spoolesMT.a` (multithreading, if available), and to `spooles.a`, in this order.
-
-### Notes on preCICE versions
-
-<details markdown="1"><summary>In case you are using some very old preCICE version, please upgrade. Our <a href="https://precice.discourse.group/" title="preCICE forum">community</a> is happy to help you. Click here and keep reading if you loved preCICE v1.x and (optionally) wish The Beatles were still around.</summary>
-
-1. This adapter uses the preCICE C bindings via pkg-config. In other words, this assumes that preCICE (at least v1.5.0) has been built & installed with CMake (e.g. using a Debian package). In case you want to keep using preCICE built with SCons, see the changes invoked by [Pull Request #14](https://github.com/precice/calculix-adapter/pull/14).
-
-</details>
+See also the [troubleshooting](adapter-calculix-troubleshooting.html) page for further known issues.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -18,3 +18,38 @@ This list is definitely not complete. If after reading this, you still have issu
 * Our tutorials also require CGX (pre- and post-processor of CalculiX).
   * Is CGX installed?
   * Is OpenGL (required by CGX) installed?
+
+## Compiling with GCC 10 or newer
+
+If you compile the adapter (v2.20.1 or earlier) with GCC 10 or newer, you will get the following error, originating from CalculiX:
+
+```text
+Error: Rank mismatch between actual argument at (1) and actual argument at (2) (rank-1 and scalar)
+```
+
+To work around this, you need to add `-fallow-argument-mismatch` to the `FFLAGS` inside `Makefile`:
+
+```diff
+- FFLAGS = -Wall -O3 -fopenmp $(INCLUDES)
++ FFLAGS = -Wall -O3 -fopenmp -fallow-argument-mismatch $(INCLUDES)
+```
+
+## Compiling with Intel OneAPI
+
+If you compile the adapter with Intel OneAPI, you will get the following error at link time, originating from CalculiX:
+
+```text
+undefined reference to MAIN__
+```
+
+To work around this, you need to add the `-nofor-main` to the `FFLAGS` inside `Makefile`. The easiest way is to define `ADDITIONAL_FFLAGS`:
+
+```shell
+ADDITIONAL_FFLAGS="-nofor-main` make
+```
+
+to specify that the main program is not written in Fortran. Read more in the [Intel compiler reference](https://www.intel.com/content/www/us/en/docs/fortran-compiler/developer-guide-reference/2026-1/nofor-main.html).
+
+## Undefined references to SPOOLES functions
+
+On systems where both `spoolesMT.a` (multithreading) and `spooles.a` are available, you might get undefined references to SPOOLES. In that case, you might need to modify `SPOOLES_LIBS` in the `Makefile` to include the paths to both `spoolesMT.a` and to `spooles.a`, in this order.


### PR DESCRIPTION
This PR adds some documentation regarding Intel OneAPI on https://precice.org/adapter-calculix-troubleshooting.html, currently documented in #119.

While we could handle these in the `Makefile`, these issues originate from CalculiX and should be handled there, instead.

It also moves the now automatic options for GCC >=10 into Troubleshooting and removes an ancient comment about preCICE v1.

Closes #119