### PR TITLE
Handle time drifts at the last time window

### DIFF
--- a/adapter/PreciceInterface.c
+++ b/adapter/PreciceInterface.c
@@ -83,8 +83,16 @@ void Precice_AdjustSolverTimestep(SimulationData *sim)
     // Compute the time step size of CalculiX
     double solver_dt = (*sim->dtheta) * (*sim->tper);
 
-    // Synchronize CalculiX time step with preCICE time window end
-    double dt = fmin(precice_dt, solver_dt);
+    // Synchronize CalculiX time step with preCICE time window end.
+    // The main idea is min(precice_dt, solver_dt),
+    // but if the last time window would leave a too small remainder, prefer the solver_dt.
+    double dt;
+    double min_dt = 1e-12;
+    if (precice_dt - solver_dt < min_dt) {
+      dt = precice_dt;
+    } else {
+      dt = solver_dt;
+    }
 
     // Normalize the agreed-on time step size
     double new_dtheta = dt / (*sim->tper);


### PR DESCRIPTION
Fixes #120, applying the [strategy suggested by the preCICE documentation](https://precice.org/couple-your-code-time-step-sizes.html#possible-subcycling-pitfall) to pick the preCICE-suggested time step size only if it is significantly smaller than the solver time step size.

As a threshold, I chose 1e-12. For 1e-13, the original case from #120 (case D in the respective table) still fails.

Tested all the reported failing cases again:

| # | `dt` / `time-window-size` | `max-time` | CalculiX end | Increments | Result |
| --- | --- | --- | --- | --- | --- |
| D | 0.00125 | 6.0  | 6.0  | 4800 | 🟢 |
| E | 0.0025  | 3.0  | 3.0  | 1200 | 🟢 |
| G | 0.0025  | 1.5  | 1.5  |  600 | 🟢 |
| I | 0.005   | 3.0  | 3.0  |  600 | 🟢 |
| K | 0.002   | 1.2  | 1.2  |  600 | 🟢 |
| L | 0.003   | 1.8  | 1.8  |  600 | 🟢 |
| M | 0.004   | 2.4  | 2.4  |  600 | 🟢 |
| N | 0.002   | 2.4  | 2.4  | 1200 | 🟢 |

The system tests report a results regression in the last time step. This is expected - I will check and update the reference results. -> Checked locally and updated in https://github.com/precice/tutorials/pull/891