### PR TITLE
Add details and hints to the unsupported simulation type error

### DIFF
--- a/ccx_2.20.c
+++ b/ccx_2.20.c
@@ -1511,7 +1511,7 @@ int main(int argc, char *argv[])
                      t0g, t1g,
                      preciceParticipantName, configFilename);
       } else {
-        printf("ERROR: Only thermal coupling or FSI is available with preCICE");
+        printf("ERROR: No compatible simulation type was detected. Consult the adapter documentation and check your CalculiX input file for keywords indicating simulation types only supported by the uncoupled CalculiX (e.g., FREQUENCY).");
         exit(0);
       }
     } else if ((nmethod <= 1) || (nmethod == 11) || ((iperturb[0] > 1) && (nmethod < 8))) {


### PR DESCRIPTION
Replaces the error message

```
ERROR: Only thermal coupling or FSI is available with preCICE
```

with

```
ERROR: No compatible simulation type was detected. Consult the adapter documentation and check your CalculiX input file for keywords indicating simulation types only supported by the uncoupled CalculiX (e.g., FREQUENCY).
```

to better point to the cause of the issue, and to give hints for an error that is bound to be faced by more people.

Closes #113