### PR TITLE
Remove an invalid free on nodeIDs

### DIFF
--- a/adapter/PreciceInterface.c
+++ b/adapter/PreciceInterface.c
@@ -595,6 +595,14 @@ void PreciceInterface_ConfigureElementsMesh(PreciceInterface *interface, Simulat
   interface->elementIDs = malloc(interface->numElements * sizeof(ITG));
   getElementsIDs(interface->elementSetID, sim->ialset, sim->istartset, sim->iendset, interface->elementIDs);
 
+  interface->numIPTotal        = sim->mi[0] * interface->numElements; // Number of Gauss points per element * number of elements
+  interface->elemIPCoordinates = malloc(interface->numIPTotal * 3 * sizeof(double));
+
+  interface->elemIPID = malloc(interface->numIPTotal * sizeof(int));
+  for (int j = 0; j < interface->numIPTotal; j++) {
+    interface->elemIPID[j] = j;
+  }
+
   int numElements = interface->numElements;
 
   enum ElemType elemType = findSimulationMeshType(sim);
@@ -607,14 +615,6 @@ void PreciceInterface_ConfigureElementsMesh(PreciceInterface *interface, Simulat
     nodesPerElement = 8;
   } else {
     supportedElementError();
-  }
-  int numGaussPointsPerElement = sim->mi[0];
-
-  interface->numIPTotal        = numGaussPointsPerElement * interface->numElements;
-  interface->elemIPCoordinates = malloc(interface->numIPTotal * 3 * sizeof(double));
-  interface->elemIPID          = malloc(interface->numIPTotal * sizeof(int));
-  for (int j = 0; j < interface->numIPTotal; j++) {
-    interface->elemIPID[j] = j;
   }
 
   FORTRAN(getelementgausspointcoords, (&numElements,

--- a/adapter/PreciceInterface.c
+++ b/adapter/PreciceInterface.c
@@ -682,8 +682,7 @@ void PreciceInterface_ConfigureNodesMesh(PreciceInterface *interface, Simulation
   char *nodeSetName    = toNodeSetName(interface->name);
   interface->nodeSetID = getSetID(nodeSetName, sim->set, sim->nset);
   interface->numNodes  = getNumSetElements(interface->nodeSetID, sim->istartset, sim->iendset);
-  interface->nodeIDs   = malloc(interface->numNodes * sizeof(ITG));
-  getElementsIDs(interface->nodeSetID, sim->ialset, sim->istartset, sim->iendset, interface->nodeIDs);
+  interface->nodeIDs   = &sim->ialset[sim->istartset[interface->nodeSetID] - 1];
 
   free(nodeSetName);
 
@@ -870,7 +869,6 @@ void PreciceInterface_FreeData(PreciceInterface *preciceInterface)
   free(preciceInterface->elemIPID);
   free(preciceInterface->elemIPCoordinates);
   free(preciceInterface->faceIDs);
-  free(preciceInterface->nodeIDs);
   free(preciceInterface->preciceFaceCenterIDs);
   free(preciceInterface->faceCenterCoordinates);
   free(preciceInterface->nodeCoordinates);

--- a/adapter/PreciceInterface.c
+++ b/adapter/PreciceInterface.c
@@ -595,26 +595,29 @@ void PreciceInterface_ConfigureElementsMesh(PreciceInterface *interface, Simulat
   interface->elementIDs = malloc(interface->numElements * sizeof(ITG));
   getElementsIDs(interface->elementSetID, sim->ialset, sim->istartset, sim->iendset, interface->elementIDs);
 
-  interface->numIPTotal        = sim->mi[0] * interface->numElements; // Number of Gauss points per element * number of elements
-  interface->elemIPCoordinates = malloc(interface->numIPTotal * 3 * sizeof(double));
-
-  interface->elemIPID = malloc(interface->numIPTotal * sizeof(int));
-  for (int j = 0; j < interface->numIPTotal; j++) {
-    interface->elemIPID[j] = j;
-  }
-
   int numElements = interface->numElements;
 
   enum ElemType elemType = findSimulationMeshType(sim);
 
   // Gauss point extraction is supported only for tetrahedra and hexahedra elements.
   int nodesPerElement;
+  int numGaussPointsPerElement;
   if (elemType == TETRAHEDRA) {
-    nodesPerElement = 4;
+    nodesPerElement          = 4;
+    numGaussPointsPerElement = 1;
   } else if (elemType == HEXAHEDRA) {
-    nodesPerElement = 8;
+    nodesPerElement          = 8;
+    numGaussPointsPerElement = 8;
   } else {
     supportedElementError();
+  }
+
+  // Keep GP counts aligned with getelementgausspointcoords.f (tet:1, hex:8)
+  interface->numIPTotal        = numGaussPointsPerElement * interface->numElements;
+  interface->elemIPCoordinates = malloc(interface->numIPTotal * 3 * sizeof(double));
+  interface->elemIPID          = malloc(interface->numIPTotal * sizeof(int));
+  for (int j = 0; j < interface->numIPTotal; j++) {
+    interface->elemIPID[j] = j;
   }
 
   FORTRAN(getelementgausspointcoords, (&numElements,
@@ -682,7 +685,8 @@ void PreciceInterface_ConfigureNodesMesh(PreciceInterface *interface, Simulation
   char *nodeSetName    = toNodeSetName(interface->name);
   interface->nodeSetID = getSetID(nodeSetName, sim->set, sim->nset);
   interface->numNodes  = getNumSetElements(interface->nodeSetID, sim->istartset, sim->iendset);
-  interface->nodeIDs   = &sim->ialset[sim->istartset[interface->nodeSetID] - 1]; // Lucia: make a copy
+  interface->nodeIDs   = malloc(interface->numNodes * sizeof(ITG));
+  getElementsIDs(interface->nodeSetID, sim->ialset, sim->istartset, sim->iendset, interface->nodeIDs);
 
   free(nodeSetName);
 

--- a/adapter/PreciceInterface.c
+++ b/adapter/PreciceInterface.c
@@ -601,16 +601,14 @@ void PreciceInterface_ConfigureElementsMesh(PreciceInterface *interface, Simulat
 
   // Gauss point extraction is supported only for tetrahedra and hexahedra elements.
   int nodesPerElement;
-  int numGaussPointsPerElement;
   if (elemType == TETRAHEDRA) {
-    nodesPerElement          = 4;
-    numGaussPointsPerElement = 1;
+    nodesPerElement = 4;
   } else if (elemType == HEXAHEDRA) {
-    nodesPerElement          = 8;
-    numGaussPointsPerElement = 8;
+    nodesPerElement = 8;
   } else {
     supportedElementError();
   }
+  int numGaussPointsPerElement = sim->mi[0];
 
   // Keep GP counts aligned with getelementgausspointcoords.f (tet:1, hex:8)
   interface->numIPTotal        = numGaussPointsPerElement * interface->numElements;

--- a/adapter/PreciceInterface.c
+++ b/adapter/PreciceInterface.c
@@ -610,7 +610,6 @@ void PreciceInterface_ConfigureElementsMesh(PreciceInterface *interface, Simulat
   }
   int numGaussPointsPerElement = sim->mi[0];
 
-  // Keep GP counts aligned with getelementgausspointcoords.f (tet:1, hex:8)
   interface->numIPTotal        = numGaussPointsPerElement * interface->numElements;
   interface->elemIPCoordinates = malloc(interface->numIPTotal * 3 * sizeof(double));
   interface->elemIPID          = malloc(interface->numIPTotal * sizeof(int));

--- a/adapter/PreciceInterface.h
+++ b/adapter/PreciceInterface.h
@@ -27,7 +27,7 @@ typedef struct PreciceInterface {
 
   // Interface nodes
   int          numNodes;
-  int *        nodeIDs;
+  ITG *        nodeIDs;
   Mapping2D3D *mappingQuasi2D3D;
   double *     nodeCoordinates;
   int          nodeSetID;
@@ -36,13 +36,13 @@ typedef struct PreciceInterface {
   char *       elementsMeshName;
 
   int     numElements;
-  int *   elementIDs;
+  ITG *   elementIDs;
   int *   elemIPID;
   int     elementSetID;
   double *elemIPCoordinates;
   int     numIPTotal;
 
-  int *   faceIDs;
+  ITG *   faceIDs;
   double *faceCenterCoordinates;
   int     faceSetID;
   char *  faceCentersMeshName;

--- a/adapter/PreciceInterface.h
+++ b/adapter/PreciceInterface.h
@@ -27,7 +27,7 @@ typedef struct PreciceInterface {
 
   // Interface nodes
   int          numNodes;
-  ITG *        nodeIDs;
+  int *        nodeIDs;
   Mapping2D3D *mappingQuasi2D3D;
   double *     nodeCoordinates;
   int          nodeSetID;
@@ -36,13 +36,13 @@ typedef struct PreciceInterface {
   char *       elementsMeshName;
 
   int     numElements;
-  ITG *   elementIDs;
+  int *   elementIDs;
   int *   elemIPID;
   int     elementSetID;
   double *elemIPCoordinates;
   int     numIPTotal;
 
-  ITG *   faceIDs;
+  int *   faceIDs;
   double *faceCenterCoordinates;
   int     faceSetID;
   char *  faceCentersMeshName;


### PR DESCRIPTION
After merging https://github.com/precice/calculix-adapter/pull/146, I started getting segfaults at the end of the simulation, in `PreciceInterface_FreeData`. The new calls added with #146 were:

```c
free(preciceInterface->elemIPID);
free(preciceInterface->elemIPCoordinates);
free(preciceInterface->nodeIDs);
free(preciceInterface->elementsMeshName);
```

The issue here is that `nodeIDs` is not allocated, but a reference to previously allocated memory. There are two possible fixes:

A. Make the reference a copy, as suggested by Lucia in the comment that is still there, or
B. remove the invalid `free`.

The solution to (A) would be:

```diff
- interface->nodeIDs = &sim->ialset[sim->istartset[interface->nodeSetID] - 1]; // Lucia: make a copy
+  interface->nodeIDs   = malloc(interface->numNodes * sizeof(ITG));
+  getElementsIDs(interface->nodeSetID, sim->ialset, sim->istartset, sim->iendset, interface->nodeIDs);
```

but, since the current version has been working fine so far, I suggest just removing the invalid free, and not to introduce an unnecessary copy.